### PR TITLE
Ensures origin path isn’t included in output when targeting a directory

### DIFF
--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -11,9 +11,9 @@ class TemplatePassthrough {
   }
 
   getOutputPath() {
-    return TemplatePath.normalizeUrlPath(
+    return TemplatePath.normalize(
       this.outputDir,
-      TemplatePath.getLastDir(this.path)
+      TemplatePath.stripPathFromDir(this.path, this.inputDir)
     );
   }
 

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -11,7 +11,10 @@ class TemplatePassthrough {
   }
 
   getOutputPath() {
-    return TemplatePath.normalize(this.outputDir, this.path);
+    return TemplatePath.normalizeUrlPath(
+      this.outputDir,
+      TemplatePath.getLastDir(this.path)
+    );
   }
 
   setDryRun(isDryRun) {

--- a/test/TemplatePassthroughTest.js
+++ b/test/TemplatePassthroughTest.js
@@ -12,3 +12,27 @@ test("Constructor Dry Run", t => {
   pass.setDryRun(true);
   t.is(pass.isDryRun, true);
 });
+
+test("Origin path isn’t included in output when targeting a directory", t => {
+  let pass = new TemplatePassthrough("_src/img", "_site");
+  t.truthy(pass);
+  t.is(pass.getOutputPath(), "_site/img");
+});
+
+test("Origin path isn’t included in output when targeting a directory several levels deep", t => {
+  let pass = new TemplatePassthrough("_src/subdir/img", "_site");
+  t.truthy(pass);
+  t.is(pass.getOutputPath(), "_site/img");
+});
+
+test("Origin path isn’t included in output when targeting a file", t => {
+  let pass = new TemplatePassthrough("_src/avatar.png", "_site");
+  t.truthy(pass);
+  t.is(pass.getOutputPath(), "_site/avatar.png");
+});
+
+test("Origin path isn’t included in output when targeting a file several levels deep", t => {
+  let pass = new TemplatePassthrough("_src/subdir/img/avatar.png", "_site");
+  t.truthy(pass);
+  t.is(pass.getOutputPath(), "_site/avatar.png");
+});

--- a/test/TemplatePassthroughTest.js
+++ b/test/TemplatePassthroughTest.js
@@ -14,25 +14,31 @@ test("Constructor Dry Run", t => {
 });
 
 test("Origin path isn’t included in output when targeting a directory", t => {
-  let pass = new TemplatePassthrough("_src/img", "_site");
+  let pass = new TemplatePassthrough("img", "_site", "_src");
   t.truthy(pass);
   t.is(pass.getOutputPath(), "_site/img");
 });
 
 test("Origin path isn’t included in output when targeting a directory several levels deep", t => {
-  let pass = new TemplatePassthrough("_src/subdir/img", "_site");
+  let pass = new TemplatePassthrough("img", "_site", "_src/subdir");
   t.truthy(pass);
   t.is(pass.getOutputPath(), "_site/img");
 });
 
+test("Target directory’s subdirectory structure is retained", t => {
+  let pass = new TemplatePassthrough("subdir/img", "_site", "_src");
+  t.truthy(pass);
+  t.is(pass.getOutputPath(), "_site/subdir/img");
+});
+
 test("Origin path isn’t included in output when targeting a file", t => {
-  let pass = new TemplatePassthrough("_src/avatar.png", "_site");
+  let pass = new TemplatePassthrough("avatar.png", "_site", "_src");
   t.truthy(pass);
   t.is(pass.getOutputPath(), "_site/avatar.png");
 });
 
 test("Origin path isn’t included in output when targeting a file several levels deep", t => {
-  let pass = new TemplatePassthrough("_src/subdir/img/avatar.png", "_site");
+  let pass = new TemplatePassthrough("avatar.png", "_site", "_src/subdir/img");
   t.truthy(pass);
   t.is(pass.getOutputPath(), "_site/avatar.png");
 });


### PR DESCRIPTION
Fixes #90 