### PR TITLE
Throw when localConfig is a function that returns a promise

### DIFF
--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -98,6 +98,15 @@ class TemplateConfig {
     if (typeof localConfig === "function") {
       localConfig = localConfig(eleventyConfig);
       // debug( "localConfig is a function, after calling, eleventyConfig is %o", eleventyConfig );
+
+      if (
+        typeof localConfig === "object" &&
+        typeof localConfig.then === "function"
+      ) {
+        throw new EleventyConfigError(
+          `Error in your Eleventy config file '${path}': Returning a promise is not supported`
+        );
+      }
     }
 
     let eleventyConfigApiMergingObject = eleventyConfig.getMergingConfigObject();

--- a/test/TemplateConfigTest.js
+++ b/test/TemplateConfigTest.js
@@ -319,3 +319,12 @@ test("Properly throws error on missing module #182", t => {
     );
   });
 });
+
+test("Properly throws error when config returns a Promise", t => {
+  t.throws(function() {
+    new TemplateConfig(
+      require("../config.js"),
+      "./test/stubs/config-promise.js"
+    );
+  });
+});

--- a/test/stubs/config-promise.js
+++ b/test/stubs/config-promise.js
@@ -1,0 +1,5 @@
+module.exports = async function() {
+  return {
+    layouts: "promise"
+  };
+};


### PR DESCRIPTION
I attempted to use an async function in `.eleventy.js` because I wanted to try something depending on disk access, and usually do those things async. It turned out everything I tried to configure didn't work. The reason for this was that the config resolution doesn't handle async or promises, and just went ahead and merged my returned promise with the default config.

This PR makes the config resolution throw if a localConfig function returns a promise. Changing the entire flow to support async can be a major undertaking, but at least this addition will help future users identify their mistake clearly if they make the same one.