### PR TITLE
Add getFilteredByTags method and tests

### DIFF
--- a/src/TemplateCollection.js
+++ b/src/TemplateCollection.js
@@ -60,10 +60,7 @@ class TemplateCollection extends Sortable {
     });
   }
 
-  getFilteredByTags(tags) {
-    if (!Array.isArray(tags)) {
-      return this.getFilteredByTag(tags);
-    }
+  getFilteredByTags(...tags) {
     return this.getAllSorted().filter(item =>
       tags.every(requiredTag => {
         const itemTags = item.data.tags;

--- a/test/TemplateCollectionTest.js
+++ b/test/TemplateCollectionTest.js
@@ -111,11 +111,11 @@ test("getFilteredByTags", async t => {
   await c._testAddTemplate(tmpl2);
   await c._testAddTemplate(tmpl3);
 
-  let postsAndCats = c.getFilteredByTags(["post", "cat"]);
+  let postsAndCats = c.getFilteredByTags("post", "cat");
   t.is(postsAndCats.length, 1);
   t.deepEqual(postsAndCats[0].template, tmpl3);
 
-  let cats = c.getFilteredByTags(["cat"]);
+  let cats = c.getFilteredByTags("cat");
   t.is(cats.length, 2);
   t.deepEqual(cats[0].template, tmpl2);
   t.deepEqual(cats[1].template, tmpl3);
@@ -131,12 +131,12 @@ test("getFilteredByTags (added out of order, sorted)", async t => {
   await c._testAddTemplate(tmpl2);
   await c._testAddTemplate(tmpl1);
 
-  let postsAndCats = c.getFilteredByTags(["post", "cat"]);
+  let postsAndCats = c.getFilteredByTags("post", "cat");
   t.truthy(postsAndCats.length);
   t.is(postsAndCats.length, 1);
   t.deepEqual(postsAndCats[0].template, tmpl3);
 
-  let cats = c.getFilteredByTags(["cat"]);
+  let cats = c.getFilteredByTags("cat");
   t.truthy(cats.length);
   t.is(cats.length, 2);
   t.deepEqual(cats[0].template, tmpl2);


### PR DESCRIPTION
Hello everyone,
in the light of #708 I decided to go with the custom collections for now while my amount of tags is still manageable. However, when creating my custom collections I discovered that there is no filter collections by multiple tags either and the `getFilteredByTag` method is not chainable. So I implemented a method that accepts either an array of values to filter by or a single value:

Single value:
Call is forwarded to the existing `getFilteredByTag` method and its result returned. Strictly speaking the method should return an error at this point and but hey this is JS and I'm a generous god ... err developer (_\*insert Xerxes meme\*_).

Array of values:
The method returns an array of elements which contain every value from the input array in its list of tags.

There are currently still errors in the tests but I'm not sure where they are coming from so input is highly appreciated.

Cheers

Edit: Almost forgot to mention, I also trimmed the `getFilteredByTag` methods a bit by switching to array methods instead of using manual comparisons.