### PR TITLE
Allow optional opening of browser tab on init

### DIFF
--- a/config.js
+++ b/config.js
@@ -27,6 +27,7 @@ module.exports = function(config) {
     passthroughFileCopy: true,
     htmlOutputSuffix: "-o",
     jsDataFileSuffix: ".11tydata",
+    openBrowser: false,
     keys: {
       package: "pkg",
       layout: "layout",

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -66,7 +66,7 @@ class EleventyServe {
         port: port || 8080,
         ignore: ["node_modules"],
         watch: false,
-        open: false,
+        open: this.config.openBrowser || false,
         notify: false,
         index: "index.html"
       },


### PR DESCRIPTION
This simple modification has been a popular request amongst developers at our org. 

Does what it says in the title:

```
  return {
    ...
    openBrowser: true,
    ...
  };
```

Will open a new browser tab via browserSync on 11ty init. 

