### PR TITLE
Add Layouts Directory to debug output

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -166,6 +166,7 @@ class Eleventy {
 Input: ${this.inputDir}
 Data: ${this.templateData.getDataDir()}
 Includes: ${this.eleventyFiles.getIncludesDir()}
+Layouts: ${this.eleventyFiles.getLayoutsDir()}
 Output: ${this.outputDir}
 Template Formats: ${formats.join(",")}`);
 

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -248,6 +248,10 @@ class EleventyFiles {
     return this.includesDir;
   }
 
+  getLayoutsDir() {
+    return this.layoutsDir;
+  }
+
   getFileGlobs() {
     return this.templateGlobsWithIgnores;
   }


### PR DESCRIPTION
Closes #571 

While running `DEBUG=Eleventy* npx eleventy`, I noticed that the `Layouts` directory is not output along with the other config directories (`Input`, `Data`, `Includes`, `Output`). At first I thought I was configuring the `Layouts` directory incorrectly, and it took me a while to figure out that it simply wasn't in the debugging output.

This adds the `Layouts` directory to the debugging output. I thought it might save someone else the same trouble if they're trying to confirm that their `Layouts` directory is configured correctly.