### PR TITLE
Template utility cleanup

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -240,12 +240,12 @@ class Eleventy {
     );
 
     let versionStr = `v${pkg.version}`;
-    let time = ((new Date() - this.start) / 1000).toFixed(2);
+    let time = ((new Date().getTime() - this.start.getTime()) / 1000).toFixed(2);
     ret.push(`in ${time} ${simplePlural(time, "second", "seconds")}`);
 
     if (writeCount >= 10) {
       ret.push(
-        `(${((time * 1000) / writeCount).toFixed(1)}ms each, ${versionStr})`
+        `(${((Number(time) * 1000) / writeCount).toFixed(1)}ms each, ${versionStr})`
       );
     } else {
       ret.push(`(${versionStr})`);

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -151,7 +151,7 @@ class Eleventy {
    * Updates the watch targets.
    *
    * @method
-   * @param {} watchTargets - The new watch targets.
+   * @param {EleventyWatchTargets} watchTargets - The new watch targets.
    */
   setWatchTargets(watchTargets) {
     this.watchTargets = watchTargets;

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -72,11 +72,11 @@ class EleventyFiles {
   initFormatsGlobs() {
     // Input was a directory
     if (this.input === this.inputDir) {
-      this.templateGlobs = TemplateGlob.map(
-        this.extensionMap.getGlobs(this.inputDir)
-      );
+      this.templateGlobs = this.extensionMap
+        .getGlobs(this.inputDir)
+        .map(globPath => TemplateGlob.normalize(globPath));
     } else {
-      this.templateGlobs = TemplateGlob.map([this.input]);
+      this.templateGlobs = [TemplateGlob.normalize(this.input)];
     }
   }
 
@@ -116,9 +116,9 @@ class EleventyFiles {
     this.ignores = this.getIgnores();
 
     if (this.passthroughAll) {
-      this.watchedGlobs = TemplateGlob.map([
+      this.watchedGlobs = [
         TemplateGlob.normalizePath(this.input, "/**")
-      ]).concat(this.ignores);
+      ].concat(this.ignores);
     } else {
       this.watchedGlobs = this.templateGlobs.concat(this.ignores);
     }
@@ -250,7 +250,7 @@ class EleventyFiles {
       );
     }
 
-    files = files.concat(TemplateGlob.map("!" + this.outputDir + "/**"));
+    files = files.concat(TemplateGlob.normalize("!" + this.outputDir + "/**"));
 
     return files;
   }
@@ -333,18 +333,18 @@ class EleventyFiles {
     // we want this to fail on "" because we don’t want to ignore the
     // entire input directory when using ""
     if (this.config.dir.includes) {
-      files = files.concat(TemplateGlob.map(this.includesDir + "/**"));
+      files = files.concat(TemplateGlob.normalize(this.includesDir + "/**"));
     }
 
     // we want this to fail on "" because we don’t want to ignore the
     // entire input directory when using ""
     if (this.config.dir.layouts) {
-      files = files.concat(TemplateGlob.map(this.layoutsDir + "/**"));
+      files = files.concat(TemplateGlob.normalize(this.layoutsDir + "/**"));
     }
 
     if (this.config.dir.data && this.config.dir.data !== ".") {
       let dataDir = this.getDataDir();
-      files = files.concat(TemplateGlob.map(dataDir + "/**"));
+      files = files.concat(TemplateGlob.normalize(dataDir + "/**"));
     }
 
     return files;

--- a/src/Template.js
+++ b/src/Template.js
@@ -684,7 +684,8 @@ class Template extends TemplateContent {
     entries.push({
       template: this,
       inputPath: this.inputPath,
-      data: data
+      data: data,
+      _pages: null
     });
     return entries;
   }

--- a/src/TemplateGlob.js
+++ b/src/TemplateGlob.js
@@ -1,6 +1,12 @@
 const TemplatePath = require("./TemplatePath");
 
 class TemplateGlob {
+  /**
+   * Normalizes a path containing glob patterns.
+   *
+   * @param  {string[]} paths
+   * @returns {string}
+   */
   static normalizePath(...paths) {
     if (paths[0].charAt(0) === "!") {
       throw new Error(
@@ -9,27 +15,21 @@ class TemplateGlob {
         )}`
       );
     }
+
     return TemplatePath.addLeadingDotSlash(TemplatePath.join(...paths));
   }
 
+  /**
+   * Normalizes paths containing glob patterns.
+   *
+   * @param {string} path
+   * @returns {string}
+   */
   static normalize(path) {
-    path = path.trim();
     if (path.charAt(0) === "!") {
       return "!" + TemplateGlob.normalizePath(path.substr(1));
     } else {
       return TemplateGlob.normalizePath(path);
-    }
-  }
-
-  static map(files) {
-    if (typeof files === "string") {
-      return TemplateGlob.normalize(files);
-    } else if (Array.isArray(files)) {
-      return files.map(function(path) {
-        return TemplateGlob.normalize(path);
-      });
-    } else {
-      return files;
     }
   }
 }

--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -502,6 +502,13 @@ class TemplateMap {
   checkForDuplicatePermalinks() {
     let permalinks = {};
     let warnings = {};
+
+    function getPermalinkOutput(permalinks, page) {
+      return permalinks[page.url]
+        .map((inputPath, index) => `  ${index + 2}. ${inputPath}\n`)
+        .join("");
+    }
+
     for (let entry of this.map) {
       for (let page of entry._pages) {
         if (page.url === false) {
@@ -509,18 +516,14 @@ class TemplateMap {
         } else if (!permalinks[page.url]) {
           permalinks[page.url] = [entry.inputPath];
         } else {
-          warnings[
+          warnings[page.outputPath] = `
+          Output conflict: multiple input files are writing to \`${
             page.outputPath
-          ] = `Output conflict: multiple input files are writing to \`${
-            page.outputPath
-          }\`. Use distinct \`permalink\` values to resolve this conflict.
+          }\`.
+          Use distinct \`permalink\` values to resolve this conflict.
   1. ${entry.inputPath}
-${permalinks[page.url]
-  .map(function(inputPath, index) {
-    return `  ${index + 2}. ${inputPath}\n`;
-  })
-  .join("")}
-`;
+${getPermalinkOutput(permalinks, page)}
+          `.trim();
 
           permalinks[page.url].push(entry.inputPath);
         }

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -3,283 +3,287 @@ const normalize = require("normalize-path");
 const parsePath = require("parse-filepath");
 const fs = require("fs-extra");
 
-function TemplatePath() {}
+class TemplatePath {
+  /**
+   * @returns {string} the absolute path to Eleventy’s project directory.
+   */
+  static getWorkingDir() {
+    return TemplatePath.normalize(path.resolve("."));
+  }
 
-/**
- * @returns {String} the absolute path to Eleventy’s project directory.
- */
-TemplatePath.getWorkingDir = function() {
-  return TemplatePath.normalize(path.resolve("."));
-};
+  /**
+   * Returns the directory portion of a path.
+   * Works for directory and file paths and paths ending in a glob pattern.
+   *
+   * @param {string} path A path
+   * @returns {string} the directory portion of a path.
+   */
+  static getDir(path) {
+    if (TemplatePath.isDirectorySync(path)) {
+      return path;
+    }
 
-/**
- * Returns the directory portion of a path.
- * Works for directory and file paths and paths ending in a glob pattern.
- *
- * @param {String} path A path
- * @returns {String} the directory portion of a path.
- */
-TemplatePath.getDir = function(path) {
-  if (TemplatePath.isDirectorySync(path)) {
+    return TemplatePath.getDirFromFilePath(path);
+  }
+
+  /**
+   * Returns the directory portion of a path that either points to a file
+   * or ends in a glob pattern. If `path` points to a directory,
+   * the returned value will have its last path segment stripped
+   * due to how [`parsePath`][1] works.
+   *
+   * [1]: https://www.npmjs.com/package/parse-filepath
+   *
+   * @param {string} path A path
+   * @returns {string} the directory portion of a path.
+   */
+  static getDirFromFilePath(path) {
+    return parsePath(path).dir || ".";
+  }
+
+  /**
+   * Returns the last path segment in a path (no leading/trailing slashes).
+   *
+   * Assumes [`parsePath`][1] was called on `path` before.
+   *
+   * [1]: https://www.npmjs.com/package/parse-filepath
+   *
+   * @param {string} path A path
+   * @returns {string} the last path segment in a path
+   */
+  static getLastPathSegment(path) {
+    if (!path.includes("/")) {
+      return path;
+    }
+
+    // Trim a trailing slash if there is one
+    path = path.replace(/\/$/, "");
+
+    return path.substr(path.lastIndexOf("/") + 1);
+  }
+
+  /**
+   * @param {string} path A path
+   * @returns {string[]} an array of paths pointing to each path segment of the
+   * provided `path`.
+   */
+  static getAllDirs(path) {
+    // Trim a trailing slash if there is one
+    path = path.replace(/\/$/, "");
+
+    if (!path.includes("/")) {
+      return [path];
+    }
+
+    return path
+      .split("/")
+      .map((segment, index, array) => array.slice(0, index + 1).join("/"))
+      .filter(path => path !== ".")
+      .reverse();
+  }
+
+  /**
+   * Normalizes a path, resolving single-dot and double-dot segments.
+   *
+   * Node.js’ [`path.normalize`][1] is called to strip a possible leading `"./"` segment.
+   *
+   * [1]: https://nodejs.org/api/path.html#path_path_normalize_path
+   *
+   * @param {string} thePath The path that should be normalized.
+   * @returns {string} the normalized path.
+   */
+  static normalize(thePath) {
+    return normalize(path.normalize(thePath));
+  }
+
+  /**
+   * Joins all given path segments together.
+   *
+   * It uses Node.js’ [`path.join`][1] method and the [normalize-path][2] package.
+   *
+   * [1]: https://nodejs.org/api/path.html#path_path_join_paths
+   * [2]: https://www.npmjs.com/package/normalize-path
+   *
+   * @param {string[]} paths An arbitrary amount of path segments.
+   * @returns {string} the normalized and joined path.
+   */
+  static join(...paths) {
+    return normalize(path.join(...paths));
+  }
+
+  /**
+   * Joins the given URL path segments and normalizes the resulting path.
+   * Maintains traling a single trailing slash if the last URL path argument
+   * had atleast one.
+   *
+   * @param {string[]} urlPaths
+   * @returns {string} a normalized URL path described by the given URL path segments.
+   */
+  static normalizeUrlPath(...urlPaths) {
+    const urlPath = path.posix.join(...urlPaths);
+    return urlPath.replace(/\/+$/, "/");
+  }
+
+  /**
+   * Joins the given path segments. Since the first path is absolute,
+   * the resulting path will be absolute as well.
+   *
+   * @param {string[]} paths
+   * @returns {string} the absolute path described by the given path segments.
+   */
+  static absolutePath(...paths) {
+    return TemplatePath.join(TemplatePath.getWorkingDir(), ...paths);
+  }
+
+  /**
+   * Turns an absolute path into a path relative Eleventy’s project directory.
+   *
+   * @param {string} absolutePath
+   * @returns {string} the relative path.
+   */
+  static relativePath(absolutePath) {
+    return TemplatePath.stripLeadingSubPath(
+      absolutePath,
+      TemplatePath.getWorkingDir()
+    );
+  }
+
+  /**
+   * Adds a leading dot-slash segment to each path in the `paths` array.
+   *
+   * @param {string[]} paths
+   * @returns {string[]}
+   */
+  static addLeadingDotSlashArray(paths) {
+    return paths.map(path => TemplatePath.addLeadingDotSlash(path));
+  }
+
+  /**
+   * Adds a leading dot-slash segment to `path`.
+   *
+   * @param {string} path
+   * @returns {string}
+   */
+  static addLeadingDotSlash(path) {
+    if (path === "." || path === "..") {
+      return path + "/";
+    }
+
+    if (
+      path.startsWith("/") ||
+      path.startsWith("./") ||
+      path.startsWith("../")
+    ) {
+      return path;
+    }
+
+    return "./" + path;
+  }
+
+  /**
+   * Removes a leading dot-slash segment.
+   *
+   * @param {string} path
+   * @returns {string} the `path` without a leading dot-slash segment.
+   */
+  static stripLeadingDotSlash(path) {
+    return typeof path === "string" ? path.replace(/^\.\//, "") : path;
+  }
+
+  /**
+   * Determines whether a path starts with a given sub path.
+   *
+   * @param {string} path A path
+   * @param {string} subPath A path
+   * @returns {boolean} whether `path` starts with `subPath`.
+   */
+  static startsWithSubPath(path, subPath) {
+    path = TemplatePath.normalize(path);
+    subPath = TemplatePath.normalize(subPath);
+
+    return path.startsWith(subPath);
+  }
+
+  /**
+   * Removes the `subPath` at the start of `path` if present
+   * and returns the remainding path.
+   *
+   * @param {string} path A path
+   * @param {string} subPath A path
+   * @returns {string} the `path` without `subPath` at the start of it.
+   */
+  static stripLeadingSubPath(path, subPath) {
+    path = TemplatePath.normalize(path);
+    subPath = TemplatePath.normalize(subPath);
+
+    if (subPath !== "." && path.startsWith(subPath)) {
+      return path.substr(subPath.length + 1);
+    }
+
     return path;
   }
 
-  return TemplatePath.getDirFromFilePath(path);
-};
+  /**
+   * @param {string} path A path
+   * @returns {boolean} whether `path` points to an existing directory.
+   */
+  static isDirectorySync(path) {
+    return fs.existsSync(path) && fs.statSync(path).isDirectory();
+  }
 
-/**
- * Returns the directory portion of a path that either points to a file
- * or ends in a glob pattern. If `path` points to a directory,
- * the returned value will have its last path segment stripped
- * due to how [`parsePath`][1] works.
- *
- * [1]: https://www.npmjs.com/package/parse-filepath
- *
- * @param {String} path A path
- * @returns {String} the directory portion of a path.
- */
-TemplatePath.getDirFromFilePath = function(path) {
-  return parsePath(path).dir || ".";
-};
+  /**
+   * Appends a recursive wildcard glob pattern to `path`
+   * unless `path` is not a directory; then, `path` is assumed to be a file path
+   * and is left unchaged.
+   *
+   * @param {string} path
+   * @returns {string}
+   */
+  static convertToRecursiveGlob(path) {
+    if (path === "") {
+      return "./**";
+    }
 
-/**
- * Returns the last path segment in a path (no leading/trailing slashes).
- *
- * Assumes [`parsePath`][1] was called on `path` before.
- *
- * [1]: https://www.npmjs.com/package/parse-filepath
- *
- * @param {String} path A path
- * @returns {String} the last path segment in a path
- */
-TemplatePath.getLastPathSegment = function(path) {
-  if (!path.includes("/")) {
+    path = TemplatePath.addLeadingDotSlash(path);
+
+    if (TemplatePath.isDirectorySync(path)) {
+      return path + (!path.endsWith("/") ? "/" : "") + "**";
+    }
+
     return path;
   }
 
-  // Trim a trailing slash if there is one
-  path = path.replace(/\/$/, "");
-
-  return path.substr(path.lastIndexOf("/") + 1);
-};
-
-/**
- * @param {String} path A path
- * @returns {String[]} an array of paths pointing to each path segment of the
- * provided `path`.
- */
-TemplatePath.getAllDirs = function(path) {
-  // Trim a trailing slash if there is one
-  path = path.replace(/\/$/, "");
-
-  if (!path.includes("/")) {
-    return [path];
+  /**
+   * Returns the extension of the path without the leading dot.
+   * If the path has no extensions, the empty string is returned.
+   *
+   * @param {string} thePath
+   * @returns {string} the path’s extension if it exists;
+   * otherwise, the empty string.
+   */
+  static getExtension(thePath) {
+    return path.extname(thePath).replace(/^\./, "");
   }
 
-  return path
-    .split("/")
-    .map((segment, index, array) => array.slice(0, index + 1).join("/"))
-    .filter(path => path !== ".")
-    .reverse();
-};
+  /**
+   * Removes the extension from a path.
+   *
+   * @param {string} path
+   * @param {string} extension
+   * @returns {string}
+   */
+  static removeExtension(path, extension = undefined) {
+    if (extension === undefined) {
+      return path;
+    }
 
-/**
- * Normalizes a path, resolving single-dot and double-dot segments.
- *
- * Node.js’ [`path.normalize`][1] is called to strip a possible leading `"./"` segment.
- *
- * [1]: https://nodejs.org/api/path.html#path_path_normalize_path
- *
- * @param {String} thePath The path that should be normalized.
- * @returns {String} the normalized path.
- */
-TemplatePath.normalize = function(thePath) {
-  return normalize(path.normalize(thePath));
-};
+    const pathExtension = TemplatePath.getExtension(path);
+    if (pathExtension !== "" && extension.endsWith(pathExtension)) {
+      return path.substring(0, path.lastIndexOf(pathExtension) - 1);
+    }
 
-/**
- * Joins all given path segments together.
- *
- * It uses Node.js’ [`path.join`][1] method and the [normalize-path][2] package.
- *
- * [1]: https://nodejs.org/api/path.html#path_path_join_paths
- * [2]: https://www.npmjs.com/package/normalize-path
- *
- * @param {String[]} paths An arbitrary amount of path segments.
- * @returns {String} the normalized and joined path.
- */
-TemplatePath.join = function(...paths) {
-  return normalize(path.join(...paths));
-};
-
-/**
- * Joins the given URL path segments and normalizes the resulting path.
- * Maintains traling a single trailing slash if the last URL path argument
- * had atleast one.
- *
- * @param {String[]} urlPaths
- * @returns {String} a normalized URL path described by the given URL path segments.
- */
-TemplatePath.normalizeUrlPath = function(...urlPaths) {
-  const urlPath = path.posix.join(...urlPaths);
-  return urlPath.replace(/\/+$/, "/");
-};
-
-/**
- * Joins the given path segments. Since the first path is absolute,
- * the resulting path will be absolute as well.
- *
- * @param {String[]} paths
- * @returns {String} the absolute path described by the given path segments.
- */
-TemplatePath.absolutePath = function(...paths) {
-  return TemplatePath.join(TemplatePath.getWorkingDir(), ...paths);
-};
-
-/**
- * Turns an absolute path into a path relative Eleventy’s project directory.
- *
- * @param {String} absolutePath
- * @returns {String} the relative path.
- */
-TemplatePath.relativePath = function(absolutePath) {
-  return TemplatePath.stripLeadingSubPath(
-    absolutePath,
-    TemplatePath.getWorkingDir()
-  );
-};
-
-/**
- * Adds a leading dot-slash segment to each path in the `paths` array.
- *
- * @param {String[]} paths
- * @returns {String[]}
- */
-TemplatePath.addLeadingDotSlashArray = function(paths) {
-  return paths.map(path => TemplatePath.addLeadingDotSlash(path));
-};
-
-/**
- * Adds a leading dot-slash segment to `path`.
- *
- * @param {String} path
- * @returns {String}
- */
-TemplatePath.addLeadingDotSlash = function(path) {
-  if (path === "." || path === "..") {
-    return path + "/";
-  }
-
-  if (path.startsWith("/") || path.startsWith("./") || path.startsWith("../")) {
     return path;
   }
-
-  return "./" + path;
-};
-
-/**
- * Removes a leading dot-slash segment.
- *
- * @param {String} path
- * @returns {String} the `path` without a leading dot-slash segment.
- */
-TemplatePath.stripLeadingDotSlash = function(path) {
-  return typeof path === "string" ? path.replace(/^\.\//, "") : path;
-};
-
-/**
- * Determines whether a path starts with a given sub path.
- *
- * @param {String} path A path
- * @param {String} subPath A path
- * @returns {Boolean} whether `path` starts with `subPath`.
- */
-TemplatePath.startsWithSubPath = function(path, subPath) {
-  path = TemplatePath.normalize(path);
-  subPath = TemplatePath.normalize(subPath);
-
-  return path.startsWith(subPath);
-};
-
-/**
- * Removes the `subPath` at the start of `path` if present
- * and returns the remainding path.
- *
- * @param {String} path A path
- * @param {String} subPath A path
- * @returns {String} the `path` without `subPath` at the start of it.
- */
-TemplatePath.stripLeadingSubPath = function(path, subPath) {
-  path = TemplatePath.normalize(path);
-  subPath = TemplatePath.normalize(subPath);
-
-  if (subPath !== "." && path.startsWith(subPath)) {
-    return path.substr(subPath.length + 1);
-  }
-
-  return path;
-};
-
-/**
- * @param {String} path A path
- * @returns {Boolean} whether `path` points to an existing directory.
- */
-TemplatePath.isDirectorySync = function(path) {
-  return fs.existsSync(path) && fs.statSync(path).isDirectory();
-};
-
-/**
- * Appends a recursive wildcard glob pattern to `path`
- * unless `path` is not a directory; then, `path` is assumed to be a file path
- * and is left unchaged.
- *
- * @param {String} path
- * @returns {String}
- */
-TemplatePath.convertToRecursiveGlob = function(path) {
-  if (path === "") {
-    return "./**";
-  }
-
-  path = TemplatePath.addLeadingDotSlash(path);
-
-  if (TemplatePath.isDirectorySync(path)) {
-    return path + (!path.endsWith("/") ? "/" : "") + "**";
-  }
-
-  return path;
-};
-
-/**
- * Returns the extension of the path without the leading dot.
- * If the path has no extensions, the empty string is returned.
- *
- * @param {String} thePath
- * @returns {String} the path’s extension if it exists;
- * otherwise, the empty string.
- */
-TemplatePath.getExtension = function(thePath) {
-  return path.extname(thePath).replace(/^\./, "");
-};
-
-/**
- * Removes the extension from a path.
- *
- * @param {String} path
- * @param {String} extension
- * @returns {String}
- */
-TemplatePath.removeExtension = function(path, extension = undefined) {
-  if (extension === undefined) {
-    return path;
-  }
-
-  const pathExtension = TemplatePath.getExtension(path);
-  if (pathExtension !== "" && extension.endsWith(pathExtension)) {
-    return path.substring(0, path.lastIndexOf(pathExtension) - 1);
-  }
-
-  return path;
-};
+}
 
 module.exports = TemplatePath;

--- a/test/TemplateGlobTest.js
+++ b/test/TemplateGlobTest.js
@@ -10,32 +10,35 @@ test("TemplatePath assumptions", t => {
 });
 
 test("Normalize string argument", t => {
-  t.deepEqual(TemplateGlob.map("views"), "./views");
-  t.deepEqual(TemplateGlob.map("views/"), "./views");
-  t.deepEqual(TemplateGlob.map("./views"), "./views");
-  t.deepEqual(TemplateGlob.map("./views/"), "./views");
+  t.deepEqual(TemplateGlob.normalize("views"), "./views");
+  t.deepEqual(TemplateGlob.normalize("views/"), "./views");
+  t.deepEqual(TemplateGlob.normalize("./views"), "./views");
+  t.deepEqual(TemplateGlob.normalize("./views/"), "./views");
 });
 
 test("Normalize with nots", t => {
-  t.deepEqual(TemplateGlob.map("!views"), "!./views");
-  t.deepEqual(TemplateGlob.map("!views/"), "!./views");
-  t.deepEqual(TemplateGlob.map("!./views"), "!./views");
-  t.deepEqual(TemplateGlob.map("!./views/"), "!./views");
+  t.deepEqual(TemplateGlob.normalize("!views"), "!./views");
+  t.deepEqual(TemplateGlob.normalize("!views/"), "!./views");
+  t.deepEqual(TemplateGlob.normalize("!./views"), "!./views");
+  t.deepEqual(TemplateGlob.normalize("!./views/"), "!./views");
 });
 
 test("Normalize with globstar", t => {
-  t.deepEqual(TemplateGlob.map("!views/**"), "!./views/**");
-  t.deepEqual(TemplateGlob.map("!./views/**"), "!./views/**");
+  t.deepEqual(TemplateGlob.normalize("!views/**"), "!./views/**");
+  t.deepEqual(TemplateGlob.normalize("!./views/**"), "!./views/**");
 });
 
 test("Normalize with globstar and star", t => {
-  t.deepEqual(TemplateGlob.map("!views/**/*"), "!./views/**/*");
-  t.deepEqual(TemplateGlob.map("!./views/**/*"), "!./views/**/*");
+  t.deepEqual(TemplateGlob.normalize("!views/**/*"), "!./views/**/*");
+  t.deepEqual(TemplateGlob.normalize("!./views/**/*"), "!./views/**/*");
 });
 
 test("Normalize with globstar and star and file extension", t => {
-  t.deepEqual(TemplateGlob.map("!views/**/*.json"), "!./views/**/*.json");
-  t.deepEqual(TemplateGlob.map("!./views/**/*.json"), "!./views/**/*.json");
+  t.deepEqual(TemplateGlob.normalize("!views/**/*.json"), "!./views/**/*.json");
+  t.deepEqual(
+    TemplateGlob.normalize("!./views/**/*.json"),
+    "!./views/**/*.json"
+  );
 });
 
 test("NormalizePath with globstar and star and file extension", t => {
@@ -67,20 +70,13 @@ test("NormalizePath with globstar and star and file extension (errors)", t => {
   });
 });
 
-test("Normalize array argument", t => {
-  t.deepEqual(TemplateGlob.map(["views", "content"]), ["./views", "./content"]);
-  t.deepEqual(TemplateGlob.map("views/"), "./views");
-  t.deepEqual(TemplateGlob.map("./views"), "./views");
-  t.deepEqual(TemplateGlob.map("./views/"), "./views");
-});
-
 test("matuzo project issue with fastglob assumptions", async t => {
   let dotslashincludes = await fastglob(
-    TemplateGlob.map([
+    [
       "./test/stubs/globby/**/*.html",
       "!./test/stubs/globby/_includes/**/*",
       "!./test/stubs/globby/_data/**/*"
-    ])
+    ].map(globPath => TemplateGlob.normalize(globPath))
   );
 
   t.is(
@@ -91,11 +87,11 @@ test("matuzo project issue with fastglob assumptions", async t => {
   );
 
   let globincludes = await fastglob(
-    TemplateGlob.map([
+    [
       "test/stubs/globby/**/*.html",
       "!./test/stubs/globby/_includes/**/*",
       "!./test/stubs/globby/_data/**/*"
-    ])
+    ].map(globPath => TemplateGlob.normalize(globPath))
   );
   t.is(
     globincludes.filter(function(file) {


### PR DESCRIPTION
This is a maintenance pull request to fix some linter errors and streamline some Eleventy utilities.

- Turns `TemplatePath` utility into a class with static methods to match other utility classes in the Eleventy code.
- Removes the `TemplateGlob.map` utility in favor of calling its underlying methods. There seems to be no need to wrap a `Array.prototype.map` call like it is done currently. Tests for the removed method were removed.
- `Eleventy.setWatchTargets`: Adds a parameter type annotation to `Eleventy.setWatchTargets` to fix linter errors.
- `Eleventy.logFinished`: Adds appropriate casts to explicit number types in mathematical operations to silence linter errors. These conversions do happen upon calling operators like `-` anyway.
- `TemplateMap.checkForDuplicatePermalinks`: A bit of moving around code to make the output generation more readable. Not entirely happy with the result. We can tweak or discard this change.
- `Template.getTemplateMapEntries`: Add missing `_pages` property to the `entries` array to silence linter errors.