### PR TITLE
Update liquidjs dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gray-matter": "^3.1.1",
     "hamljs": "^0.6.2",
     "handlebars": "^4.0.11",
-    "liquidjs": "^2.2.1",
+    "liquidjs": "^4.0.0",
     "lodash.chunk": "^4.2.0",
     "lodash.clone": "^4.5.0",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
Hey @zachleat! Not sure if there was a particular reason for keeping liquidjs pinned to this earlier version; all the tests pass updating to v4.0.0.

Recent updates to this dependancy fix a number of issues, not least [forloop.last being incorrect if the loop had a limit applied](https://github.com/harttle/liquidjs/issues/67), and the [`strip_html` filter not working](https://github.com/harttle/liquidjs/issues/68) in a way consistent with Ruby Liquid.