### PR TITLE
Extend Slugify to slug reserved characters

### DIFF
--- a/src/Filters/Slug.js
+++ b/src/Filters/Slug.js
@@ -1,5 +1,6 @@
 const slugify = require("slugify");
 
+slugify.extend({'\'': '-'})
 module.exports = function(str) {
   return slugify(str, {
     replacement: "-",

--- a/src/Filters/Slug.js
+++ b/src/Filters/Slug.js
@@ -1,9 +1,9 @@
 const slugify = require("slugify");
 
-slugify.extend({'\'': '-'})
 module.exports = function(str) {
   return slugify(str, {
     replacement: "-",
-    lower: true
+    lower: true,
+    remove: /[:\/\?\#\[\]@!$&'()*+,;=]/g
   });
 };


### PR DESCRIPTION
* Before : `"John's cars" | slug` => `john's-cars`
* After : `"John's cars" | slug` => `johns-cars`

Example Use case: using tags in permalinks, like in https://github.com/11ty/eleventy-base-blog and having a tag that contains an apostrophe.