### PR TITLE
Resolves #693 and #677

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -183,7 +183,9 @@ class EleventyFiles {
         })
         .filter(line => {
           // empty lines or comments get filtered out
-          return line.length > 0 && line.charAt(0) !== "#";
+          return (
+            line.length > 0 && line.charAt(0) !== "#" && line.charAt(0) !== "!"
+          );
         })
         .map(line => {
           let path = TemplateGlob.normalizePath(dir, "/", line);


### PR DESCRIPTION
Checking for negative patterns in gitignore and eleventyignore files and and not processing them as files to ignore. This allows you to use the negative pattern (!filename) in your .gitignore and .eleventyignore files without eleventy skipping over everything and not processing your files.