### PR TITLE
YAML data files support

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "semver": "^6.1.1",
     "slugify": "^1.3.4",
     "time-require": "^0.1.2",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "js-yaml": "^3.13.1"
   },
   "pre-commit": "lint-staged",
   "pre-push": "test"

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -557,6 +557,7 @@ test("Glob Watcher Files with Config Passthroughs (no template formats)", async 
   evf.init();
 
   t.deepEqual(await evf.getGlobWatcherTemplateDataFiles(), [
+    "./test/stubs/**/*.yml",
     "./test/stubs/**/*.json",
     "./test/stubs/**/*.11tydata.js"
   ]);

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -55,6 +55,7 @@ test("Eleventy file watching", async t => {
     "./test/stubs/_includes/**",
     "./test/stubs/_data/**",
     "./.eleventy.js",
+    "./test/stubs/**/*.yml",
     "./test/stubs/**/*.json",
     "./test/stubs/**/*.11tydata.js",
     "./test/stubs/deps/dep1.js",
@@ -77,6 +78,7 @@ test("Eleventy file watching (no JS dependencies)", async t => {
     "./test/stubs/_includes/**",
     "./test/stubs/_data/**",
     "./.eleventy.js",
+    "./test/stubs/**/*.yml",
     "./test/stubs/**/*.json",
     "./test/stubs/**/*.11tydata.js"
   ]);

--- a/test/TemplateDataTest.js
+++ b/test/TemplateDataTest.js
@@ -97,14 +97,16 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does not 
 test("Global Dir Directory", async t => {
   let dataObj = new TemplateData("./");
 
-  t.deepEqual(await dataObj.getGlobalDataGlob(), ["./_data/**/*.(json|js)"]);
+  t.deepEqual(await dataObj.getGlobalDataGlob(), [
+    "./_data/**/*.(yml|json|js)"
+  ]);
 });
 
 test("Global Dir Directory with Constructor Path Arg", async t => {
   let dataObj = new TemplateData("./test/stubs/");
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), [
-    "./test/stubs/_data/**/*.(json|js)"
+    "./test/stubs/_data/**/*.(yml|json|js)"
   ]);
 });
 
@@ -197,7 +199,9 @@ test("getLocalDataPaths", async t => {
   );
 
   t.deepEqual(paths, [
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -210,13 +214,19 @@ test("Deeper getLocalDataPaths", async t => {
   );
 
   t.deepEqual(paths, [
+    "./test/test.yml",
     "./test/test.json",
+    "./test/test.11tydata.yml",
     "./test/test.11tydata.json",
     "./test/test.11tydata.js",
+    "./test/stubs/stubs.yml",
     "./test/stubs/stubs.json",
+    "./test/stubs/stubs.11tydata.yml",
     "./test/stubs/stubs.11tydata.json",
     "./test/stubs/stubs.11tydata.js",
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -229,7 +239,9 @@ test("getLocalDataPaths with an 11ty js template", async t => {
   );
 
   t.deepEqual(paths, [
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -242,7 +254,9 @@ test("getLocalDataPaths with inputDir passed in (trailing slash)", async t => {
   );
 
   t.deepEqual(paths, [
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -255,7 +269,9 @@ test("getLocalDataPaths with inputDir passed in (no trailing slash)", async t =>
   );
 
   t.deepEqual(paths, [
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -268,7 +284,9 @@ test("getLocalDataPaths with inputDir passed in (no leading slash)", async t => 
   );
 
   t.deepEqual(paths, [
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -285,6 +303,7 @@ test("getTemplateDataFileGlob", async t => {
   let tw = new TemplateData("test/stubs");
 
   t.deepEqual(await tw.getTemplateDataFileGlob(), [
+    "./test/stubs/**/*.yml",
     "./test/stubs/**/*.json",
     "./test/stubs/**/*.11tydata.js"
   ]);
@@ -333,4 +352,26 @@ test("Parent directory for data (Issue #337)", async t => {
       hi: "bye"
     }
   });
+});
+
+test("getYamlData()", async t => {
+  let dataObj = new TemplateData("./test/stubs/");
+  let data = await dataObj.getData();
+
+  t.is(data.globalData3.datakey1, "yaml-datavalue", "simple data value");
+  t.is(
+    data.globalData3.datakey2,
+    "@11ty/eleventy",
+    `variables, resolve ${config.keys.package} to its value.`
+  );
+
+  let withLocalData = await dataObj.getLocalData(
+    "./test/stubs/component-yaml/component.njk"
+  );
+
+  t.is(withLocalData.yamlKey1, "yaml1");
+  t.is(withLocalData.yamlKey2, "yaml2");
+  t.is(withLocalData.jsonKey1, "json1");
+  t.is(withLocalData.jsonKey2, "json2");
+  t.is(withLocalData.jsKey1, "js1");
 });

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -441,7 +441,9 @@ test("Local template data file import (without a global data json)", async t => 
 
   let data = await tmpl.getData();
   t.deepEqual(await dataObj.getLocalDataPaths(tmpl.getInputPath()), [
+    "./test/stubs/component/component.yml",
     "./test/stubs/component/component.json",
+    "./test/stubs/component/component.11tydata.yml",
     "./test/stubs/component/component.11tydata.json",
     "./test/stubs/component/component.11tydata.js"
   ]);
@@ -461,13 +463,19 @@ test("Local template data file import (two subdirectories deep)", async t => {
   );
 
   t.deepEqual(await dataObj.getLocalDataPaths(tmpl.getInputPath()), [
+    "./test/stubs/firstdir/firstdir.yml",
     "./test/stubs/firstdir/firstdir.json",
+    "./test/stubs/firstdir/firstdir.11tydata.yml",
     "./test/stubs/firstdir/firstdir.11tydata.json",
     "./test/stubs/firstdir/firstdir.11tydata.js",
+    "./test/stubs/firstdir/seconddir/seconddir.yml",
     "./test/stubs/firstdir/seconddir/seconddir.json",
+    "./test/stubs/firstdir/seconddir/seconddir.11tydata.yml",
     "./test/stubs/firstdir/seconddir/seconddir.11tydata.json",
     "./test/stubs/firstdir/seconddir/seconddir.11tydata.js",
+    "./test/stubs/firstdir/seconddir/component.yml",
     "./test/stubs/firstdir/seconddir/component.json",
+    "./test/stubs/firstdir/seconddir/component.11tydata.yml",
     "./test/stubs/firstdir/seconddir/component.11tydata.json",
     "./test/stubs/firstdir/seconddir/component.11tydata.js"
   ]);
@@ -486,10 +494,14 @@ test("Posts inherits local JSON, layouts", async t => {
 
   let localDataPaths = await dataObj.getLocalDataPaths(tmpl.getInputPath());
   t.deepEqual(localDataPaths, [
+    "./test/stubs/posts/posts.yml",
     "./test/stubs/posts/posts.json",
+    "./test/stubs/posts/posts.11tydata.yml",
     "./test/stubs/posts/posts.11tydata.json",
     "./test/stubs/posts/posts.11tydata.js",
+    "./test/stubs/posts/post1.yml",
     "./test/stubs/posts/post1.json",
+    "./test/stubs/posts/post1.11tydata.yml",
     "./test/stubs/posts/post1.11tydata.json",
     "./test/stubs/posts/post1.11tydata.js"
   ]);
@@ -521,7 +533,9 @@ test("Template and folder name are the same, make sure data imports work ok", as
 
   let localDataPaths = await dataObj.getLocalDataPaths(tmpl.getInputPath());
   t.deepEqual(localDataPaths, [
+    "./test/stubs/posts/posts.yml",
     "./test/stubs/posts/posts.json",
+    "./test/stubs/posts/posts.11tydata.yml",
     "./test/stubs/posts/posts.11tydata.json",
     "./test/stubs/posts/posts.11tydata.js"
   ]);

--- a/test/stubs/_data/globalData3.yml
+++ b/test/stubs/_data/globalData3.yml
@@ -1,0 +1,2 @@
+datakey1: yaml-datavalue
+datakey2: "{{pkg.name}}"

--- a/test/stubs/component-yaml/component.11tydata.js
+++ b/test/stubs/component-yaml/component.11tydata.js
@@ -1,0 +1,5 @@
+const dep2 = require("../deps/dep2");
+
+module.exports = {
+  jsKey1: "js1"
+};

--- a/test/stubs/component-yaml/component.11tydata.json
+++ b/test/stubs/component-yaml/component.11tydata.json
@@ -1,0 +1,3 @@
+{
+    "jsonKey1": "json1"
+}

--- a/test/stubs/component-yaml/component.11tydata.yml
+++ b/test/stubs/component-yaml/component.11tydata.yml
@@ -1,0 +1,3 @@
+yamlKey2: "yaml2"
+jsonKey1: "overriden"
+jsKey1: "overriden"

--- a/test/stubs/component-yaml/component.json
+++ b/test/stubs/component-yaml/component.json
@@ -1,0 +1,4 @@
+{
+    "jsonKey2": "json2",
+    "jsKey1": "overriden"
+}

--- a/test/stubs/component-yaml/component.njk
+++ b/test/stubs/component-yaml/component.njk
@@ -1,0 +1,1 @@
+{{localkeyOverride}}

--- a/test/stubs/component-yaml/component.yml
+++ b/test/stubs/component-yaml/component.yml
@@ -1,0 +1,3 @@
+yamlKey1: "yaml1"
+jsonKey1: "overriden"
+jsKey1: "overriden"


### PR DESCRIPTION
A very straightforward implementation of YAML data files using the js-yaml library.
Changes in TemplateData.js, package.json and various tests.
In this implementation, YAML has lower priority than JSON and JS. 
"if" branch for YAML files in TemplateData.getDataValue is an almost exact copy of JSON branch. Helper function for loading json|yml could be made later if this PR gets an approval.
