### PR TITLE
Fix: Tests invoking illegal constructor TemplateData() (fixes #362)

### DIFF
--- a/test/TemplateDataTest.js
+++ b/test/TemplateDataTest.js
@@ -102,7 +102,7 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does not 
 });
 
 test("Global Dir Directory", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./");
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), ["./_data/**/*.(json|js)"]);
 });

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -414,7 +414,7 @@ test("Layout from template-data-file that has a permalink (fileslug) Issue #121"
 });
 
 test("Local template data file import (without a global data json)", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/stubs/");
   await dataObj.cacheData();
 
   let tmpl = new Template(
@@ -435,7 +435,7 @@ test("Local template data file import (without a global data json)", async t => 
 });
 
 test("Local template data file import (two subdirectories deep)", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/stubs/");
   await dataObj.cacheData();
 
   let tmpl = new Template(
@@ -459,7 +459,7 @@ test("Local template data file import (two subdirectories deep)", async t => {
 });
 
 test("Posts inherits local JSON, layouts", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/stubs/");
   await dataObj.cacheData();
 
   let tmpl = new Template(
@@ -494,7 +494,7 @@ test("Posts inherits local JSON, layouts", async t => {
 });
 
 test("Template and folder name are the same, make sure data imports work ok", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/stubs/");
   await dataObj.cacheData();
 
   let tmpl = new Template(
@@ -1194,7 +1194,7 @@ test("Data Cascade (Deep merge)", async t => {
   let newConfig = Object.assign({}, config);
   newConfig.dataDeepMerge = true;
 
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/");
   dataObj._setConfig(newConfig);
   await dataObj.cacheData();
 
@@ -1226,7 +1226,7 @@ test("Data Cascade (Deep merge)", async t => {
 });
 
 test("Data Cascade (Shallow merge)", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/");
   await dataObj.cacheData();
 
   let tmpl = new Template(
@@ -1255,7 +1255,7 @@ test("Data Cascade Tag Merge (Deep merge)", async t => {
   let newConfig = Object.assign({}, config);
   newConfig.dataDeepMerge = true;
 
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/stubs/");
   dataObj._setConfig(newConfig);
   await dataObj.cacheData();
 
@@ -1272,7 +1272,7 @@ test("Data Cascade Tag Merge (Deep merge)", async t => {
 });
 
 test("Data Cascade Tag Merge (Shallow merge)", async t => {
-  let dataObj = new TemplateData();
+  let dataObj = new TemplateData("./test/stubs/");
   await dataObj.cacheData();
 
   let tmpl = new Template(


### PR DESCRIPTION
This pull requests:

- replaces all instances of `TemplateData()` in the tests with one of the following:
  - `TemplateData("./")` when targetting the global (or project) directory
  - `TemplateData("./test/")` when targetting a directory that doesn’t have a `_data` directory inside
  - `TemplateData("./test/stubs/")` in all other cases

This fixes #362.