### PR TITLE
Make glob matching case insensitive

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -259,7 +259,7 @@ class EleventyFiles {
 
     debug("Searching for: %o", globs);
     let paths = TemplatePath.addLeadingDotSlashArray(
-      await fastglob.async(globs)
+      await fastglob.async(globs, { nocase: true, onlyFiles: true })
     );
     this.pathCache = paths;
     return paths;

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -55,6 +55,22 @@ test("getFiles (with js, treated as passthrough copy)", async t => {
   t.true(TemplateRender.hasEngine("./test/stubs/writeTestJS/test.11ty.js"));
 });
 
+test("getFiles (with case insensitivity)", async t => {
+  let evf = new EleventyFiles(
+    "./test/stubs/writeTestJS",
+    "./test/stubs/_writeTestJSSite",
+    ["JS"]
+  );
+  evf.init();
+
+  t.deepEqual(await evf.getFiles(), [
+    "./test/stubs/writeTestJS/sample.js",
+    "./test/stubs/writeTestJS/test.11ty.js"
+  ]);
+  t.false(TemplateRender.hasEngine("./test/stubs/writeTestJS/sample.js"));
+  t.true(TemplateRender.hasEngine("./test/stubs/writeTestJS/test.11ty.js"));
+});
+
 test("Mutually exclusive Input and Output dirs", async t => {
   let evf = new EleventyFiles(
     "./test/stubs/writeTest",


### PR DESCRIPTION
Fixes #509 

Note: I also added the `onlyFiles` flag since I BELIEVE we probably only want files, but someone can correct me if I'm wrong.