### PR TITLE
Make EleventyConfig.addPassthroughCopy chainable

### DIFF
--- a/src/EleventyConfig.js
+++ b/src/EleventyConfig.js
@@ -154,8 +154,19 @@ class EleventyConfig {
     pluginCallback(this);
   }
 
+  /**
+   * Adds a path to a file or directory to the list of pass-through copies
+   * which are copied as-is to the output.
+   *
+   * @param {String} fileOrDir The path to the file or directory that should
+   * be copied.
+   * @returns {any} a reference to the `EleventyConfig` object.
+   * @memberof EleventyConfig
+   */
   addPassthroughCopy(fileOrDir) {
     this.passthroughCopies[fileOrDir] = true;
+
+    return this;
   }
 
   setTemplateFormats(templateFormats) {

--- a/test/EleventyConfigTest.js
+++ b/test/EleventyConfigTest.js
@@ -29,6 +29,19 @@ test("Add Collections throws error on key collision", t => {
   });
 });
 
+test("Set manual Pass-through File Copy (single call)", t => {
+  eleventyConfig.addPassthroughCopy("img");
+
+  t.is(eleventyConfig.passthroughCopies["img"], true);
+});
+
+test("Set manual Pass-through File Copy (chained calls)", t => {
+  eleventyConfig.addPassthroughCopy("css").addPassthroughCopy("js");
+
+  t.is(eleventyConfig.passthroughCopies["css"], true);
+  t.is(eleventyConfig.passthroughCopies["js"], true);
+});
+
 test("Set Template Formats (string)", t => {
   eleventyConfig.setTemplateFormats("ejs, njk, liquid");
   t.deepEqual(eleventyConfig.templateFormats, ["ejs", "njk", "liquid"]);


### PR DESCRIPTION
_(Implements #81)_

In this pull request:

- `EleventyConfig.addPassthroughCopy` returns a reference to `this` (the `EleventyConfig` object in this context)
- Tests for `EleventyConfig.addPassthroughCopy` are added

Should this be mentioned in [Pass-through File Copy: Manual Passthrough Copy (Faster)](https://github.com/11ty/eleventy/blob/master/docs/copy.md#manual-passthrough-copy-faster)? I could add a little example in the code snippet.

Also, you might not like the method documentation I added. However, I think it’s very helpful as some editors actually display this in a useful manner on hovering over function calls (e.g. VS Code).