### PR TITLE
User data hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "toml": "^3.0.0",
     "viperhtml": "^2.17.0",
     "vue": "^2.6.10",
-    "vue-server-renderer": "^2.6.10"
+    "vue-server-renderer": "^2.6.10",
+    "js-yaml": "^3.13.1"
   },
   "dependencies": {
     "browser-sync": "^2.26.7",

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -110,10 +110,19 @@ class TemplateData {
 
   async getTemplateDataFileGlob() {
     let dir = await this.getInputDir();
-    return TemplatePath.addLeadingDotSlashArray([
+    let paths = [
       `${dir}/**/*.json`, // covers .11tydata.json too
       `${dir}/**/*${this.config.jsDataFileSuffix}.js`
-    ]);
+    ];
+
+    if (this.hasUserDataExtensions()) {
+      let userPaths = this.getUserDataExtensions().map(
+        extension => `${dir}/**/*.${extension}` // covers .11tydata.{extension} too
+      );
+      paths = userPaths.concat(paths);
+    }
+
+    return TemplatePath.addLeadingDotSlashArray(paths);
   }
 
   async getTemplateJavaScriptDataFileGlob() {
@@ -125,7 +134,15 @@ class TemplateData {
 
   async getGlobalDataGlob() {
     let dir = await this.getInputDir();
-    return [this._getGlobalDataGlobByExtension(dir, "(json|js)")];
+    let userExtensions = "";
+    // creating glob string for user extensions
+    if (this.hasUserDataExtensions()) {
+      userExtensions = this.getUserDataExtensions().join("|") + "|";
+    }
+
+    return [
+      this._getGlobalDataGlobByExtension(dir, "(" + userExtensions + "json|js)")
+    ];
   }
 
   getWatchPathCache() {
@@ -156,6 +173,7 @@ class TemplateData {
     let files = TemplatePath.addLeadingDotSlashArray(
       await this.getGlobalDataFiles()
     );
+
     let dataFileConflicts = {};
 
     for (let j = 0, k = files.length; j < k; j++) {
@@ -217,7 +235,31 @@ class TemplateData {
     return localData;
   }
 
-  async _getLocalJsonString(path) {
+  getUserDataExtensions() {
+    if (!this.config.dataExtensions) {
+      return [];
+    }
+
+    // returning extensions in reverse order to create proper extension order
+    // later added formats will override first ones
+    return Array.from(this.config.dataExtensions.keys()).reverse();
+  }
+
+  getUserDataParser(extension) {
+    return this.config.dataExtensions.get(extension);
+  }
+
+  isUserDataExtension(extension) {
+    return (
+      this.config.dataExtensions && this.config.dataExtensions.has(extension)
+    );
+  }
+
+  hasUserDataExtensions() {
+    return this.config.dataExtensions && this.config.dataExtensions.size > 0;
+  }
+
+  async _loadFileContents(path) {
     let rawInput;
     try {
       rawInput = await fs.readFile(path, "utf-8");
@@ -227,56 +269,78 @@ class TemplateData {
     return rawInput;
   }
 
-  async getDataValue(path, rawImports, ignoreProcessing) {
-    if (ignoreProcessing || TemplatePath.getExtension(path) === "js") {
-      let localPath = TemplatePath.absolutePath(path);
-      if (await fs.pathExists(localPath)) {
-        let dataBench = bench.get(`\`${path}\``);
-        dataBench.before();
-        delete require.cache[localPath];
-        let returnValue = require(localPath);
-        if (typeof returnValue === "function") {
-          returnValue = await returnValue();
-        }
+  async _parseDataFile(path, rawImports, ignoreProcessing, parser) {
+    let rawInput = await this._loadFileContents(path);
+    let engineName = this.dataTemplateEngine;
 
-        dataBench.after();
-        return returnValue;
-      } else {
-        return {};
-      }
-    } else {
-      let rawInput = await this._getLocalJsonString(path);
-      let engineName = this.dataTemplateEngine;
-
-      if (rawInput) {
-        if (ignoreProcessing || engineName === false) {
-          try {
-            return JSON.parse(rawInput);
-          } catch (e) {
-            throw new TemplateDataParseError(
-              `Having trouble parsing data file ${path}`,
-              e
-            );
-          }
-        } else {
-          let fn = await new TemplateRender(engineName).getCompiledTemplate(
-            rawInput
-          );
-
-          try {
-            // pass in rawImports, don’t pass in global data, that’s what we’re parsing
-            return JSON.parse(await fn(rawImports));
-          } catch (e) {
-            throw new TemplateDataParseError(
-              `Having trouble parsing data file ${path}`,
-              e
-            );
-          }
-        }
-      }
+    if (!rawInput) {
+      return {};
     }
 
-    return {};
+    if (ignoreProcessing || engineName === false) {
+      try {
+        return parser(rawInput);
+      } catch (e) {
+        throw new TemplateDataParseError(
+          `Having trouble parsing data file ${path}`,
+          e
+        );
+      }
+    } else {
+      let fn = await new TemplateRender(engineName).getCompiledTemplate(
+        rawInput
+      );
+
+      try {
+        // pass in rawImports, don’t pass in global data, that’s what we’re parsing
+        let raw = await fn(rawImports);
+        return parser(raw);
+      } catch (e) {
+        throw new TemplateDataParseError(
+          `Having trouble parsing data file ${path}`,
+          e
+        );
+      }
+    }
+  }
+
+  async getDataValue(path, rawImports, ignoreProcessing) {
+    let extension = TemplatePath.getExtension(path);
+
+    if ((ignoreProcessing && extension === "json") || extension === "js") {
+      let localPath = TemplatePath.absolutePath(path);
+      if (!(await fs.pathExists(localPath))) {
+        return {};
+      }
+
+      let dataBench = bench.get(`\`${path}\``);
+      dataBench.before();
+      delete require.cache[localPath];
+
+      let returnValue = require(localPath);
+      if (typeof returnValue === "function") {
+        returnValue = await returnValue();
+      }
+
+      dataBench.after();
+      return returnValue;
+    } else if (this.isUserDataExtension(extension)) {
+      var parser = this.getUserDataParser(extension);
+      return this._parseDataFile(path, rawImports, ignoreProcessing, parser);
+    } else {
+      return this._parseDataFile(
+        path,
+        rawImports,
+        ignoreProcessing,
+        JSON.parse
+      );
+    }
+  }
+
+  _pushExtensionsToPaths(paths, curpath, extensions) {
+    for (let extension of extensions) {
+      paths.push(curpath + "." + extension);
+    }
   }
 
   async getLocalDataPaths(templatePath) {
@@ -285,19 +349,34 @@ class TemplateData {
     let inputDir = TemplatePath.addLeadingDotSlash(
       TemplatePath.normalize(this.inputDir)
     );
+
     debugDev("getLocalDataPaths(%o)", templatePath);
     debugDev("parsed.dir: %o", parsed.dir);
+
+    let userExtensions = this.getUserDataExtensions();
 
     if (parsed.dir) {
       let fileNameNoExt = EleventyExtensionMap.removeTemplateExtension(
         parsed.base
       );
+
       let filePathNoExt = parsed.dir + "/" + fileNameNoExt;
       let dataSuffix = this.config.jsDataFileSuffix;
       debug("Using %o to find data files.", dataSuffix);
+
+      // data suffix
       paths.push(filePathNoExt + dataSuffix + ".js");
       paths.push(filePathNoExt + dataSuffix + ".json");
+      // inject user extensions
+      this._pushExtensionsToPaths(
+        paths,
+        filePathNoExt + dataSuffix,
+        userExtensions
+      );
+
+      // top level
       paths.push(filePathNoExt + ".json");
+      this._pushExtensionsToPaths(paths, filePathNoExt, userExtensions);
 
       let allDirs = TemplatePath.getAllDirs(parsed.dir);
       debugDev("allDirs: %o", allDirs);
@@ -306,15 +385,33 @@ class TemplateData {
         let dirPathNoExt = dir + "/" + lastDir;
 
         if (!inputDir) {
+          // data suffix
           paths.push(dirPathNoExt + dataSuffix + ".js");
           paths.push(dirPathNoExt + dataSuffix + ".json");
+          this._pushExtensionsToPaths(
+            paths,
+            dirPathNoExt + dataSuffix,
+            userExtensions
+          );
+
+          // top level
           paths.push(dirPathNoExt + ".json");
+          this._pushExtensionsToPaths(paths, dirPathNoExt, userExtensions);
         } else {
           debugDev("dirStr: %o; inputDir: %o", dir, inputDir);
           if (dir.indexOf(inputDir) === 0 && dir !== inputDir) {
+            // data suffix
             paths.push(dirPathNoExt + dataSuffix + ".js");
             paths.push(dirPathNoExt + dataSuffix + ".json");
+            this._pushExtensionsToPaths(
+              paths,
+              dirPathNoExt + dataSuffix,
+              userExtensions
+            );
+
+            // top level
             paths.push(dirPathNoExt + ".json");
+            this._pushExtensionsToPaths(paths, dirPathNoExt, userExtensions);
           }
         }
       }

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -54,6 +54,9 @@ class UserConfig {
     // this.templateExtensionAliases = {};
     this.watchJavaScriptDependencies = true;
     this.browserSyncConfig = {};
+
+    // using Map to preserve insertion order
+    this.dataExtensions = new Map();
   }
 
   versionCheck(expected) {
@@ -537,13 +540,18 @@ class UserConfig {
       // templateExtensionAliases: this.templateExtensionAliases,
       watchJavaScriptDependencies: this.watchJavaScriptDependencies,
       browserSyncConfig: this.browserSyncConfig,
-      frontMatterParsingOptions: this.frontMatterParsingOptions
+      frontMatterParsingOptions: this.frontMatterParsingOptions,
+      dataExtensions: this.dataExtensions
     };
   }
 
   // addExtension(fileExtension, userClass) {
   //   this.userExtensionMap[ fileExtension ] = userClass;
   // }
+
+  addDataExtension(formatExtension, formatParser) {
+    this.dataExtensions.set(formatExtension, formatParser);
+  }
 }
 
 module.exports = UserConfig;

--- a/test/UserDataExtensionsTest.js
+++ b/test/UserDataExtensionsTest.js
@@ -1,0 +1,92 @@
+import test from "ava";
+import TemplateData from "../src/TemplateData";
+let yaml = require("js-yaml");
+
+function injectDataExtensions(dataObj) {
+  dataObj.config.dataExtensions = new Map([
+    ["yaml", s => yaml.safeLoad(s)],
+    ["nosj", JSON.parse]
+  ]);
+}
+
+test("Local data", async t => {
+  let dataObj = new TemplateData("./test/stubs-630/");
+  injectDataExtensions(dataObj);
+
+  let data = await dataObj.getData();
+
+  // YAML GLOBAL DATA
+  t.is(data.globalData2.datakey1, "datavalue2");
+  t.is(data.globalData2.datakey2, "@11ty/eleventy--yaml");
+
+  // NOSJ (JSON) GLOBAL DATA
+  t.is(data.globalData3.datakey1, "datavalue3");
+  t.is(data.globalData3.datakey2, "@11ty/eleventy--nosj");
+
+  let withLocalData = await dataObj.getLocalData(
+    "./test/stubs-630/component-yaml/component.njk"
+  );
+  // console.log("localdata", withLocalData);
+
+  t.is(withLocalData.yamlKey1, "yaml1");
+  t.is(withLocalData.yamlKey2, "yaml2");
+  t.is(withLocalData.yamlKey3, "yaml3");
+  t.is(withLocalData.nosjKey1, "nosj1");
+  t.is(withLocalData.jsonKey1, "json1");
+  t.is(withLocalData.jsonKey2, "json2");
+  t.is(withLocalData.jsKey1, "js1");
+});
+
+test("Local files", async t => {
+  let dataObj = new TemplateData("./test/stubs-630/");
+  injectDataExtensions(dataObj);
+  let files = await dataObj.getLocalDataPaths(
+    "./test/stubs-630/component-yaml/component.njk"
+  );
+  t.deepEqual(files, [
+    "./test/stubs-630/component-yaml/component-yaml.yaml",
+    "./test/stubs-630/component-yaml/component-yaml.nosj",
+    "./test/stubs-630/component-yaml/component-yaml.json",
+    "./test/stubs-630/component-yaml/component-yaml.11tydata.yaml",
+    "./test/stubs-630/component-yaml/component-yaml.11tydata.nosj",
+    "./test/stubs-630/component-yaml/component-yaml.11tydata.json",
+    "./test/stubs-630/component-yaml/component-yaml.11tydata.js",
+    "./test/stubs-630/component-yaml/component.yaml",
+    "./test/stubs-630/component-yaml/component.nosj",
+    "./test/stubs-630/component-yaml/component.json",
+    "./test/stubs-630/component-yaml/component.11tydata.yaml",
+    "./test/stubs-630/component-yaml/component.11tydata.nosj",
+    "./test/stubs-630/component-yaml/component.11tydata.json",
+    "./test/stubs-630/component-yaml/component.11tydata.js"
+  ]);
+});
+
+test("Global data", async t => {
+  let dataObj = new TemplateData("./test/stubs-630/");
+
+  injectDataExtensions(dataObj);
+
+  t.deepEqual(await dataObj.getGlobalDataGlob(), [
+    "./test/stubs-630/_data/**/*.(nosj|yaml|json|js)"
+  ]);
+
+  let dataFilePaths = await dataObj.getGlobalDataFiles();
+  let data = await dataObj.getData();
+
+  // JS GLOBAL DATA
+  t.is(data.globalData0.datakey1, "datavalue0");
+
+  // JSON GLOBAL DATA
+  t.is(data.globalData1.datakey1, "datavalue1");
+  t.is(data.globalData1.datakey2, "@11ty/eleventy--json");
+
+  // YAML GLOBAL DATA
+  t.is(data.globalData2.datakey1, "datavalue2");
+  t.is(data.globalData2.datakey2, "@11ty/eleventy--yaml");
+
+  // NOSJ (JSON) GLOBAL DATA
+  t.is(data.globalData3.datakey1, "datavalue3");
+  t.is(data.globalData3.datakey2, "@11ty/eleventy--nosj");
+
+  t.is(data.subdir.globalDataSubdir.keyyaml, "yaml");
+});

--- a/test/stubs-630/_data/globalData0.js
+++ b/test/stubs-630/_data/globalData0.js
@@ -1,0 +1,3 @@
+module.exports = {
+  datakey1: "datavalue0"
+};

--- a/test/stubs-630/_data/globalData1.json
+++ b/test/stubs-630/_data/globalData1.json
@@ -1,0 +1,4 @@
+{
+  "datakey1": "datavalue1",
+  "datakey2": "{{pkg.name}}--json"
+}

--- a/test/stubs-630/_data/globalData2.yaml
+++ b/test/stubs-630/_data/globalData2.yaml
@@ -1,0 +1,2 @@
+datakey1: datavalue2
+datakey2: "{{pkg.name}}--yaml"

--- a/test/stubs-630/_data/globalData3.nosj
+++ b/test/stubs-630/_data/globalData3.nosj
@@ -1,0 +1,4 @@
+{
+  "datakey1": "datavalue3",
+  "datakey2": "{{pkg.name}}--nosj"
+}

--- a/test/stubs-630/_data/subdir/globalDataSubdir.yaml
+++ b/test/stubs-630/_data/subdir/globalDataSubdir.yaml
@@ -1,0 +1,1 @@
+keyyaml: "yaml"

--- a/test/stubs-630/component-yaml/component.11tydata.js
+++ b/test/stubs-630/component-yaml/component.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  jsKey1: "js1"
+};

--- a/test/stubs-630/component-yaml/component.11tydata.json
+++ b/test/stubs-630/component-yaml/component.11tydata.json
@@ -1,0 +1,3 @@
+{
+    "jsonKey1": "json1"
+}

--- a/test/stubs-630/component-yaml/component.11tydata.nosj
+++ b/test/stubs-630/component-yaml/component.11tydata.nosj
@@ -1,0 +1,3 @@
+{
+  "nosjKey1": "nosj1"
+}

--- a/test/stubs-630/component-yaml/component.11tydata.yaml
+++ b/test/stubs-630/component-yaml/component.11tydata.yaml
@@ -1,0 +1,5 @@
+yamlKey2: "yaml2"
+yamlKey3: "yaml3"
+jsonKey1: "overriden"
+jsKey1: "overriden"
+nosjKey1: "overriden"

--- a/test/stubs-630/component-yaml/component.json
+++ b/test/stubs-630/component-yaml/component.json
@@ -1,0 +1,5 @@
+{
+    "jsonKey2": "json2",
+    "jsKey1": "overriden",
+    "yamlKey3": "overriden"
+}

--- a/test/stubs-630/component-yaml/component.njk
+++ b/test/stubs-630/component-yaml/component.njk
@@ -1,0 +1,1 @@
+{{localkeyOverride}}

--- a/test/stubs-630/component-yaml/component.yaml
+++ b/test/stubs-630/component-yaml/component.yaml
@@ -1,0 +1,5 @@
+yamlKey1: "yaml1"
+yamlKey2: "overriden"
+jsonKey1: "overriden"
+jsonKey2: "overriden"
+jsKey1: "overriden"


### PR DESCRIPTION
This PR resolves #630.

User API looks like 
```
module.exports = function(eleventyConfig) {
  eleventyConfig.addDataExtension("yaml", contents => yaml.safeLoad(contents));
};
```
I am using Map for storing pairs {extension:parser}. 
**Override order**: in the case of 
```
  eleventyConfig.addDataExtension("yaml", contents => yaml.safeLoad(contents));
  eleventyConfig.addDataExtension("json2", contents => JSON.parse(contents));
```
json2 files will override data from yaml in the case of duplicate keys.

For tests, I created separate file UserDataExtensionsTest.js and test stubs (test/stubs-630).

I have three questions:

- In TemplateData.getDataValue was a line ` if (ignoreProcessing  || extension === "js") ` which I rewrote as  
``` if ((ignoreProcessing && extension === "json") || extension === "js")``` for my code to work. Can we remove this ignoreProcessing from here?  The block which manages JSON and custom data files has separate logic for ignoreProcessing already.
- In the tests, I attached Map with data formats to the TemplateData in the very ugly fashion.
```
function injectDataExtensions(dataObj) {
  dataObj.config.dataExtensions = new Map([
    ["yaml", s => yaml.safeLoad(s)],
    ["nosj", JSON.parse]
  ]);
}
```
 Is there a more elegant way to do it? Preferably I would like to use the user API and not `TemplateData._setConfig`.
- I found that global data from _data dir does not have data priority order, because of glob usage.
Does it need fixing?

