### PR TITLE
Improve JavaScript templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 8
   - 10
+  - 12
 before_script:
   - npm install
 script: npm run test

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -15,22 +15,33 @@ class JavaScript extends TemplateEngine {
     return result;
   }
 
+  _getInstance(mod) {
+    if (typeof mod === "string" || mod instanceof Buffer || mod.then) {
+      return { render: () => mod };
+    } else if (typeof mod === "function") {
+      if (
+        mod.prototype &&
+        ("data" in mod.prototype || "render" in mod.prototype)
+      ) {
+        return new mod();
+      } else {
+        return { render: mod };
+      }
+    } else if ("data" in mod || "render" in mod) {
+      return mod;
+    }
+  }
+
   getInstanceFromInputPath(inputPath) {
     if (this.instances[inputPath]) {
       return this.instances[inputPath];
     }
 
-    const cls = this._getRequire(inputPath);
-    if (typeof cls === "function") {
-      if (
-        cls.prototype &&
-        ("data" in cls.prototype || "render" in cls.prototype)
-      ) {
-        let inst = new cls();
-        this.instances[inputPath] = inst;
-        return inst;
-      }
-    }
+    const mod = this._getRequire(inputPath);
+    let inst = this._getInstance(mod);
+
+    this.instances[inputPath] = inst;
+    return inst;
   }
 
   _getRequire(inputPath) {
@@ -56,57 +67,28 @@ class JavaScript extends TemplateEngine {
 
   async getExtraDataFromFile(inputPath) {
     let inst = this.getInstanceFromInputPath(inputPath);
-    if (inst) {
+    if (inst && "data" in inst) {
       // get extra data from `data` method,
       // either as a function or getter or object literal
       return typeof inst.data === "function" ? await inst.data() : inst.data;
     }
-
-    const cls = this._getRequire(inputPath);
-    if (typeof cls === "object") {
-      return typeof cls.data === "function" ? await cls.data() : cls.data;
-    }
   }
 
   async compile(str, inputPath) {
-    // for permalinks
+    let inst;
     if (str) {
-      // works with String, Buffer, Function!
-      return function(data) {
-        let target = str;
-        if (typeof str === "function") {
-          target = str.call(this.config.javascriptFunctions, data);
-        }
-        return this.normalize(target);
-      }.bind(this);
+      // When str has a value, it's being used for permalinks in data
+      inst = this._getInstance(str);
+    } else {
+      // For normal templates, str will be falsy.
+      inst = this.getInstanceFromInputPath(inputPath);
     }
 
-    // for all other requires, str will be falsy
-    const cls = this._getRequire(inputPath);
-    if (typeof cls === "function") {
-      // class with a `render` method
-      if (cls.prototype && "render" in cls.prototype) {
-        let inst = this.getInstanceFromInputPath(inputPath);
-        Object.assign(inst, this.config.javascriptFunctions);
-        return function(data) {
-          return this.normalize(inst.render.call(inst, data));
-        }.bind(this);
-      }
+    if (inst && "render" in inst) {
+      Object.assign(inst, this.config.javascriptFunctions);
 
-      // raw function
       return function(data) {
-        return this.normalize(cls.call(this.config.javascriptFunctions, data));
-      }.bind(this);
-    } else if (typeof cls === "object" && "render" in cls) {
-      return function(data) {
-        return this.normalize(
-          cls.render.call(this.config.javascriptFunctions, data)
-        );
-      }.bind(this);
-    } else {
-      // string type does not work with javascriptFunctions
-      return function() {
-        return this.normalize(cls);
+        return this.normalize(inst.render.call(inst, data));
       }.bind(this);
     }
   }

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -70,7 +70,10 @@ class JavaScript extends TemplateEngine {
     if (inst && "data" in inst) {
       // get extra data from `data` method,
       // either as a function or getter or object literal
-      return typeof inst.data === "function" ? await inst.data() : inst.data;
+      let result = await (typeof inst.data === "function"
+        ? inst.data()
+        : inst.data);
+      return result;
     }
   }
 

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -15,7 +15,14 @@ class JavaScript extends TemplateEngine {
     return result;
   }
 
+  // String, Buffer, Promise
+  // Function, Class
+  // Object
   _getInstance(mod) {
+    let noop = function() {
+      return "";
+    };
+
     if (typeof mod === "string" || mod instanceof Buffer || mod.then) {
       return { render: () => mod };
     } else if (typeof mod === "function") {
@@ -23,11 +30,17 @@ class JavaScript extends TemplateEngine {
         mod.prototype &&
         ("data" in mod.prototype || "render" in mod.prototype)
       ) {
+        if (!("render" in mod.prototype)) {
+          mod.prototype.render = noop;
+        }
         return new mod();
       } else {
         return { render: mod };
       }
     } else if ("data" in mod || "render" in mod) {
+      if (!("render" in mod)) {
+        mod.render = noop;
+      }
       return mod;
     }
   }

--- a/test/TemplateRenderLiquidTest.js
+++ b/test/TemplateRenderLiquidTest.js
@@ -722,6 +722,7 @@ test("Issue 600: Liquid Shortcode argument with underscores", async t => {
 });
 
 test.skip("Issue 611: Run a function", async t => {
+  // This works in Nunjucks
   let tr = new TemplateRender("liquid", "./test/stubs/");
 
   t.is(

--- a/test/TemplateRenderNunjucksTest.js
+++ b/test/TemplateRenderNunjucksTest.js
@@ -419,6 +419,7 @@ test("Nunjucks Test if statements on arrays (Issue #524)", async t => {
 });
 
 test("Issue 611: Run a function", async t => {
+  // This does not work in Liquid
   let tr = new TemplateRender("njk", "./test/stubs/");
 
   t.is(

--- a/test/TemplateTest-JavaScript.js
+++ b/test/TemplateTest-JavaScript.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import Template from "../src/Template";
+import semver from "semver";
 
 test("JavaScript template type (function)", async t => {
   let tmpl = new Template(
@@ -43,6 +44,22 @@ test("JavaScript template type (class with data method)", async t => {
   let pages = await tmpl.getRenderedTemplates(data);
   t.is(pages[0].templateContent.trim(), "<p>Ted</p>");
 });
+
+if (semver.gte(process.version, "12.4.0")) {
+  test("JavaScript template type (class fields)", async t => {
+    let tmpl = new Template(
+      "./test/stubs/classfields-data.11ty.js",
+      "./test/stubs/",
+      "./dist"
+    );
+
+    t.is(await tmpl.getOutputPath(), "./dist/classfields-data/index.html");
+    let data = await tmpl.getData();
+
+    let pages = await tmpl.getRenderedTemplates(data);
+    t.is(pages[0].templateContent.trim(), "<p>Ted</p>");
+  });
+}
 
 test("JavaScript template type (class with shorthand data method)", async t => {
   let tmpl = new Template(
@@ -188,4 +205,32 @@ test("JavaScript template type (class with renderData)", async t => {
     pages[0].templateContent.trim(),
     "<p>StringTesthowdy Zach, meet Thanos</p>"
   );
+});
+
+test("JavaScript template type (should use the same class instance for data and render)", async t => {
+  let tmpl = new Template(
+    "./test/stubs/oneinstance.11ty.js",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let pages = await tmpl.getRenderedTemplates(data);
+  // the template renders the random number created in the class constructor
+  // the data returns the random number created in the class constructor
+  // if they are different, the class is not reused.
+  t.is(pages[0].templateContent.trim(), `<p>Ted${data.rand}</p>`);
+});
+
+// TODO needs way more tests
+test("JavaScript template type (multiple exports)", async t => {
+  let tmpl = new Template(
+    "./test/stubs/multipleexports.11ty.js",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let pages = await tmpl.getRenderedTemplates(data);
+  t.is(pages[0].templateContent.trim(), "<p>Ted</p>");
 });

--- a/test/TemplateTest-JavaScript.js
+++ b/test/TemplateTest-JavaScript.js
@@ -222,7 +222,6 @@ test("JavaScript template type (should use the same class instance for data and 
   t.is(pages[0].templateContent.trim(), `<p>Ted${data.rand}</p>`);
 });
 
-// TODO needs way more tests
 test("JavaScript template type (multiple exports)", async t => {
   let tmpl = new Template(
     "./test/stubs/multipleexports.11ty.js",
@@ -233,4 +232,60 @@ test("JavaScript template type (multiple exports)", async t => {
   let data = await tmpl.getData();
   let pages = await tmpl.getRenderedTemplates(data);
   t.is(pages[0].templateContent.trim(), "<p>Ted</p>");
+});
+
+test("JavaScript template type (multiple exports, promises)", async t => {
+  let tmpl = new Template(
+    "./test/stubs/multipleexports-promises.11ty.js",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  t.is(data.name, "Ted");
+
+  let pages = await tmpl.getRenderedTemplates(data);
+  t.is(pages[0].templateContent.trim(), "<p>Ted</p>");
+});
+
+test("JavaScript template type (object)", async t => {
+  let tmpl = new Template(
+    "./test/stubs/object.11ty.js",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  t.is(data.name, "Ted");
+
+  let pages = await tmpl.getRenderedTemplates(data);
+  t.is(pages[0].templateContent.trim(), "<p>Ted</p>");
+});
+
+test("JavaScript template type (object, no render method)", async t => {
+  let tmpl = new Template(
+    "./test/stubs/object-norender.11ty.js",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  t.is(data.name, "Ted");
+
+  let pages = await tmpl.getRenderedTemplates(data);
+  t.is(pages[0].templateContent.trim(), "");
+});
+
+test("JavaScript template type (class, no render method)", async t => {
+  let tmpl = new Template(
+    "./test/stubs/class-norender.11ty.js",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  t.is(data.name, "Ted");
+
+  let pages = await tmpl.getRenderedTemplates(data);
+  t.is(pages[0].templateContent.trim(), "");
 });

--- a/test/stubs/class-norender.11ty.js
+++ b/test/stubs/class-norender.11ty.js
@@ -1,0 +1,9 @@
+class Test {
+  data() {
+    return {
+      name: "Ted"
+    };
+  }
+}
+
+module.exports = Test;

--- a/test/stubs/classfields-data.11ty.js
+++ b/test/stubs/classfields-data.11ty.js
@@ -1,0 +1,11 @@
+class Test {
+  data = {
+    name: "Ted"
+  };
+
+  render({ name }) {
+    return `<p>${name}</p>`;
+  }
+}
+
+module.exports = Test;

--- a/test/stubs/multipleexports-promises.11ty.js
+++ b/test/stubs/multipleexports-promises.11ty.js
@@ -1,0 +1,15 @@
+exports.data = async function() {
+  return new Promise((resolve, reject) => {
+    setTimeout(function() {
+      resolve({ name: "Ted" });
+    }, 100);
+  });
+};
+
+exports.render = async function({ name }) {
+  return new Promise((resolve, reject) => {
+    setTimeout(function() {
+      resolve(`<p>${name}</p>`);
+    }, 100);
+  });
+};

--- a/test/stubs/multipleexports.11ty.js
+++ b/test/stubs/multipleexports.11ty.js
@@ -1,0 +1,7 @@
+exports.data = {
+  name: "Ted"
+};
+
+exports.render = function({ name }) {
+  return `<p>${name}</p>`;
+};

--- a/test/stubs/object-norender.11ty.js
+++ b/test/stubs/object-norender.11ty.js
@@ -1,0 +1,5 @@
+module.exports = {
+  data: {
+    name: "Ted"
+  }
+};

--- a/test/stubs/object.11ty.js
+++ b/test/stubs/object.11ty.js
@@ -1,0 +1,8 @@
+module.exports = {
+  data: {
+    name: "Ted"
+  },
+  render: function({ name }) {
+    return `<p>${name}</p>`;
+  }
+};

--- a/test/stubs/oneinstance.11ty.js
+++ b/test/stubs/oneinstance.11ty.js
@@ -1,0 +1,18 @@
+class Test {
+  constructor() {
+    this.rand = Math.random();
+  }
+
+  get data() {
+    return {
+      name: "Ted",
+      rand: this.rand
+    };
+  }
+
+  render({ name }) {
+    return `<p>${name}${this.rand}</p>`;
+  }
+}
+
+module.exports = Test;


### PR DESCRIPTION
* When using class-based templates, use a single object instance for data and rendering.
* Add support for object-based JS templates a la `module.exports = { data: function() {}, render: function() {} }` and `module.exports.data = function() {}; module.exports.render = function() {};`
* Add support for Node v12+ feature: class fields a la:

```
module.exports = class {
  data = {
    title: 'hi',
  };

  render(data) {
    return `
      <p>${data.title}</p>
    `;
  }
};
```

* Fails gracefully when class or object definition is missing a render method (returns `""`), behaves similar to a data file.

Fixes #622.