### PR TITLE
Fix incorrect debug log for TemplateEngine#cachePartialFiles

### DIFF
--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -58,7 +58,7 @@ class TemplateEngine {
 
     debug(
       `${this.inputDir}/*${this.extension} found partials for: %o`,
-      Object.keys(this.partials)
+      Object.keys(partials)
     );
 
     return partials;


### PR DESCRIPTION
The `debug()` printed the keys of `this.partials`, but should instead print the local variable `partials`, which includes the found partials.