### PR TITLE
Simplifying getTemplateData from 4 lines to 1

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -100,10 +100,7 @@ class EleventyFiles {
 
   // TODO make this a getter
   getTemplateData() {
-    if (!this.templateData) {
-      this.templateData = new TemplateData(this.inputDir);
-    }
-    return this.templateData;
+    return this.templateData ? this.templateData : new TemplateData(this.inputDir);
   }
 
   getDataDir() {


### PR DESCRIPTION
This one-liner return is more concise and doesn't seem to make the reading more complex.
What do you think?

Another even more concise solution would be: 

`return this.templateData && new TemplateData(this.inputDir);`

But I'm not sure this would be as readable for readers not familiar with how "&&" works under the hood.