### PR TITLE
chore: bump lint-staged to 10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ink-docstrap": "1.3.2",
     "js-yaml": "^3.13.1",
     "jsdoc": "3.6.3",
-    "lint-staged": "^9.5.0",
+    "lint-staged": "^10.0.7",
     "markdown-it-emoji": "^1.4.0",
     "nyc": "^15.0.0",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
   },
   "lint-staged": {
     "*.{js,css,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/okonet/lint-staged/releases

### Breaking changes:

 - Previously, lint-staged would allow empty commits in the situation where a linter task like "prettier --write" reverts all staged changes automatically. Now the default behaviour is to throw an error with a helpful warning message. The --allow empty option can be used to allow empty commits, or allowEmpty: true for the Node.js API.
- Node.js v8 is no longer supported because it will reach EOL on 2019-12-31
- Prior to version 10, tasks had to manually include git add as the final step. This behavior has been integrated into lint-staged itself in order to prevent race conditions with multiple tasks editing the same files. If lint-staged detects git add in task configurations, it will show a warning in the console. Please remove git add from your configuration after upgrading.