### PR TITLE
Fix getAllDirs not handling segments of equal name

### DIFF
--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -78,9 +78,7 @@ TemplatePath.getAllDirs = function(path) {
 
   return path
     .split("/")
-    .map(segment =>
-      path.substring(0, path.lastIndexOf(segment) + segment.length)
-    )
+    .map((segment, index, array) => array.slice(0, index + 1).join("/"))
     .filter(path => path !== ".")
     .reverse();
 };

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -30,10 +30,12 @@ test("getAllDirs", t => {
   t.deepEqual(TemplatePath.getAllDirs("./testing/"), ["./testing"]);
   t.deepEqual(TemplatePath.getAllDirs("testing/"), ["testing"]);
   t.deepEqual(TemplatePath.getAllDirs("testing"), ["testing"]);
+
   t.deepEqual(TemplatePath.getAllDirs("./testing/hello"), [
     "./testing/hello",
     "./testing"
   ]);
+
   t.deepEqual(TemplatePath.getAllDirs("./src/collections/posts"), [
     "./src/collections/posts",
     "./src/collections",
@@ -51,6 +53,12 @@ test("getAllDirs", t => {
       "./src"
     ]
   );
+
+  t.deepEqual(TemplatePath.getAllDirs("./src/_site/src"), [
+    "./src/_site/src",
+    "./src/_site",
+    "./src"
+  ]);
 });
 
 test("normalize", async t => {


### PR DESCRIPTION
Reviewing https://github.com/11ty/eleventy/issues/484#issuecomment-482911190. See #484.

The `TemplatePath.getAllDirs` utility was broken by me in #376 and stopped handling paths with multiple segments with the same name correctly. A patched version in https://github.com/11ty/eleventy/commit/f5f5c618920982d52497775740d75cc02d84338c has the same bug, but differently. This pull request should fix variants of the bug.