### PR TITLE
Correct verb conjugation mistake in comment

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -42,7 +42,7 @@ class Eleventy {
     this.isVerbose = process.env.DEBUG ? false : !this.config.quietMode;
 
     /**
-     * @member {Boolean} - Was verbose mode overrode manually?
+     * @member {Boolean} - Was verbose mode overridden manually?
      * @default false
      */
     this.isVerboseOverride = false;


### PR DESCRIPTION
The past participle of the verb "override" is "overridden", not "overrode".
We say: "foo overrode bar", but "bar was overriden by foo".
https://www.theconjugator.com/english/verb/to+override.html