### PR TITLE
Add inputPath to Haml eng. to improve consistency

### DIFF
--- a/src/Engines/Haml.js
+++ b/src/Engines/Haml.js
@@ -14,7 +14,7 @@ class Haml extends TemplateEngine {
     this.setEngineLib(lib);
   }
 
-  async compile(str) {
+  async compile(str, inputPath) {
     return this.hamlLib.compile(str);
   }
 }


### PR DESCRIPTION
In pull request #969, you said:

> Ah yeah, this was an intentional leave—I want to keep it consistent!

So you decided to leave the unused `inputPath` param in the Handlebars engine in order to be consistent.

So following this logic, it would make sense to **add** this same unused `inputPath` param in the Haml engine's compile function, right?

As you can see from the search below, the Haml engine's compile function is the only one missing this input param:

![image](https://user-images.githubusercontent.com/6030745/75688312-9229f480-5c9f-11ea-8c0b-1bcacb9c8ab9.png)

Right?