### PR TITLE
Remove unused input param in compile function

### DIFF
--- a/src/Engines/Handlebars.js
+++ b/src/Engines/Handlebars.js
@@ -55,7 +55,7 @@ class Handlebars extends TemplateEngine {
     }
   }
 
-  async compile(str, inputPath) {
+  async compile(str) {
     let fn = this.handlebarsLib.compile(str);
     return function(data) {
       return fn(data);


### PR DESCRIPTION
At first glance, we could imagine that keeping the unused parameter was a way to keep the compile function with a coherent signature across various engines, but some engines like Haml don't have the inputPath input parameter.