### PR TITLE
Update liquid to ^5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "gray-matter": "^4.0.1",
     "hamljs": "^0.6.2",
     "handlebars": "^4.0.11",
-    "liquidjs": "^4.0.0",
+    "liquidjs": "^5.1.0",
     "lodash.chunk": "^4.2.0",
     "lodash.clone": "^4.5.0",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
I recently found a bug in liquidjs (that required me to rewrite a template file that had worked with the liquid gem when I used Jekyll) and it was patched here: https://github.com/harttle/liquidjs/issues/72

I manually added the better liquidjs version to my local site & haven't found any regressions.
