### PR TITLE
Document & refactor the TemplatePath utilities

### DIFF
--- a/docs-src/.eleventy.docs.js
+++ b/docs-src/.eleventy.docs.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   nunjucksFilters: {
     removeDir: function(str) {
-      return TemplatePath.stripPathFromDir(
+      return TemplatePath.stripLeadingSubPath(
         str,
         TemplatePath.join(__dirname, "..")
       );

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -262,7 +262,7 @@ Arguments:
     this.watcher.add(this.watchTargets.getNewTargetsSinceLastReset());
 
     let isInclude =
-      path && TemplatePath.contains(path, this.eleventyFiles.getIncludesDir());
+      path && TemplatePath.startsWithSubPath(path, this.eleventyFiles.getIncludesDir());
     this.eleventyServe.reload(path, isInclude);
 
     this.active = false;

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -85,7 +85,7 @@ class Eleventy {
 
     // reload package.json values (if applicable)
     // TODO only reset this if it changed
-    delete require.cache[TemplatePath.localPath("package.json")];
+    delete require.cache[TemplatePath.absolutePath("package.json")];
 
     await this.init();
   }

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -54,7 +54,7 @@ class EleventyExtensionMap {
   }
 
   _getGlobs(formatKeys, inputDir) {
-    let dir = TemplatePath.convertToGlob(inputDir);
+    let dir = TemplatePath.convertToRecursiveGlob(inputDir);
     let globs = [];
     formatKeys.forEach(
       function(key) {

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -191,7 +191,7 @@ class EleventyFiles {
         EleventyFiles.getFileIgnores(
           [
             TemplatePath.join(
-              this.localPathRoot || TemplatePath.localPath(),
+              this.localPathRoot || TemplatePath.getWorkingDir(),
               ".gitignore"
             ),
             TemplatePath.join(this.inputDir, ".gitignore")
@@ -204,7 +204,7 @@ class EleventyFiles {
     files = files.concat(
       EleventyFiles.getFileIgnores([
         TemplatePath.join(
-          this.localPathRoot || TemplatePath.localPath(),
+          this.localPathRoot || TemplatePath.getWorkingDir(),
           ".eleventyignore"
         ),
         TemplatePath.join(this.inputDir, ".eleventyignore")

--- a/src/EleventyWatchTargets.js
+++ b/src/EleventyWatchTargets.js
@@ -84,14 +84,14 @@ class EleventyWatchTargets {
         dependencyTree
           .toList({
             filename: file,
-            directory: TemplatePath.localPath(),
+            directory: TemplatePath.absolutePath(),
             filter: function(path) {
               return path.indexOf("node_modules") === -1;
             }
           })
           .map(dependency => {
             return TemplatePath.addLeadingDotSlash(
-              TemplatePath.delocalPath(dependency)
+              TemplatePath.relativePath(dependency)
             );
           })
           .filter(dependency => {
@@ -109,7 +109,7 @@ class EleventyWatchTargets {
 
   clearDependencyRequireCache() {
     for (let path of this.dependencies) {
-      delete require.cache[TemplatePath.localPath(path)];
+      delete require.cache[TemplatePath.absolutePath(path)];
     }
   }
 

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -11,7 +11,7 @@ class JavaScript extends TemplateEngine {
   }
 
   _getRequire(inputPath) {
-    let requirePath = TemplatePath.localPath(inputPath);
+    let requirePath = TemplatePath.absolutePath(inputPath);
     return require(requirePath);
   }
 
@@ -21,7 +21,7 @@ class JavaScript extends TemplateEngine {
 
   // only remove from cache once on startup (if it already exists)
   initRequireCache(inputPath) {
-    let requirePath = TemplatePath.localPath(inputPath);
+    let requirePath = TemplatePath.absolutePath(inputPath);
     if (requirePath in require.cache) {
       delete require.cache[requirePath];
     }

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -62,7 +62,7 @@ class TemplateEngine {
     partialFiles = TemplatePath.addLeadingDotSlashArray(partialFiles);
 
     for (let j = 0, k = partialFiles.length; j < k; j++) {
-      let partialPath = TemplatePath.stripPathFromDir(
+      let partialPath = TemplatePath.stripLeadingSubPath(
         partialFiles[j],
         this.inputDir
       );

--- a/src/Template.js
+++ b/src/Template.js
@@ -66,7 +66,7 @@ class Template extends TemplateContent {
   }
 
   getTemplateSubfolder() {
-    return TemplatePath.stripPathFromDir(this.parsed.dir, this.inputDir);
+    return TemplatePath.stripLeadingSubPath(this.parsed.dir, this.inputDir);
   }
 
   get baseFile() {

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -44,7 +44,7 @@ class TemplateData {
   }
 
   getRawImports() {
-    let pkgPath = TemplatePath.localPath("package.json");
+    let pkgPath = TemplatePath.absolutePath("package.json");
 
     try {
       this.rawImports[this.config.keys.package] = require(pkgPath);
@@ -224,7 +224,7 @@ class TemplateData {
 
   async getDataValue(path, rawImports, ignoreProcessing) {
     if (ignoreProcessing || TemplatePath.getExtension(path) === "js") {
-      let localPath = TemplatePath.localPath(path);
+      let localPath = TemplatePath.absolutePath(path);
       if (await fs.pathExists(localPath)) {
         let dataBench = bench.get(`\`${path}\``);
         dataBench.before();

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -283,7 +283,7 @@ class TemplateData {
       let allDirs = TemplatePath.getAllDirs(parsed.dir);
       debugDev("allDirs: %o", allDirs);
       for (let dir of allDirs) {
-        let lastDir = TemplatePath.getLastDir(dir);
+        let lastDir = TemplatePath.getLastPathSegment(dir);
         let dirPathNoExt = dir + "/" + lastDir;
 
         if (!inputDir) {

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -135,7 +135,7 @@ class TemplateData {
   }
 
   getObjectPathForDataFile(path) {
-    let reducedPath = TemplatePath.stripPathFromDir(path, this.dataDir);
+    let reducedPath = TemplatePath.stripLeadingSubPath(path, this.dataDir);
     let parsed = parsePath(reducedPath);
     let folders = parsed.dir ? parsed.dir.split("/") : [];
     folders.push(parsed.name);

--- a/src/TemplateFileSlug.js
+++ b/src/TemplateFileSlug.js
@@ -3,7 +3,7 @@ const TemplatePath = require("./TemplatePath");
 class TemplateFileSlug {
   constructor(inputPath, inputDir) {
     if (inputDir) {
-      inputPath = TemplatePath.stripPathFromDir(inputPath, inputDir);
+      inputPath = TemplatePath.stripLeadingSubPath(inputPath, inputDir);
     }
 
     this.inputPath = inputPath;

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -13,7 +13,7 @@ class TemplatePassthrough {
   getOutputPath() {
     return TemplatePath.join(
       this.outputDir,
-      TemplatePath.stripPathFromDir(this.path, this.inputDir)
+      TemplatePath.stripLeadingSubPath(this.path, this.inputDir)
     );
   }
 

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -53,7 +53,7 @@ class TemplatePassthroughManager {
 
   getConfigPathGlobs() {
     return this.getConfigPaths().map(path => {
-      return TemplatePath.convertToGlob(path);
+      return TemplatePath.convertToRecursiveGlob(path);
     });
   }
 

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -27,9 +27,19 @@ TemplatePath.getDir = function(path) {
   return TemplatePath.getDirFromFilePath(path);
 };
 
-// Input points to a file
-TemplatePath.getDirFromFilePath = function(filepath) {
-  return parsePath(filepath).dir || ".";
+/**
+ * Returns the directory portion of a path that either points to a file
+ * or ends in a glob pattern. If `path` points to a directory,
+ * the returned value will have its last path segment stripped
+ * due to how [`parsePath`][1] works.
+ *
+ * [1]: https://www.npmjs.com/package/parse-filepath
+ *
+ * @param {String} path A path
+ * @returns {String} the directory portion of a path.
+ */
+TemplatePath.getDirFromFilePath = function(path) {
+  return parsePath(path).dir || ".";
 };
 
 // can assume a parse-filepath .dir is passed in here

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -42,16 +42,23 @@ TemplatePath.getDirFromFilePath = function(path) {
   return parsePath(path).dir || ".";
 };
 
-// can assume a parse-filepath .dir is passed in here
-TemplatePath.getLastDir = function(path) {
-  let slashIndex = path.lastIndexOf("/");
-
-  if (slashIndex === -1) {
+/**
+ * Returns the last path segment in a path (no leading/trailing slashes).
+ *
+ * Assumes [`parsePath`][1] was called on `path` before.
+ *
+ * [1]: https://www.npmjs.com/package/parse-filepath
+ *
+ * @param {String} path A path
+ * @returns {String} the last path segment in a path
+ */
+TemplatePath.getLastPathSegment = function(path) {
+  if (!path.includes("/")) {
     return path;
-  } else if (slashIndex === path.length - 1) {
-    // last character is a slash
-    path = path.substring(0, path.length - 1);
   }
+
+  // Trim a trailing slash if there is one
+  path = path.replace(/\/$/, "");
 
   return path.substr(path.lastIndexOf("/") + 1);
 };

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -111,17 +111,25 @@ TemplatePath.join = function(...paths) {
   return normalize(path.join(...paths));
 };
 
-TemplatePath.hasTrailingSlash = function(thePath, isPreNormalized) {
-  if (!thePath) {
+/**
+ * Determines whether a path ends in a path separating character.
+ *
+ * @param {String|undefined} path
+ * @param {Boolean} pathIsNormalized
+ * @returns {Boolean} whether `path` ends with a path separating character.
+ */
+TemplatePath.hasTrailingSlash = function(path, pathIsNormalized = false) {
+  if (path === undefined || path.length === 0) {
     return false;
   }
 
-  let slash = "/";
-  // handle windows slashes too
-  if (isPreNormalized && process.platform === "win32") {
-    slash = "\\";
+  let pathSeparator = "/";
+  // Handle Windows path separators
+  if (pathIsNormalized && process.platform === "win32") {
+    pathSeparator = "\\";
   }
-  return thePath.length && thePath.charAt(thePath.length - 1) === slash;
+
+  return path.endsWith(pathSeparator);
 };
 
 TemplatePath.normalizeUrlPath = function(...paths) {

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -310,13 +310,4 @@ TemplatePath.removeExtension = function(path, extension = undefined) {
   return path;
 };
 
-/**
- * USE ONLY IN TESTS.
- *
- * @returns {String} the absolute path to this module.
- */
-TemplatePath._getModuleDir = function() {
-  return path.resolve(__dirname, "..");
-};
-
 module.exports = TemplatePath;

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -256,8 +256,16 @@ TemplatePath.isDirectorySync = function(path) {
   return fs.existsSync(path) && fs.statSync(path).isDirectory();
 };
 
-TemplatePath.convertToGlob = function(path) {
-  if (!path) {
+/**
+ * Appends a recursive wildcard glob pattern to `path`
+ * unless `path` is not a directory; then, `path` is assumed to be a file path
+ * and is left unchaged.
+ *
+ * @param {String} path
+ * @returns {String}
+ */
+TemplatePath.convertToRecursiveGlob = function(path) {
+  if (path === "") {
     return "./**";
   }
 

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -171,7 +171,7 @@ TemplatePath.absolutePath = function(...paths) {
  * @returns {String} the relative path.
  */
 TemplatePath.relativePath = function(absolutePath) {
-  return TemplatePath.stripPathFromDir(
+  return TemplatePath.stripLeadingSubPath(
     absolutePath,
     TemplatePath.getWorkingDir()
   );
@@ -229,19 +229,23 @@ TemplatePath.startsWithSubPath = function(path, subPath) {
   return path.startsWith(subPath);
 };
 
-TemplatePath.stripLeadingDots = function(str) {
-  return str.replace(/^\.*/, "");
-};
+/**
+ * Removes the `subPath` at the start of `path` if present
+ * and returns the remainding path.
+ *
+ * @param {String} path A path
+ * @param {String} subPath A path
+ * @returns {String} the `path` without `subPath` at the start of it.
+ */
+TemplatePath.stripLeadingSubPath = function(path, subPath) {
+  path = TemplatePath.normalize(path);
+  subPath = TemplatePath.normalize(subPath);
 
-TemplatePath.stripPathFromDir = function(targetDir, prunedPath) {
-  targetDir = TemplatePath.stripLeadingDotSlash(normalize(targetDir));
-  prunedPath = TemplatePath.stripLeadingDotSlash(normalize(prunedPath));
-
-  if (prunedPath && prunedPath !== "." && targetDir.indexOf(prunedPath) === 0) {
-    return targetDir.substr(prunedPath.length + 1);
+  if (subPath !== "." && path.startsWith(subPath)) {
+    return path.substr(subPath.length + 1);
   }
 
-  return targetDir;
+  return path;
 };
 
 TemplatePath.isDirectorySync = function(path) {

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -132,13 +132,23 @@ TemplatePath.hasTrailingSlash = function(path, pathIsNormalized = false) {
   return path.endsWith(pathSeparator);
 };
 
-TemplatePath.normalizeUrlPath = function(...paths) {
-  let thePath = path.join(...paths);
-  let hasTrailingSlashBefore = TemplatePath.hasTrailingSlash(thePath, true);
-  let normalizedPath = normalize(thePath);
-  let hasTrailingSlashAfter = TemplatePath.hasTrailingSlash(normalizedPath);
+/**
+ * Joins the given URL path segments and normalizes the resulting path.
+ * Maintains traling path separators.
+ *
+ * @param {String[]} urlPaths
+ * @returns {String} a normalized URL path described by the given URL path segments.
+ */
+TemplatePath.normalizeUrlPath = function(...urlPaths) {
+  const urlPath = path.join(...urlPaths);
+  const hasTrailingSlashBefore = TemplatePath.hasTrailingSlash(urlPath, true);
+  const normalizedUrlPath = normalize(urlPath);
+  const hasTrailingSlashAfter = TemplatePath.hasTrailingSlash(
+    normalizedUrlPath
+  );
+
   return (
-    normalizedPath +
+    normalizedUrlPath +
     (hasTrailingSlashBefore && !hasTrailingSlashAfter ? "/" : "")
   );
 };

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -5,10 +5,6 @@ const fs = require("fs-extra");
 
 function TemplatePath() {}
 
-TemplatePath.getModuleDir = function() {
-  return path.resolve(__dirname, "..");
-};
-
 TemplatePath.getWorkingDir = function() {
   return path.resolve("./");
 };
@@ -203,6 +199,15 @@ TemplatePath.removeExtension = function(path, extension) {
   }
 
   return path;
+};
+
+/**
+ * USE ONLY IN TESTS.
+ *
+ * @returns {String} the absolute path to this module.
+ */
+TemplatePath._getModuleDir = function() {
+  return path.resolve(__dirname, "..");
 };
 
 module.exports = TemplatePath;

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -290,16 +290,21 @@ TemplatePath.getExtension = function(thePath) {
   return path.extname(thePath).replace(/^\./, "");
 };
 
-TemplatePath.removeExtension = function(path, extension) {
-  let split = path.split(".");
+/**
+ * Removes the extension from a path.
+ *
+ * @param {String} path
+ * @param {String} extension
+ * @returns {String}
+ */
+TemplatePath.removeExtension = function(path, extension = undefined) {
+  if (extension === undefined) {
+    return path;
+  }
 
-  // only remove extension if extension is passed in and an extension is found
-  if (extension && split.length > 1) {
-    let ext = split.pop();
-    if (extension.charAt(0) === ".") {
-      extension = extension.substr(1);
-    }
-    return split.join(".") + (!extension || ext === extension ? "" : "." + ext);
+  const pathExtension = TemplatePath.getExtension(path);
+  if (pathExtension !== "" && extension.endsWith(pathExtension)) {
+    return path.substring(0, path.lastIndexOf(pathExtension) - 1);
   }
 
   return path;

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -205,12 +205,18 @@ TemplatePath.addLeadingDotSlash = function(path) {
   return "./" + path;
 };
 
-TemplatePath.stripLeadingDots = function(str) {
-  return str.replace(/^\.*/, "");
+/**
+ * Removes a leading dot-slash segment.
+ *
+ * @param {String} path
+ * @returns {String} the `path` without a leading dot-slash segment.
+ */
+TemplatePath.stripLeadingDotSlash = function(path) {
+  return path.replace(/^\.\//, "");
 };
 
-TemplatePath.stripLeadingDotSlash = function(dir) {
-  return dir.replace(/^\.\//, "");
+TemplatePath.stripLeadingDots = function(str) {
+  return str.replace(/^\.*/, "");
 };
 
 TemplatePath.contains = function(haystack, needle) {

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -177,22 +177,31 @@ TemplatePath.relativePath = function(absolutePath) {
   );
 };
 
+/**
+ * Adds a leading dot-slash segment to each path in the `paths` array.
+ *
+ * @param {String[]} paths
+ * @returns {String[]}
+ */
 TemplatePath.addLeadingDotSlashArray = function(paths) {
-  return paths.map(function(path) {
-    return TemplatePath.addLeadingDotSlash(path);
-  });
+  return paths.map(path => TemplatePath.addLeadingDotSlash(path));
 };
 
+/**
+ * Adds a leading dot-slash segment to `path`.
+ *
+ * @param {String} path
+ * @returns {String}
+ */
 TemplatePath.addLeadingDotSlash = function(path) {
   if (path === "." || path === "..") {
     return path + "/";
-  } else if (
-    path.indexOf("/") === 0 ||
-    path.indexOf("./") === 0 ||
-    path.indexOf("../") === 0
-  ) {
+  }
+
+  if (path.startsWith("/") || path.startsWith("./") || path.startsWith("../")) {
     return path;
   }
+
   return "./" + path;
 };
 

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -215,15 +215,22 @@ TemplatePath.stripLeadingDotSlash = function(path) {
   return path.replace(/^\.\//, "");
 };
 
-TemplatePath.stripLeadingDots = function(str) {
-  return str.replace(/^\.*/, "");
+/**
+ * Determines whether a path starts with a given sub path.
+ *
+ * @param {String} path A path
+ * @param {String} subPath A path
+ * @returns {Boolean} whether `path` starts with `subPath`.
+ */
+TemplatePath.startsWithSubPath = function(path, subPath) {
+  path = TemplatePath.normalize(path);
+  subPath = TemplatePath.normalize(subPath);
+
+  return path.startsWith(subPath);
 };
 
-TemplatePath.contains = function(haystack, needle) {
-  haystack = TemplatePath.stripLeadingDotSlash(normalize(haystack));
-  needle = TemplatePath.stripLeadingDotSlash(normalize(needle));
-
-  return haystack.indexOf(needle) === 0;
+TemplatePath.stripLeadingDots = function(str) {
+  return str.replace(/^\.*/, "");
 };
 
 TemplatePath.stripPathFromDir = function(targetDir, prunedPath) {

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -248,6 +248,10 @@ TemplatePath.stripLeadingSubPath = function(path, subPath) {
   return path;
 };
 
+/**
+ * @param {String} path A path
+ * @returns {Boolean} whether `path` points to an existing directory.
+ */
 TemplatePath.isDirectorySync = function(path) {
   return fs.existsSync(path) && fs.statSync(path).isDirectory();
 };

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -112,45 +112,16 @@ TemplatePath.join = function(...paths) {
 };
 
 /**
- * Determines whether a path ends in a path separating character.
- *
- * @param {String|undefined} path
- * @param {Boolean} pathIsNormalized
- * @returns {Boolean} whether `path` ends with a path separating character.
- */
-TemplatePath.hasTrailingSlash = function(path, pathIsNormalized = false) {
-  if (path === undefined || path.length === 0) {
-    return false;
-  }
-
-  let pathSeparator = "/";
-  // Handle Windows path separators
-  if (pathIsNormalized && process.platform === "win32") {
-    pathSeparator = "\\";
-  }
-
-  return path.endsWith(pathSeparator);
-};
-
-/**
  * Joins the given URL path segments and normalizes the resulting path.
- * Maintains traling path separators.
+ * Maintains traling a single trailing slash if the last URL path argument
+ * had atleast one.
  *
  * @param {String[]} urlPaths
  * @returns {String} a normalized URL path described by the given URL path segments.
  */
 TemplatePath.normalizeUrlPath = function(...urlPaths) {
   const urlPath = path.join(...urlPaths);
-  const hasTrailingSlashBefore = TemplatePath.hasTrailingSlash(urlPath, true);
-  const normalizedUrlPath = normalize(urlPath);
-  const hasTrailingSlashAfter = TemplatePath.hasTrailingSlash(
-    normalizedUrlPath
-  );
-
-  return (
-    normalizedUrlPath +
-    (hasTrailingSlashBefore && !hasTrailingSlashAfter ? "/" : "")
-  );
+  return urlPath.replace(/\/+$/, "/");
 };
 
 /**
@@ -272,7 +243,7 @@ TemplatePath.convertToRecursiveGlob = function(path) {
   path = TemplatePath.addLeadingDotSlash(path);
 
   if (TemplatePath.isDirectorySync(path)) {
-    return path + (!TemplatePath.hasTrailingSlash(path) ? "/" : "") + "**";
+    return path + (!path.endsWith("/") ? "/" : "") + "**";
   }
 
   return path;

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -79,7 +79,8 @@ TemplatePath.getAllDirs = function(path) {
   return path
     .split("/")
     .map(segment => path.substring(0, path.indexOf(segment) + segment.length))
-    .filter(path => path !== ".");
+    .filter(path => path !== ".")
+    .reverse();
 };
 
 /**

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -278,12 +278,16 @@ TemplatePath.convertToRecursiveGlob = function(path) {
   return path;
 };
 
-TemplatePath.getExtension = function(path) {
-  let split = path.split(".");
-  if (split.length > 1) {
-    return split.pop();
-  }
-  return "";
+/**
+ * Returns the extension of the path without the leading dot.
+ * If the path has no extensions, the empty string is returned.
+ *
+ * @param {String} thePath
+ * @returns {String} the path’s extension if it exists;
+ * otherwise, the empty string.
+ */
+TemplatePath.getExtension = function(thePath) {
+  return path.extname(thePath).replace(/^\./, "");
 };
 
 TemplatePath.removeExtension = function(path, extension) {

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -5,8 +5,11 @@ const fs = require("fs-extra");
 
 function TemplatePath() {}
 
+/**
+ * @returns {String} the absolute path to Eleventy’s project directory.
+ */
 TemplatePath.getWorkingDir = function() {
-  return path.resolve("./");
+  return TemplatePath.normalize(path.resolve("."));
 };
 
 // input is ambiguous—maybe a folder, maybe a file

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -12,7 +12,13 @@ TemplatePath.getWorkingDir = function() {
   return TemplatePath.normalize(path.resolve("."));
 };
 
-// input is ambiguous—maybe a folder, maybe a file
+/**
+ * Returns the directory portion of a path.
+ * Works for directory and file paths and paths ending in a glob pattern.
+ *
+ * @param {String} path A path
+ * @returns {String} the directory portion of a path.
+ */
 TemplatePath.getDir = function(path) {
   if (TemplatePath.isDirectorySync(path)) {
     return path;

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -63,21 +63,23 @@ TemplatePath.getLastPathSegment = function(path) {
   return path.substr(path.lastIndexOf("/") + 1);
 };
 
+/**
+ * @param {String} path A path
+ * @returns {String[]} an array of paths pointing to each path segment of the
+ * provided `path`.
+ */
 TemplatePath.getAllDirs = function(path) {
-  if (path.indexOf("/") === -1) {
+  // Trim a trailing slash if there is one
+  path = path.replace(/\/$/, "");
+
+  if (!path.includes("/")) {
     return [path];
   }
 
-  let split = path.split("/");
-  let results = [];
-  while (split.length) {
-    let folder = split.pop();
-    let parent = split.join("/");
-    if (folder && folder !== ".") {
-      results.push((parent ? parent + "/" : "") + folder);
-    }
-  }
-  return results;
+  return path
+    .split("/")
+    .map(segment => path.substring(0, path.indexOf(segment) + segment.length))
+    .filter(path => path !== ".");
 };
 
 /**

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -153,12 +153,28 @@ TemplatePath.normalizeUrlPath = function(...urlPaths) {
   );
 };
 
-TemplatePath.localPath = function(...paths) {
-  return normalize(path.join(TemplatePath.getWorkingDir(), ...paths));
+/**
+ * Joins the given path segments. Since the first path is absolute,
+ * the resulting path will be absolute as well.
+ *
+ * @param {String[]} paths
+ * @returns {String} the absolute path described by the given path segments.
+ */
+TemplatePath.absolutePath = function(...paths) {
+  return TemplatePath.join(TemplatePath.getWorkingDir(), ...paths);
 };
 
-TemplatePath.delocalPath = function(path) {
-  return TemplatePath.stripPathFromDir(path, TemplatePath.getWorkingDir());
+/**
+ * Turns an absolute path into a path relative Eleventy’s project directory.
+ *
+ * @param {String} absolutePath
+ * @returns {String} the relative path.
+ */
+TemplatePath.relativePath = function(absolutePath) {
+  return TemplatePath.stripPathFromDir(
+    absolutePath,
+    TemplatePath.getWorkingDir()
+  );
 };
 
 TemplatePath.addLeadingDotSlashArray = function(paths) {

--- a/test/EleventyExtensionMapTest.js
+++ b/test/EleventyExtensionMapTest.js
@@ -3,16 +3,16 @@ import EleventyExtensionMap from "../src/EleventyExtensionMap";
 
 test("Empty formats", t => {
   let map = new EleventyExtensionMap([]);
-  t.deepEqual(map.getGlobs(), []);
+  t.deepEqual(map.getGlobs("."), []);
 });
 test("Single format", t => {
   let map = new EleventyExtensionMap(["pug"]);
-  t.deepEqual(map.getGlobs(), ["./**/*.pug"]);
+  t.deepEqual(map.getGlobs("."), ["./**/*.pug"]);
   t.deepEqual(map.getGlobs("src"), ["./src/**/*.pug"]);
 });
 test("Multiple formats", t => {
   let map = new EleventyExtensionMap(["njk", "pug"]);
-  t.deepEqual(map.getGlobs(), ["./**/*.njk", "./**/*.pug"]);
+  t.deepEqual(map.getGlobs("."), ["./**/*.njk", "./**/*.pug"]);
   t.deepEqual(map.getGlobs("src"), ["./src/**/*.njk", "./src/**/*.pug"]);
 });
 
@@ -21,7 +21,7 @@ test("Invalid keys are filtered (no passthrough copy)", t => {
   map.config = {
     passthroughFileCopy: false
   };
-  t.deepEqual(map.getGlobs(), []);
+  t.deepEqual(map.getGlobs("."), []);
 });
 
 test("Invalid keys are filtered (using passthrough copy)", t => {
@@ -29,17 +29,17 @@ test("Invalid keys are filtered (using passthrough copy)", t => {
   map.config = {
     passthroughFileCopy: true
   };
-  t.deepEqual(map.getGlobs(), ["./**/*.lksdjfjlsk"]);
+  t.deepEqual(map.getGlobs("."), ["./**/*.lksdjfjlsk"]);
 });
 
 test("Keys are mapped to lower case", t => {
   let map = new EleventyExtensionMap(["PUG", "NJK"]);
-  t.deepEqual(map.getGlobs(), ["./**/*.pug", "./**/*.njk"]);
+  t.deepEqual(map.getGlobs("."), ["./**/*.pug", "./**/*.njk"]);
 });
 
 test("Pruned globs", t => {
   let map = new EleventyExtensionMap(["pug", "njk", "png"]);
-  t.deepEqual(map.getPrunedGlobs(), ["./**/*.png"]);
+  t.deepEqual(map.getPrunedGlobs("."), ["./**/*.png"]);
 });
 
 test("Empty path for fileList", t => {
@@ -120,7 +120,7 @@ test("Extension aliasing (one format key)", t => {
   t.deepEqual(map.getExtensionsFromKey("njk"), ["njk", "nunjucks"]);
 
   // should filter out N/A aliases
-  t.deepEqual(map.getGlobs(), ["./**/*.md", "./**/*.markdown"]);
+  t.deepEqual(map.getGlobs("."), ["./**/*.md", "./**/*.markdown"]);
 });
 
 test("Extension aliasing (two format keys)", t => {
@@ -134,7 +134,7 @@ test("Extension aliasing (two format keys)", t => {
   t.deepEqual(map.getExtensionsFromKey("md"), ["md", "markdown"]);
   t.deepEqual(map.getExtensionsFromKey("njk"), ["njk", "nunjucks"]);
 
-  t.deepEqual(map.getGlobs(), [
+  t.deepEqual(map.getGlobs("."), [
     "./**/*.md",
     "./**/*.markdown",
     "./**/*.njk",

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -8,6 +8,15 @@ test("getWorkingDir", t => {
   t.is(TemplatePath._getModuleDir(), path.resolve(__dirname, ".."));
 });
 
+test("getDir", t => {
+  t.is(TemplatePath.getDir("README.md"), ".");
+  t.is(TemplatePath.getDir("test/stubs/config.js"), "test/stubs");
+  t.is(TemplatePath.getDir("./test/stubs/config.js"), "./test/stubs");
+  t.is(TemplatePath.getDir("test/stubs/*.md"), "test/stubs");
+  t.is(TemplatePath.getDir("test/stubs/**"), "test/stubs");
+  t.is(TemplatePath.getDir("test/stubs/!(multiple.md)"), "test/stubs");
+});
+
 test("normalize", async t => {
   t.is(TemplatePath.normalize(""), ".");
   t.is(TemplatePath.normalize("."), ".");
@@ -132,12 +141,6 @@ test("stripPathFromDir", t => {
 
   t.is(TemplatePath.stripPathFromDir(".htaccess", "./"), ".htaccess");
   t.is(TemplatePath.stripPathFromDir(".htaccess", "."), ".htaccess");
-});
-
-test("getDir", t => {
-  t.is(TemplatePath.getDir("README.md"), ".");
-  t.is(TemplatePath.getDir("test/stubs/config.js"), "test/stubs");
-  t.is(TemplatePath.getDir("./test/stubs/config.js"), "./test/stubs");
 });
 
 test("getLastDir", t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -5,7 +5,7 @@ import TemplatePath from "../src/TemplatePath";
 
 test("Working dir", t => {
   t.is(TemplatePath.getWorkingDir(), path.resolve("./"));
-  t.is(TemplatePath.getModuleDir(), path.resolve(__dirname, ".."));
+  t.is(TemplatePath._getModuleDir(), path.resolve(__dirname, ".."));
 });
 
 test("normalize", async t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -96,6 +96,22 @@ test("hasTrailingSlash", t => {
   t.is(TemplatePath.hasTrailingSlash("./test/stubs/"), true);
 });
 
+test("absolutePath", t => {
+  t.is(
+    TemplatePath.absolutePath(".eleventy.js")
+      .split("/")
+      .pop(),
+    ".eleventy.js"
+  );
+});
+
+test("absolutePath and relativePath", t => {
+  t.is(
+    TemplatePath.relativePath(TemplatePath.absolutePath(".eleventy.js")),
+    ".eleventy.js"
+  );
+});
+
 test("stripLeadingDotSlash", t => {
   t.is(TemplatePath.stripLeadingDotSlash("./test/stubs"), "test/stubs");
   t.is(TemplatePath.stripLeadingDotSlash("./dist"), "dist");
@@ -227,20 +243,4 @@ test("stripLeadingDots", t => {
   t.is(TemplatePath.stripLeadingDots("./dist"), "/dist");
   t.is(TemplatePath.stripLeadingDots("../dist"), "/dist");
   t.is(TemplatePath.stripLeadingDots("dist"), "dist");
-});
-
-test("localPath", t => {
-  t.is(
-    TemplatePath.localPath(".eleventy.js")
-      .split("/")
-      .pop(),
-    ".eleventy.js"
-  );
-});
-
-test("localPath and delocalPath", t => {
-  t.is(
-    TemplatePath.delocalPath(TemplatePath.localPath(".eleventy.js")),
-    ".eleventy.js"
-  );
 });

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -30,6 +30,24 @@ test("getLastPathSegment", t => {
   t.is(TemplatePath.getLastPathSegment("testing"), "testing");
 });
 
+test("getAllDirs", t => {
+  t.deepEqual(TemplatePath.getAllDirs("."), ["."]);
+  t.deepEqual(TemplatePath.getAllDirs("./"), ["."]);
+  t.deepEqual(TemplatePath.getAllDirs("./testing"), ["./testing"]);
+  t.deepEqual(TemplatePath.getAllDirs("./testing/"), ["./testing"]);
+  t.deepEqual(TemplatePath.getAllDirs("testing/"), ["testing"]);
+  t.deepEqual(TemplatePath.getAllDirs("testing"), ["testing"]);
+  t.deepEqual(TemplatePath.getAllDirs("./testing/hello"), [
+    "./testing",
+    "./testing/hello"
+  ]);
+  t.deepEqual(TemplatePath.getAllDirs("./src/collections/posts"), [
+    "./src",
+    "./src/collections",
+    "./src/collections/posts"
+  ]);
+});
+
 test("normalize", async t => {
   t.is(TemplatePath.normalize(""), ".");
   t.is(TemplatePath.normalize("."), ".");
@@ -154,23 +172,6 @@ test("stripPathFromDir", t => {
 
   t.is(TemplatePath.stripPathFromDir(".htaccess", "./"), ".htaccess");
   t.is(TemplatePath.stripPathFromDir(".htaccess", "."), ".htaccess");
-});
-
-test("getAllDirs", t => {
-  t.deepEqual(TemplatePath.getAllDirs("."), ["."]);
-  t.deepEqual(TemplatePath.getAllDirs("./testing/hello"), [
-    "./testing/hello",
-    "./testing"
-  ]);
-  t.deepEqual(TemplatePath.getAllDirs("./testing"), ["./testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("./testing/"), ["./testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("testing/"), ["testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("testing"), ["testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("./src/collections/posts"), [
-    "./src/collections/posts",
-    "./src/collections",
-    "./src"
-  ]);
 });
 
 test("Convert to glob", t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -3,7 +3,7 @@ import path from "path";
 import normalize from "normalize-path";
 import TemplatePath from "../src/TemplatePath";
 
-test("Working dir", t => {
+test("getWorkingDir", t => {
   t.is(TemplatePath.getWorkingDir(), path.resolve("./"));
   t.is(TemplatePath._getModuleDir(), path.resolve(__dirname, ".."));
 });

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -198,11 +198,17 @@ test("stripLeadingSubPath", t => {
   t.is(TemplatePath.stripLeadingSubPath(".htaccess", "."), ".htaccess");
 });
 
-test("Convert to glob", t => {
-  t.is(TemplatePath.convertToGlob(""), "./**");
-  t.is(TemplatePath.convertToGlob("test/stubs"), "./test/stubs/**");
-  t.is(TemplatePath.convertToGlob("test/stubs/"), "./test/stubs/**");
-  t.is(TemplatePath.convertToGlob("./test/stubs/"), "./test/stubs/**");
+test("convertToRecursiveGlob", t => {
+  t.is(TemplatePath.convertToRecursiveGlob(""), "./**");
+  t.is(TemplatePath.convertToRecursiveGlob("."), "./**");
+  t.is(TemplatePath.convertToRecursiveGlob("./"), "./**");
+  t.is(TemplatePath.convertToRecursiveGlob("test/stubs"), "./test/stubs/**");
+  t.is(TemplatePath.convertToRecursiveGlob("test/stubs/"), "./test/stubs/**");
+  t.is(TemplatePath.convertToRecursiveGlob("./test/stubs/"), "./test/stubs/**");
+  t.is(
+    TemplatePath.convertToRecursiveGlob("./test/stubs/config.js"),
+    "./test/stubs/config.js"
+  );
 });
 
 test("Get extension", t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -78,14 +78,21 @@ test("join", async t => {
   t.is(TemplatePath.join("src", "test", "..", "_includes"), "src/_includes");
 });
 
-test("hasTrailingSlash", t => {
-  t.is(TemplatePath.hasTrailingSlash(undefined), false);
-  t.is(TemplatePath.hasTrailingSlash(""), false);
-  t.is(TemplatePath.hasTrailingSlash("dist"), false);
-  t.is(TemplatePath.hasTrailingSlash("./test/stubs"), false);
-  t.is(TemplatePath.hasTrailingSlash("/"), true);
-  t.is(TemplatePath.hasTrailingSlash("dist/"), true);
-  t.is(TemplatePath.hasTrailingSlash("./test/stubs/"), true);
+test("normalizeUrlPath", t => {
+  t.is(TemplatePath.normalizeUrlPath(""), ".");
+  t.is(TemplatePath.normalizeUrlPath("."), ".");
+  t.is(TemplatePath.normalizeUrlPath("./"), "./");
+  t.is(TemplatePath.normalizeUrlPath(".."), "..");
+  t.is(TemplatePath.normalizeUrlPath("../"), "../");
+
+  t.is(TemplatePath.normalizeUrlPath("/"), "/");
+  t.is(TemplatePath.normalizeUrlPath("//"), "/");
+  t.is(TemplatePath.normalizeUrlPath("/../"), "/");
+  t.is(TemplatePath.normalizeUrlPath("/test"), "/test");
+  t.is(TemplatePath.normalizeUrlPath("/test/"), "/test/");
+  t.is(TemplatePath.normalizeUrlPath("/test//"), "/test/");
+  t.is(TemplatePath.normalizeUrlPath("/test/../"), "/");
+  t.is(TemplatePath.normalizeUrlPath("/test/../../"), "/");
 });
 
 test("absolutePath", t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -211,7 +211,7 @@ test("convertToRecursiveGlob", t => {
   );
 });
 
-test("Get extension", t => {
+test("getExtension", t => {
   t.is(TemplatePath.getExtension(""), "");
   t.is(TemplatePath.getExtension("test/stubs"), "");
   t.is(TemplatePath.getExtension("test/stubs.njk"), "njk");

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -31,13 +31,13 @@ test("getAllDirs", t => {
   t.deepEqual(TemplatePath.getAllDirs("testing/"), ["testing"]);
   t.deepEqual(TemplatePath.getAllDirs("testing"), ["testing"]);
   t.deepEqual(TemplatePath.getAllDirs("./testing/hello"), [
-    "./testing",
-    "./testing/hello"
+    "./testing/hello",
+    "./testing"
   ]);
   t.deepEqual(TemplatePath.getAllDirs("./src/collections/posts"), [
-    "./src",
+    "./src/collections/posts",
     "./src/collections",
-    "./src/collections/posts"
+    "./src"
   ]);
 });
 

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -179,22 +179,23 @@ test("startsWithSubPath", t => {
   );
 });
 
-test("stripPathFromDir", t => {
+test("stripLeadingSubPath", t => {
   t.is(
-    TemplatePath.stripPathFromDir("./testing/hello", "./lskdjklfjz"),
+    TemplatePath.stripLeadingSubPath("./testing/hello", "./lskdjklfjz"),
     "testing/hello"
   );
-  t.is(TemplatePath.stripPathFromDir("./test/stubs", "./test"), "stubs");
-  t.is(TemplatePath.stripPathFromDir("./testing/hello", "testing"), "hello");
-  t.is(TemplatePath.stripPathFromDir("testing/hello", "testing"), "hello");
-  t.is(TemplatePath.stripPathFromDir("testing/hello", "./testing"), "hello");
+  t.is(TemplatePath.stripLeadingSubPath("./test/stubs", "stubs"), "test/stubs");
+  t.is(TemplatePath.stripLeadingSubPath("./test/stubs", "./test"), "stubs");
+  t.is(TemplatePath.stripLeadingSubPath("./testing/hello", "testing"), "hello");
+  t.is(TemplatePath.stripLeadingSubPath("testing/hello", "testing"), "hello");
+  t.is(TemplatePath.stripLeadingSubPath("testing/hello", "./testing"), "hello");
   t.is(
-    TemplatePath.stripPathFromDir("testing/hello/subdir/test", "testing"),
+    TemplatePath.stripLeadingSubPath("testing/hello/subdir/test", "testing"),
     "hello/subdir/test"
   );
 
-  t.is(TemplatePath.stripPathFromDir(".htaccess", "./"), ".htaccess");
-  t.is(TemplatePath.stripPathFromDir(".htaccess", "."), ".htaccess");
+  t.is(TemplatePath.stripLeadingSubPath(".htaccess", "./"), ".htaccess");
+  t.is(TemplatePath.stripLeadingSubPath(".htaccess", "."), ".htaccess");
 });
 
 test("Convert to glob", t => {
@@ -241,13 +242,4 @@ test("Remove extension", t => {
     TemplatePath.removeExtension("./test/stubs.hbs", ".hbs"),
     "./test/stubs"
   );
-});
-
-test("stripLeadingDots", t => {
-  t.is(TemplatePath.stripLeadingDots(".11ty.js"), "11ty.js");
-  t.is(TemplatePath.stripLeadingDots(".htaccess"), "htaccess");
-
-  t.is(TemplatePath.stripLeadingDots("./dist"), "/dist");
-  t.is(TemplatePath.stripLeadingDots("../dist"), "/dist");
-  t.is(TemplatePath.stripLeadingDots("dist"), "dist");
 });

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -147,25 +147,32 @@ test("stripLeadingDotSlash", t => {
   t.is(TemplatePath.stripLeadingDotSlash(".htaccess"), ".htaccess");
 });
 
-test("contains", t => {
-  t.false(TemplatePath.contains("./testing/hello", "./lskdjklfjz"));
-  t.false(TemplatePath.contains("./testing/hello", "lskdjklfjz"));
-  t.false(TemplatePath.contains("testing/hello", "./lskdjklfjz"));
-  t.false(TemplatePath.contains("testing/hello", "lskdjklfjz"));
+test("startsWithSubPath", t => {
+  t.false(TemplatePath.startsWithSubPath("./testing/hello", "./lskdjklfjz"));
+  t.false(TemplatePath.startsWithSubPath("./testing/hello", "lskdjklfjz"));
+  t.false(TemplatePath.startsWithSubPath("testing/hello", "./lskdjklfjz"));
+  t.false(TemplatePath.startsWithSubPath("testing/hello", "lskdjklfjz"));
 
-  t.true(TemplatePath.contains("./testing/hello", "./testing"));
-  t.true(TemplatePath.contains("./testing/hello", "testing"));
-  t.true(TemplatePath.contains("testing/hello", "./testing"));
-  t.true(TemplatePath.contains("testing/hello", "testing"));
+  t.true(TemplatePath.startsWithSubPath("./testing/hello", "./testing"));
+  t.true(TemplatePath.startsWithSubPath("./testing/hello", "testing"));
+  t.true(TemplatePath.startsWithSubPath("testing/hello", "./testing"));
+  t.true(TemplatePath.startsWithSubPath("testing/hello", "testing"));
 
-  t.true(TemplatePath.contains("testing/hello/subdir/test", "testing"));
-  t.false(TemplatePath.contains("testing/hello/subdir/test", "hello"));
-  t.false(TemplatePath.contains("testing/hello/subdir/test", "hello/subdir"));
   t.true(
-    TemplatePath.contains("testing/hello/subdir/test", "testing/hello/subdir")
+    TemplatePath.startsWithSubPath("testing/hello/subdir/test", "testing")
+  );
+  t.false(TemplatePath.startsWithSubPath("testing/hello/subdir/test", "hello"));
+  t.false(
+    TemplatePath.startsWithSubPath("testing/hello/subdir/test", "hello/subdir")
   );
   t.true(
-    TemplatePath.contains(
+    TemplatePath.startsWithSubPath(
+      "testing/hello/subdir/test",
+      "testing/hello/subdir"
+    )
+  );
+  t.true(
+    TemplatePath.startsWithSubPath(
       "testing/hello/subdir/test",
       "testing/hello/subdir/test"
     )

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -218,7 +218,7 @@ test("getExtension", t => {
   t.is(TemplatePath.getExtension("test/stubs.hbs"), "hbs");
 });
 
-test("Remove extension", t => {
+test("removeExtension", t => {
   t.is(TemplatePath.removeExtension(""), "");
   t.is(TemplatePath.removeExtension("", "hbs"), "");
 

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -86,6 +86,16 @@ test("join", async t => {
   t.is(TemplatePath.join("src", "test", "..", "_includes"), "src/_includes");
 });
 
+test("hasTrailingSlash", t => {
+  t.is(TemplatePath.hasTrailingSlash(undefined), false);
+  t.is(TemplatePath.hasTrailingSlash(""), false);
+  t.is(TemplatePath.hasTrailingSlash("dist"), false);
+  t.is(TemplatePath.hasTrailingSlash("./test/stubs"), false);
+  t.is(TemplatePath.hasTrailingSlash("/"), true);
+  t.is(TemplatePath.hasTrailingSlash("dist/"), true);
+  t.is(TemplatePath.hasTrailingSlash("./test/stubs/"), true);
+});
+
 test("stripLeadingDotSlash", t => {
   t.is(TemplatePath.stripLeadingDotSlash("./test/stubs"), "test/stubs");
   t.is(TemplatePath.stripLeadingDotSlash("./dist"), "dist");
@@ -93,16 +103,6 @@ test("stripLeadingDotSlash", t => {
   t.is(TemplatePath.stripLeadingDotSlash("dist"), "dist");
 
   t.is(TemplatePath.stripLeadingDotSlash(".htaccess"), ".htaccess");
-});
-
-test("hasTrailingSlash", t => {
-  t.is(TemplatePath.hasTrailingSlash(), false);
-  t.is(TemplatePath.hasTrailingSlash(""), false);
-  t.is(TemplatePath.hasTrailingSlash("dist"), false);
-  t.is(TemplatePath.hasTrailingSlash("./test/stubs"), false);
-  t.is(TemplatePath.hasTrailingSlash("/"), true);
-  t.is(TemplatePath.hasTrailingSlash("dist/"), true);
-  t.is(TemplatePath.hasTrailingSlash("./test/stubs/"), true);
 });
 
 test("addLeadingDotSlash", t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -1,12 +1,5 @@
 import test from "ava";
-import path from "path";
-import normalize from "normalize-path";
 import TemplatePath from "../src/TemplatePath";
-
-test("getWorkingDir", t => {
-  t.is(TemplatePath.getWorkingDir(), path.resolve("./"));
-  t.is(TemplatePath._getModuleDir(), path.resolve(__dirname, ".."));
-});
 
 test("getDir", t => {
   t.is(TemplatePath.getDir("README.md"), ".");
@@ -66,7 +59,6 @@ test("normalize", async t => {
   t.is(TemplatePath.normalize("./testing/hello"), "testing/hello");
   t.is(TemplatePath.normalize("./testing/hello/"), "testing/hello");
 
-  t.is(normalize(".htaccess"), ".htaccess");
   t.is(TemplatePath.normalize(".htaccess"), ".htaccess");
 });
 

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -112,15 +112,6 @@ test("absolutePath and relativePath", t => {
   );
 });
 
-test("stripLeadingDotSlash", t => {
-  t.is(TemplatePath.stripLeadingDotSlash("./test/stubs"), "test/stubs");
-  t.is(TemplatePath.stripLeadingDotSlash("./dist"), "dist");
-  t.is(TemplatePath.stripLeadingDotSlash("../dist"), "../dist");
-  t.is(TemplatePath.stripLeadingDotSlash("dist"), "dist");
-
-  t.is(TemplatePath.stripLeadingDotSlash(".htaccess"), ".htaccess");
-});
-
 test("addLeadingDotSlash", t => {
   t.is(TemplatePath.addLeadingDotSlash("."), "./");
   t.is(TemplatePath.addLeadingDotSlash(".."), "../");
@@ -145,6 +136,15 @@ test("addLeadingDotSlashArray", t => {
   t.deepEqual(TemplatePath.addLeadingDotSlashArray([".nyc_output"]), [
     "./.nyc_output"
   ]);
+});
+
+test("stripLeadingDotSlash", t => {
+  t.is(TemplatePath.stripLeadingDotSlash("./test/stubs"), "test/stubs");
+  t.is(TemplatePath.stripLeadingDotSlash("./dist"), "dist");
+  t.is(TemplatePath.stripLeadingDotSlash("../dist"), "../dist");
+  t.is(TemplatePath.stripLeadingDotSlash("dist"), "dist");
+
+  t.is(TemplatePath.stripLeadingDotSlash(".htaccess"), ".htaccess");
 });
 
 test("contains", t => {

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -17,6 +17,11 @@ test("getDir", t => {
   t.is(TemplatePath.getDir("test/stubs/!(multiple.md)"), "test/stubs");
 });
 
+test("getDirFromFilePath", t => {
+  t.is(TemplatePath.getDirFromFilePath("test/stubs/*.md"), "test/stubs");
+  t.is(TemplatePath.getDirFromFilePath("test/stubs/!(x.md)"), "test/stubs");
+});
+
 test("normalize", async t => {
   t.is(TemplatePath.normalize(""), ".");
   t.is(TemplatePath.normalize("."), ".");

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -22,6 +22,14 @@ test("getDirFromFilePath", t => {
   t.is(TemplatePath.getDirFromFilePath("test/stubs/!(x.md)"), "test/stubs");
 });
 
+test("getLastPathSegment", t => {
+  t.is(TemplatePath.getLastPathSegment("./testing/hello"), "hello");
+  t.is(TemplatePath.getLastPathSegment("./testing"), "testing");
+  t.is(TemplatePath.getLastPathSegment("./testing/"), "testing");
+  t.is(TemplatePath.getLastPathSegment("testing/"), "testing");
+  t.is(TemplatePath.getLastPathSegment("testing"), "testing");
+});
+
 test("normalize", async t => {
   t.is(TemplatePath.normalize(""), ".");
   t.is(TemplatePath.normalize("."), ".");
@@ -146,14 +154,6 @@ test("stripPathFromDir", t => {
 
   t.is(TemplatePath.stripPathFromDir(".htaccess", "./"), ".htaccess");
   t.is(TemplatePath.stripPathFromDir(".htaccess", "."), ".htaccess");
-});
-
-test("getLastDir", t => {
-  t.is(TemplatePath.getLastDir("./testing/hello"), "hello");
-  t.is(TemplatePath.getLastDir("./testing"), "testing");
-  t.is(TemplatePath.getLastDir("./testing/"), "testing");
-  t.is(TemplatePath.getLastDir("testing/"), "testing");
-  t.is(TemplatePath.getLastDir("testing"), "testing");
 });
 
 test("getAllDirs", t => {

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -447,12 +447,12 @@ test("Local template data file import (two subdirectories deep)", async t => {
   );
 
   t.deepEqual(await dataObj.getLocalDataPaths(tmpl.getInputPath()), [
-    "./test/stubs/firstdir/firstdir.json",
-    "./test/stubs/firstdir/firstdir.11tydata.json",
-    "./test/stubs/firstdir/firstdir.11tydata.js",
     "./test/stubs/firstdir/seconddir/seconddir.json",
     "./test/stubs/firstdir/seconddir/seconddir.11tydata.json",
     "./test/stubs/firstdir/seconddir/seconddir.11tydata.js",
+    "./test/stubs/firstdir/firstdir.json",
+    "./test/stubs/firstdir/firstdir.11tydata.json",
+    "./test/stubs/firstdir/firstdir.11tydata.js",
     "./test/stubs/firstdir/seconddir/component.json",
     "./test/stubs/firstdir/seconddir/component.11tydata.json",
     "./test/stubs/firstdir/seconddir/component.11tydata.js"

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -447,12 +447,12 @@ test("Local template data file import (two subdirectories deep)", async t => {
   );
 
   t.deepEqual(await dataObj.getLocalDataPaths(tmpl.getInputPath()), [
-    "./test/stubs/firstdir/seconddir/seconddir.json",
-    "./test/stubs/firstdir/seconddir/seconddir.11tydata.json",
-    "./test/stubs/firstdir/seconddir/seconddir.11tydata.js",
     "./test/stubs/firstdir/firstdir.json",
     "./test/stubs/firstdir/firstdir.11tydata.json",
     "./test/stubs/firstdir/firstdir.11tydata.js",
+    "./test/stubs/firstdir/seconddir/seconddir.json",
+    "./test/stubs/firstdir/seconddir/seconddir.11tydata.json",
+    "./test/stubs/firstdir/seconddir/seconddir.11tydata.js",
     "./test/stubs/firstdir/seconddir/component.json",
     "./test/stubs/firstdir/seconddir/component.11tydata.json",
     "./test/stubs/firstdir/seconddir/component.11tydata.js"


### PR DESCRIPTION
Before tackling #368, I realized I needed to know more about `TemplatePath`’s utility functions. I went ahead and added documentation comments to every function. I also refactored some of them, mainly with the goal of simplifying the code.

I created a separate commit for each function because this makes it way easier to review the whole thing (e.g. function name changes are happening in the commit where that function is concerned). Should this get merged, you potentially want to squash all commits with the prefix `TemplatePath: ` into one. Your choice.

## Changes

- `TemplatePath._getModuleDir`: <del>prefixed the function name with an underscore as it’s done in other files to signal that it’s only used in tests.</del><ins>See https://github.com/11ty/eleventy/pull/376#issuecomment-453755611</ins>
- `TemplatePath.getWorkingDir`: <del>Normalizing the working directory so all code is dealing with the same.</del><ins>See https://github.com/11ty/eleventy/pull/376#issuecomment-453755611</ins>
- `TemplatePath.getDir`: Added some tests with glob patterns.
- `TemplatePath.getDirFromFilePath`: Added tests.
- `TemplatePath.getLastPathSegment`: Renamed from `getLastDir`. Refactored for readability.
- `TemplatePath.getAllDirs`: Refactored for readability. Adjusted tests in order, not values. I wonder if there is an orderless `deepEqual`. Reading the diffs for those is extremely cumbersome.
- `TemplatePath.hasTrailingSlash`: <del>Refactored slightly to handle `undefined` input explicitly. I don’t think this should handle `undefined` at all, to be honest. Passing `undefined` here should be an immediate error.</del><ins>See https://github.com/11ty/eleventy/pull/376#issuecomment-453824902</ins>
- `TemplatePath.normalizeUrlPath`: <del>Just the documentation string. No implementation change.</del><ins>See https://github.com/11ty/eleventy/pull/376#issuecomment-453824902</ins>
- `TemplatePath.absolutePath` + `TemplatePath.relativePath`: Renamed from `localPath` and `delocalPath` (:cool:). Replaced calls to `absolutePath` without an argument with `getWorkingDir` because it’s the same and more clear.
- `TemplatePath.addLeadingDotSlash` + `TemplatePath.addLeadingDotSlashArray`:
- `TemplatePath.stripLeadingDotSlash`: Slight readability changes.
- `TemplatePath.startsWithSubPath`: Renamed from `contains` (*contains* is not the right meaning because it only matches at the start of the path)
- `TemplatePath.stripLeadingSubPath`: Renamed from `stripPathFromDir` because it wasn’t clear which argument is which when reading a call to the function. Both arguments are paths.
- `TemplatePath.isDirectorySync`: Documentation comment.
- `TemplatePath.convertToRecursiveGlob`: Renamed from `convertToGlob` to make clear what kind of glob pattern is meant. Also added missing arguments to all function calls in the tests to avoid handling `undefined` as an argument.
- `TemplatePath.getExtension`: Use Node.js’ `path.extname`.
- `TemplatePath.removeExtension`: Re-use `TemplatePath.getExtension`.

---

Okay, I admit, this is quite the massive pull request. I won’t be mad if it doesn’t get merged (or reviewed anytime soon for that matter). :sweat_smile: 