### PR TITLE
Check whether file exists before isDirectory check

### DIFF
--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -133,7 +133,7 @@ TemplatePath.stripPathFromDir = function(targetDir, prunedPath) {
 };
 
 TemplatePath.isDirectorySync = function(path) {
-  return fs.statSync(path).isDirectory();
+  return fs.existsSync(path) && fs.statSync(path).isDirectory();
 };
 
 TemplatePath.convertToGlob = function(path) {

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -48,6 +48,16 @@ test("Single File Input (shallow path)", async t => {
   t.is(files[0], "./README.md");
 });
 
+test("Glob Input", async t => {
+  let evf = new EleventyFiles("./test/stubs/glob-pages/!(contact.md)", "./test/stubs/_site", ["md"]);
+
+  let globs = evf.getFileGlobs();
+  let files = await fastglob.async(globs);
+  t.is(files.length, 2);
+  t.is(files[0], "./test/stubs/glob-pages/about.md");
+  t.is(files[1], "./test/stubs/glob-pages/home.md");
+});
+
 test(".eleventyignore parsing", t => {
   let ignores = EleventyFiles.getFileIgnores("./test/stubs/.eleventyignore");
   t.is(ignores.length, 2);

--- a/test/stubs/glob-pages/about.md
+++ b/test/stubs/glob-pages/about.md
@@ -1,0 +1,5 @@
+---
+title: "About"
+---
+
+About 

--- a/test/stubs/glob-pages/contact.md
+++ b/test/stubs/glob-pages/contact.md
@@ -1,0 +1,6 @@
+---
+title: "Contact"
+---
+
+Contact
+

--- a/test/stubs/glob-pages/home.md
+++ b/test/stubs/glob-pages/home.md
@@ -1,0 +1,5 @@
+---
+title: "Home"
+---
+
+Home


### PR DESCRIPTION
This adds a file exists check before statting the file.
This avoids an exception being thrown, but more importantly, allows glob
arguments to be passed as `--input`, fixing #173 in the process.

An example of a glob pattern that didn't work before, but will after this change, is:

```
$ eleventy --input=pages/!(contact.md)
```

It will process all file in the `pages` directory, except `contact.md`.

I've added a unit test for the glob argument, let me know if you'd like to see more checks!