### PR TITLE
Use Browsersync for --serve

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -36,16 +36,7 @@ EleventyNodeVersionCheck().then(
         console.log(elev.getHelp());
       } else if (argv.serve) {
         elev.watch().then(function() {
-          const serve = require("serve");
-          const server = serve(elev.getOutputDir(), {
-            port: argv.port || 8080,
-            ignore: ["node_modules"]
-          });
-
-          process.on("SIGINT", function() {
-            server.stop();
-            process.exit();
-          });
+          elev.serve(argv.port);
         });
       } else if (argv.watch) {
         elev.watch();

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prettier": "1.11.1"
   },
   "dependencies": {
+    "browser-sync": "^2.24.4",
     "chalk": "^2.3.2",
     "check-node-version": "^3.2.0",
     "debug": "^3.1.0",
@@ -80,7 +81,6 @@
     "pretty": "^2.0.0",
     "pug": "^2.0.3",
     "semver": "^5.5.0",
-    "serve": "^6.5.5",
     "slugify": "^1.2.9",
     "time-require": "^0.1.2",
     "valid-url": "^1.0.9"

--- a/playground/pretty.html
+++ b/playground/pretty.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<html lang="en"><head></head><body></body></html>
+<html lang="en"><head></head><body>Howdy</body></html>

--- a/src/Template.js
+++ b/src/Template.js
@@ -503,7 +503,7 @@ class Template {
     this.writeCount++;
 
     if (!this.isDryRun) {
-      await pify(fs.outputFile)(outputPath, finalContent);
+      await fs.outputFile(outputPath, finalContent);
     }
 
     let writeDesc = this.isDryRun ? "Pretending to write" : "Writing";

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -94,6 +94,13 @@ TemplatePath.stripLeadingDotSlash = function(dir) {
   return dir.replace(/^\.\//, "");
 };
 
+TemplatePath.contains = function(haystack, needle) {
+  haystack = TemplatePath.stripLeadingDotSlash(normalize(haystack));
+  needle = TemplatePath.stripLeadingDotSlash(normalize(needle));
+
+  return haystack.indexOf(needle) === 0;
+};
+
 TemplatePath.stripPathFromDir = function(targetDir, prunedPath) {
   targetDir = TemplatePath.stripLeadingDotSlash(normalize(targetDir));
   prunedPath = TemplatePath.stripLeadingDotSlash(normalize(prunedPath));

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -56,6 +56,31 @@ test("addLeadingDotSlash", t => {
   t.is(TemplatePath.addLeadingDotSlash(".nyc_output"), "./.nyc_output");
 });
 
+test("contains", t => {
+  t.false(TemplatePath.contains("./testing/hello", "./lskdjklfjz"));
+  t.false(TemplatePath.contains("./testing/hello", "lskdjklfjz"));
+  t.false(TemplatePath.contains("testing/hello", "./lskdjklfjz"));
+  t.false(TemplatePath.contains("testing/hello", "lskdjklfjz"));
+
+  t.true(TemplatePath.contains("./testing/hello", "./testing"));
+  t.true(TemplatePath.contains("./testing/hello", "testing"));
+  t.true(TemplatePath.contains("testing/hello", "./testing"));
+  t.true(TemplatePath.contains("testing/hello", "testing"));
+
+  t.true(TemplatePath.contains("testing/hello/subdir/test", "testing"));
+  t.false(TemplatePath.contains("testing/hello/subdir/test", "hello"));
+  t.false(TemplatePath.contains("testing/hello/subdir/test", "hello/subdir"));
+  t.true(
+    TemplatePath.contains("testing/hello/subdir/test", "testing/hello/subdir")
+  );
+  t.true(
+    TemplatePath.contains(
+      "testing/hello/subdir/test",
+      "testing/hello/subdir/test"
+    )
+  );
+});
+
 test("stripPathFromDir", t => {
   t.is(
     TemplatePath.stripPathFromDir("./testing/hello", "./lskdjklfjz"),


### PR DESCRIPTION
Switch to Browsersync for --serve (seamless reloads when watch finishes). Works transparently with `pathPrefix` to host your site in the subdirectory specified in your config file.

Smart reloads CSS files:

1. If they are in _includes, reload the entire page (css files included directly in <style>).
2. If they are anywhere else, injects them without reload.

Fixes #119 