### PR TITLE
Enable packaging with zeit/pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,5 +113,8 @@
       "pre-commit": "lint-staged",
       "pre-push": "npx ava"
     }
+  },
+  "pkg": {
+    "scripts": "src/**/*"
   }
 }


### PR DESCRIPTION
Partially solves #104.

Now, we can run `pkg .` to build binary files.