### PR TITLE
Make code style more coherent on error file

### DIFF
--- a/src/Errors/TemplateContentPrematureUseError.js
+++ b/src/Errors/TemplateContentPrematureUseError.js
@@ -1,4 +1,5 @@
 const EleventyBaseError = require("../EleventyBaseError");
+
 class TemplateContentPrematureUseError extends EleventyBaseError {}
 
 module.exports = TemplateContentPrematureUseError;


### PR DESCRIPTION
In most files in the project, there is a line break between the const declarations on top and the class definition.

So I'm doing the same here to add some consistency.

The contrast is obvious when opening the 2 error files right after the other, as they should have the same layout but don't.