### PR TITLE
Scope mapEntry variable to for..of loop in TemplateWriter

### DIFF
--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -171,9 +171,8 @@ class TemplateWriter {
     await this._createTemplateMap(paths);
     debug("Template map created.");
 
-    let mapEntry;
     let usedTemplateContentTooEarlyMap = [];
-    for (mapEntry of this.templateMap.getMap()) {
+    for (let mapEntry of this.templateMap.getMap()) {
       promises.push(
         this._writeTemplate(mapEntry).catch(function(e) {
           // Premature templateContent in layout render, this also happens in
@@ -192,7 +191,7 @@ class TemplateWriter {
       );
     }
 
-    for (mapEntry of usedTemplateContentTooEarlyMap) {
+    for (let mapEntry of usedTemplateContentTooEarlyMap) {
       promises.push(
         this._writeTemplate(mapEntry).catch(function(e) {
           return Promise.reject(


### PR DESCRIPTION
Fixes #722. Previously we wouldn't scope the value of the mapEntry variable to each iteration when looping over the templates to write. This became an issue of any of the generated promises threw an error, since the error message would always report that it stemmed from the template from the last iteration.