### PR TITLE
Fix broken tests on Windows (yes, it’s newlines)

### DIFF
--- a/test/TemplateMapTest.js
+++ b/test/TemplateMapTest.js
@@ -2,6 +2,7 @@ import test from "ava";
 import Template from "../src/Template";
 import TemplateMap from "../src/TemplateMap";
 import TemplateCollection from "../src/TemplateCollection";
+import normalizeNewLines from "./Util/normalizeNewLines";
 
 let tmpl1 = new Template(
   "./test/stubs/templateMapCollection/test1.md",
@@ -199,7 +200,7 @@ test("Issue #115, mixing pagination and collections", async t => {
   t.is(Object.keys(map[2].data.collections.bars).length, 1);
 
   t.deepEqual(
-    map[2].templateContent,
+    normalizeNewLines(map[2].templateContent),
     `This page is foos
 This page is bars
 `
@@ -259,7 +260,7 @@ test("Issue #115 with layout, mixing pagination and collections", async t => {
   t.is(Object.keys(map[2].data.collections.bars).length, 1);
 
   t.deepEqual(
-    map[2].templateContent,
+    normalizeNewLines(map[2].templateContent),
     `This page is foos
 This page is bars
 `

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -4,6 +4,7 @@ import pretty from "pretty";
 import TemplateData from "../src/TemplateData";
 import Template from "../src/Template";
 import templateConfig from "../src/Config";
+import normalizeNewLines from "./Util/normalizeNewLines";
 
 const config = templateConfig.getConfig();
 
@@ -176,7 +177,7 @@ test("One Layout (using new content var)", async t => {
   t.is(data[config.keys.layout], "defaultLayout");
 
   t.is(
-    cleanHtml(await tmpl.renderLayout(tmpl, data)),
+    normalizeNewLines(cleanHtml(await tmpl.renderLayout(tmpl, data))),
     `<div id="layout">
   <p>Hello.</p>
 </div>`
@@ -204,7 +205,7 @@ test("One Layout (using layoutContent)", async t => {
   t.is(data[config.keys.layout], "defaultLayoutLayoutContent");
 
   t.is(
-    cleanHtml(await tmpl.renderLayout(tmpl, data)),
+    normalizeNewLines(cleanHtml(await tmpl.renderLayout(tmpl, data))),
     `<div id="layout">
   <p>Hello.</p>
 </div>`
@@ -257,7 +258,7 @@ test("One Layout (_layoutContent deprecated but supported)", async t => {
   t.is(data[config.keys.layout], "defaultLayout_layoutContent");
 
   t.is(
-    cleanHtml(await tmpl.renderLayout(tmpl, data)),
+    normalizeNewLines(cleanHtml(await tmpl.renderLayout(tmpl, data))),
     `<div id="layout">
   <p>Hello.</p>
 </div>`
@@ -285,7 +286,7 @@ test("One Layout (liquid test)", async t => {
   t.is(data[config.keys.layout], "layoutLiquid.liquid");
 
   t.is(
-    cleanHtml(await tmpl.renderLayout(tmpl, data)),
+    normalizeNewLines(cleanHtml(await tmpl.renderLayout(tmpl, data))),
     `<div id="layout">
   <p>Hello.</p>
 </div>`
@@ -311,7 +312,7 @@ test("Two Layouts", async t => {
   t.is(data.key1, "value1");
 
   t.is(
-    cleanHtml(await tmpl.renderLayout(tmpl, data)),
+    normalizeNewLines(cleanHtml(await tmpl.renderLayout(tmpl, data))),
     `<div id="layout-b">
   <div id="layout-a">
     <p>value2-a</p>
@@ -487,7 +488,7 @@ test("Posts inherits local JSON, layouts", async t => {
   t.is(localData.layout, "mylocallayout.njk");
 
   t.is(
-    (await tmpl.render(data)).trim(),
+    normalizeNewLines((await tmpl.render(data)).trim()),
     `<div id="locallayout">Post1
 </div>`
   );
@@ -519,7 +520,7 @@ test("Template and folder name are the same, make sure data imports work ok", as
   t.is(localData.layout, "mylocallayout.njk");
 
   t.is(
-    (await tmpl.render(data)).trim(),
+    normalizeNewLines((await tmpl.render(data)).trim()),
     `<div id="locallayout">Posts
 </div>`
   );
@@ -979,7 +980,7 @@ test("Using a markdown source file (with a layout that uses njk), markdown shoul
   );
 
   t.is(
-    (await tmpl.render()).trim(),
+    normalizeNewLines((await tmpl.render()).trim()),
     `# Layout header
 
 <div id="layoutvalue"><h1>My Title</h1>
@@ -995,7 +996,7 @@ test("Override base templating engine from .md to ejs,md (with a layout that use
   );
 
   t.is(
-    (await tmpl.render()).trim(),
+    normalizeNewLines((await tmpl.render()).trim()),
     `# Layout header
 
 <div id="layoutvalue"><h1>My Title</h1>

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -2,13 +2,13 @@ import test from "ava";
 import fs from "fs-extra";
 import fastglob from "fast-glob";
 import parsePath from "parse-filepath";
-import TemplateRender from "../src/TemplateRender";
 import EleventyFiles from "../src/EleventyFiles";
 import EleventyExtensionMap from "../src/EleventyExtensionMap";
 import TemplateWriter from "../src/TemplateWriter";
 // Not sure why but this import up `ava` and _createTemplate 👀
 // import Template from "../src/Template";
 import eleventyConfig from "../src/EleventyConfig";
+import normalizeNewLines from "./Util/normalizeNewLines";
 
 // TODO make sure if output is a subdir of input dir that they don’t conflict.
 test("Output is a subdir of input", async t => {
@@ -248,7 +248,7 @@ test("Use a collection inside of a template", async t => {
 
   // test content
   t.is(
-    templates[0].templateContent.trim(),
+    normalizeNewLines(templates[0].templateContent.trim()),
     `Layout
 
 Template
@@ -288,7 +288,7 @@ test("Use a collection inside of a layout", async t => {
 
   // test content
   t.is(
-    templates[0].templateContent.trim(),
+    normalizeNewLines(templates[0].templateContent.trim()),
     `Layout
 
 Template

--- a/test/Util/normalizeNewLines.js
+++ b/test/Util/normalizeNewLines.js
@@ -1,0 +1,5 @@
+function normalizeNewLines(str) {
+  return str.replace(/\r/g, "");
+}
+
+module.exports = normalizeNewLines;


### PR DESCRIPTION
I booted into Windows after months again and ran Eleventy’s tests. Some were broken due to newline mismatch. I fixed them by normalizing newlines to `\n` in the tests.