### PR TITLE
Throw an error if includes or data directory is outside of Eleventy’s working directory

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -268,8 +268,7 @@ class Eleventy {
       this.input,
       this.outputDir,
       formats,
-      this.templateData,
-      this.isPassthroughAll
+      this.templateData
     );
 
     this.writer.setEleventyFiles(this.eleventyFiles);

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -12,7 +12,7 @@ const debug = require("debug")("Eleventy:EleventyFiles");
 // const debugDev = require("debug")("Dev:Eleventy:EleventyFiles");
 
 class EleventyFiles {
-  constructor(input, outputDir, formats, passthroughAll) {
+  constructor(input, outputDir, formats, isPassthroughAll) {
     this.config = config.getConfig();
     this.input = input;
     this.inputDir = TemplatePath.getDir(this.input);
@@ -20,7 +20,7 @@ class EleventyFiles {
 
     this.initConfig();
 
-    this.passthroughAll = !!passthroughAll;
+    this.isPassthroughAll = !!isPassthroughAll;
 
     this.formats = formats;
     this.extensionMap = new EleventyExtensionMap(formats);
@@ -63,10 +63,6 @@ class EleventyFiles {
   /* Set command root for local project paths */
   _setLocalPathRoot(dir) {
     this.localPathRoot = dir;
-  }
-
-  setPassthroughAll(passthroughAll) {
-    this.passthroughAll = !!passthroughAll;
   }
 
   initFormatsGlobs() {
@@ -115,7 +111,7 @@ class EleventyFiles {
   setupGlobs() {
     this.ignores = this.getIgnores();
 
-    if (this.passthroughAll) {
+    if (this.isPassthroughAll) {
       this.watchedGlobs = TemplateGlob.map([
         TemplateGlob.normalizePath(this.input, "/**")
       ]).concat(this.ignores);

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -22,6 +22,8 @@ class TemplateConfig {
     }
     this.initializeRootConfig();
     this.config = this.mergeConfig(this.localProjectConfigPath);
+
+    this.checkPathsAreAllowed();
   }
 
   getLocalProjectConfigFile() {
@@ -134,6 +136,18 @@ class TemplateConfig {
     debug("Current configuration: %o", merged);
 
     return merged;
+  }
+
+  checkPathsAreAllowed() {
+    ["includes", "data"].forEach(eleventyDirName => {
+      const eleventyDirectory = this.config.dir[eleventyDirName];
+
+      if (!TemplatePath.isInsideWorkingDir(eleventyDirectory)) {
+        throw new EleventyConfigError(
+          `Error in your Eleventy config file: The configured ${eleventyDirName} directory (${eleventyDirectory}) is outside of Eleventy’s working directory.`
+        );
+      }
+    });
   }
 }
 

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -13,6 +13,17 @@ TemplatePath.getWorkingDir = function() {
 };
 
 /**
+ * @param {String} path
+ * @returns {Boolean} whether the path is inside Eleventy’s working directory.
+ */
+TemplatePath.isInsideWorkingDir = function(path) {
+  return TemplatePath.startsWithSubPath(
+    TemplatePath.absolutePath(path),
+    TemplatePath.getWorkingDir()
+  );
+};
+
+/**
  * Returns the directory portion of a path.
  * Works for directory and file paths and paths ending in a glob pattern.
  *

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -2,7 +2,6 @@ const Template = require("./Template");
 const TemplatePath = require("./TemplatePath");
 const TemplateMap = require("./TemplateMap");
 const TemplateRender = require("./TemplateRender");
-const EleventyFiles = require("./EleventyFiles");
 const EleventyBaseError = require("./EleventyBaseError");
 const EleventyErrorHandler = require("./EleventyErrorHandler");
 const EleventyErrorUtil = require("./EleventyErrorUtil");
@@ -18,8 +17,7 @@ class TemplateWriter {
     inputPath,
     outputDir,
     templateFormats, // TODO remove this, see `.getFileManager()` first
-    templateData,
-    isPassthroughAll
+    templateData
   ) {
     this.config = config.getConfig();
     this.input = inputPath;
@@ -31,9 +29,6 @@ class TemplateWriter {
     this.isDryRun = false;
     this.writeCount = 0;
     this.pretendWriteCount = 0;
-
-    // TODO can we get rid of this? It’s only used for tests in getFileManager()
-    this.passthroughAll = isPassthroughAll;
   }
 
   /* For testing */
@@ -52,18 +47,6 @@ class TemplateWriter {
   }
 
   getFileManager() {
-    // usually Eleventy.js will setEleventyFiles with the EleventyFiles manager
-    if (!this.eleventyFiles) {
-      // if not, we can create one (used only by tests)
-      this.eleventyFiles = new EleventyFiles(
-        this.input,
-        this.outputDir,
-        this.templateFormats,
-        this.passthroughAll
-      );
-      this.eleventyFiles.init();
-    }
-
     return this.eleventyFiles;
   }
 

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -562,8 +562,14 @@ test("Glob Watcher Files with Config Passthroughs (no template formats)", async 
   ]);
 });
 
-test("Glob Watcher Files with passthroughAll", async t => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", [], true);
+test("Glob Watcher Files with isPassthroughAll", async t => {
+  const isPassthroughAll = true;
+  let evf = new EleventyFiles(
+    "test/stubs",
+    "test/stubs/_site",
+    [],
+    isPassthroughAll
+  );
   evf.init();
 
   t.is((await evf.getFileGlobs())[0], "./test/stubs/**");

--- a/test/TemplateConfigTest.js
+++ b/test/TemplateConfigTest.js
@@ -328,3 +328,21 @@ test("Properly throws error when config returns a Promise", t => {
     );
   });
 });
+
+test("Properly throws error on illegal includes directory", t => {
+  t.throws(function() {
+    new TemplateConfig(
+      require("../config.js"),
+      "./test/stubs/config-illegal-includes-dir.js"
+    );
+  });
+});
+
+test("Properly throws error on illegal data directory", t => {
+  t.throws(function() {
+    new TemplateConfig(
+      require("../config.js"),
+      "./test/stubs/config-illegal-data-dir.js"
+    );
+  });
+});

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -10,6 +10,13 @@ test("getDir", t => {
   t.is(TemplatePath.getDir("test/stubs/!(multiple.md)"), "test/stubs");
 });
 
+test("isInsideWorkingDir", t => {
+  t.true(TemplatePath.isInsideWorkingDir("_includes"));
+  t.true(TemplatePath.isInsideWorkingDir("doesnt-exist-but-is-valid-anyway"));
+  t.true(TemplatePath.isInsideWorkingDir("."));
+  t.false(TemplatePath.isInsideWorkingDir(".."));
+});
+
 test("getDirFromFilePath", t => {
   t.is(TemplatePath.getDirFromFilePath("test/stubs/*.md"), "test/stubs");
   t.is(TemplatePath.getDirFromFilePath("test/stubs/!(x.md)"), "test/stubs");

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -11,18 +11,35 @@ import TemplateWriter from "../src/TemplateWriter";
 import eleventyConfig from "../src/EleventyConfig";
 import normalizeNewLines from "./Util/normalizeNewLines";
 
+function setEleventyFiles(templateWriter) {
+  if (templateWriter.eleventyFiles === undefined) {
+    const eleventyFiles = new EleventyFiles(
+      templateWriter.input,
+      templateWriter.outputDir,
+      templateWriter.templateFormats,
+      false
+    );
+
+    eleventyFiles.init();
+    templateWriter.setEleventyFiles(eleventyFiles);
+  }
+}
+
 // TODO make sure if output is a subdir of input dir that they don’t conflict.
 test("Output is a subdir of input", async t => {
   let tw = new TemplateWriter(
     "./test/stubs/writeTest",
     "./test/stubs/writeTest/_writeTestSite"
   );
+
   let evf = new EleventyFiles(
     "./test/stubs/writeTest",
     "./test/stubs/writeTest/_writeTestSite",
     ["ejs", "md"]
   );
   evf.init();
+
+  tw.setEleventyFiles(evf);
 
   let files = await fastglob(evf.getFileGlobs());
   t.is(evf.getRawFiles().length, 2);
@@ -43,6 +60,8 @@ test("_createTemplateMap", async t => {
     ["ejs", "md"]
   );
 
+  setEleventyFiles(tw);
+
   let paths = await tw._getAllPaths();
   t.true(paths.length > 0);
   t.is(paths[0], "./test/stubs/writeTest/test.md");
@@ -61,6 +80,8 @@ test("_createTemplateMap (no leading dot slash)", async t => {
     ["ejs", "md"]
   );
 
+  setEleventyFiles(tw);
+
   let paths = await tw._getAllPaths();
   t.true(paths.length > 0);
   t.is(paths[0], "./test/stubs/writeTest/test.md");
@@ -70,6 +91,8 @@ test("getCollectionsData", async t => {
   let tw = new TemplateWriter("./test/stubs/collection", "./test/stubs/_site", [
     "md"
   ]);
+
+  setEleventyFiles(tw);
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -85,6 +108,8 @@ test("_testGetAllTags", async t => {
     "md"
   ]);
 
+  setEleventyFiles(tw);
+
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
   let tags = templateMap._testGetAllTags();
@@ -96,6 +121,8 @@ test("Collection of files sorted by date", async t => {
   let tw = new TemplateWriter("./test/stubs/dates", "./test/stubs/_site", [
     "md"
   ]);
+
+  setEleventyFiles(tw);
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -109,6 +136,8 @@ test("_getCollectionsData with custom collection (ascending)", async t => {
     "./test/stubs/_site",
     ["md"]
   );
+
+  setEleventyFiles(tw);
 
   /* Careful here, eleventyConfig is a global */
   eleventyConfig.addCollection("customPostsAsc", function(collection) {
@@ -132,6 +161,8 @@ test("_getCollectionsData with custom collection (descending)", async t => {
     ["md"]
   );
 
+  setEleventyFiles(tw);
+
   /* Careful here, eleventyConfig is a global */
   eleventyConfig.addCollection("customPosts", function(collection) {
     return collection.getFilteredByTag("post").sort(function(a, b) {
@@ -153,6 +184,8 @@ test("_getCollectionsData with custom collection (filter only to markdown input)
     "./test/stubs/_site",
     ["md"]
   );
+
+  setEleventyFiles(tw);
 
   /* Careful here, eleventyConfig is a global */
   eleventyConfig.addCollection("onlyMarkdown", function(collection) {
@@ -176,6 +209,8 @@ test("Pagination with a Collection", async t => {
     "./test/stubs/_site",
     ["njk"]
   );
+
+  setEleventyFiles(tw);
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -206,6 +241,8 @@ test("Pagination with a Collection from another Paged Template", async t => {
     "./test/stubs/_site",
     ["njk"]
   );
+
+  setEleventyFiles(tw);
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -239,6 +276,8 @@ test("Pagination with a Collection (apply all pages to collections)", async t =>
     "./test/stubs/_site",
     ["njk"]
   );
+
+  setEleventyFiles(tw);
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -291,6 +330,8 @@ test("Use a collection inside of a template", async t => {
     ["ejs"]
   );
 
+  setEleventyFiles(tw);
+
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
 
@@ -333,6 +374,8 @@ test("Use a collection inside of a layout", async t => {
     ["ejs"]
   );
 
+  setEleventyFiles(tw);
+
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
 
@@ -367,6 +410,9 @@ Layout 1 dog`
 
 test("Glob Watcher Files with Passthroughs", t => {
   let tw = new TemplateWriter("test/stubs", "test/stubs/_site", ["njk", "png"]);
+
+  setEleventyFiles(tw);
+
   t.deepEqual(tw.getFileManager().getPassthroughPaths(), []);
 });
 
@@ -376,6 +422,8 @@ test("Pagination and TemplateContent", async t => {
     "./test/stubs/pagination-templatecontent/_site",
     ["njk", "md"]
   );
+
+  setEleventyFiles(tw);
 
   tw.setVerboseOutput(false);
   await tw.write();
@@ -400,6 +448,8 @@ test("Custom collection returns array", async t => {
     ["md"]
   );
 
+  setEleventyFiles(tw);
+
   /* Careful here, eleventyConfig is a global */
   eleventyConfig.addCollection("returnAllInputPaths", function(collection) {
     return collection.getAllSorted().map(function(item) {
@@ -422,8 +472,10 @@ test("Custom collection returns a string", async t => {
     ["md"]
   );
 
+  setEleventyFiles(tw);
+
   /* Careful here, eleventyConfig is a global */
-  eleventyConfig.addCollection("returnATestString", function(collection) {
+  eleventyConfig.addCollection("returnATestString", function() {
     return "test";
   });
 
@@ -439,6 +491,8 @@ test("Custom collection returns an object", async t => {
     "./test/stubs/_site",
     ["md"]
   );
+
+  setEleventyFiles(tw);
 
   /* Careful here, eleventyConfig is a global */
   eleventyConfig.addCollection("returnATestObject", function() {
@@ -457,6 +511,8 @@ test("fileSlug should exist in a collection", async t => {
     "./test/stubs/collection-slug/_site",
     ["njk"]
   );
+
+  setEleventyFiles(tw);
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -482,6 +538,8 @@ test.skip("renderData should exist and be resolved in a collection (Issue #289)"
     ["njk"]
   );
 
+  setEleventyFiles(tw);
+
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
 
@@ -503,12 +561,15 @@ test("Write Test 11ty.js", async t => {
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite"
   );
+
   let evf = new EleventyFiles(
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite",
     ["11ty.js"]
   );
   evf.init();
+
+  tw.setEleventyFiles(evf);
 
   let files = await fastglob(evf.getFileGlobs());
   t.deepEqual(evf.getRawFiles(), ["./test/stubs/writeTestJS/**/*.11ty.js"]);
@@ -626,6 +687,8 @@ test("Passthrough file output", async t => {
     ["njk", "md"]
   );
 
+  setEleventyFiles(tw);
+
   const mgr = tw.getFileManager().getPassthroughManager();
   mgr.setConfig({
     passthroughFileCopy: true,
@@ -653,8 +716,11 @@ test("Passthrough file output", async t => {
   ];
 
   let results = await Promise.all(
-    output.map(function(path) {
-      return fs.exists(path);
+    output.map(path => {
+      return fs
+        .access(path, fs.constants.F_OK)
+        .then(() => Promise.resolve(true))
+        .catch(() => Promise.resolve(false));
     })
   );
 

--- a/test/stubs/config-illegal-data-dir.js
+++ b/test/stubs/config-illegal-data-dir.js
@@ -1,0 +1,7 @@
+module.exports = function() {
+  return {
+    dir: {
+      data: ".."
+    }
+  };
+};

--- a/test/stubs/config-illegal-includes-dir.js
+++ b/test/stubs/config-illegal-includes-dir.js
@@ -1,0 +1,7 @@
+module.exports = function() {
+  return {
+    dir: {
+      includes: ".."
+    }
+  };
+};


### PR DESCRIPTION
This pull request is the first step for #368.

- Makes `TemplateConfig` throw an error on construction if either the includes or data directories point outside of Eleventy’s working directory.
- There is also some unrelated clean up in the first commit:

  The `TemplateWriter` class no longer creates its `EleventyFiles` object itself when it is missing. This was only there to ensure that the `EleventyFiles` object is set during testing. Setting it is now a responsibility of the tests itself.

What do you think about the error message or error handling in general?

**Note**: Since there might be users who rely on the current functionality, this is a breaking change.