### PR TITLE
Inverse boolean logic to avoid empty statement

### DIFF
--- a/src/Engines/Ejs.js
+++ b/src/Engines/Ejs.js
@@ -40,9 +40,8 @@ class Ejs extends TemplateEngine {
 
   async compile(str, inputPath) {
     let options = this.getEjsOptions();
-    if (!inputPath || inputPath === "ejs" || inputPath === "md") {
-      // do nothing
-    } else {
+    
+    if (inputPath && inputPath ==! "ejs" && inputPath ==! "md") {
       options.filename = inputPath;
     }
 

--- a/src/Engines/Ejs.js
+++ b/src/Engines/Ejs.js
@@ -41,7 +41,7 @@ class Ejs extends TemplateEngine {
   async compile(str, inputPath) {
     let options = this.getEjsOptions();
     
-    if (inputPath && inputPath ==! "ejs" && inputPath ==! "md") {
+    if (inputPath && inputPath !== "ejs" && inputPath !== "md") {
       options.filename = inputPath;
     }
 


### PR DESCRIPTION
I'm not sure what's the benefit of having a condition leading to an empty statement ?
You may have a good reason that I have missed though.