### PR TITLE
404 proof of concept

### DIFF
--- a/playground/404.html
+++ b/playground/404.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="en"><head></head><body>Page Not Found</body></html>

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -3,6 +3,7 @@ const fs = require("fs-extra");
 const TemplatePath = require("./TemplatePath");
 const config = require("./Config");
 const debug = require("debug")("EleventyServe");
+const path = require("path");
 
 class EleventyServe {
   constructor() {}
@@ -145,7 +146,17 @@ class EleventyServe {
     this.cleanupRedirect(this.savedPathPrefix);
     this.savedPathPrefix = pathPrefix;
 
-    this.server.init(this.getOptions(port));
+    const options = this.getOptions(port);
+    this.server.init(options, (err, bs) => {
+      const content_404 = fs.readFileSync(
+        path.join(options.server.baseDir, "404/index.html")
+      );
+      bs.addMiddleware("*", (req, res) => {
+        // Provides the 404 content without redirect.
+        res.write(content_404);
+        res.end();
+      });
+    });
   }
 
   close() {


### PR DESCRIPTION
Provides a proof of concept for [an issue requesting 404 support in `eleventy serve`](https://github.com/11ty/eleventy/issues/386). 

Code for the redirect on 404 comes from [this browserSync issue](https://github.com/BrowserSync/browser-sync/issues/1398). 

As written, this is a change to the default behavior, and I'm not sure that's desired. 

I'm also not sure that the path I'm using in line 152 is correct in the case that a redirect directory is being used. 