### PR TITLE
Add getTemplateData caching test

### DIFF
--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -383,6 +383,14 @@ test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore ha
 });
 /* End .eleventyignore and .gitignore combos */
 
+test("getTemplateData caching", t => {
+  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", []);
+  evf.init();
+  let templateDataFirstCall = evf.getTemplateData();
+  let templateDataSecondCall = evf.getTemplateData();
+  t.is(templateDataFirstCall, templateDataSecondCall);
+});
+
 test("getDataDir", t => {
   let evf = new EleventyFiles(".", "_site", []);
   evf.init();


### PR DESCRIPTION
In PR #967, I tried to refactor the `getTemplateData` function in `EleventyFiles.js`  by replacing the `if` and `return` by a ternary operator.

My refactor broke the caching but all the tests passed nonetheless.

On closing the PR, @zachleat said:

> Would be very interested in a PR that adds a test around this!

So here is the PR that adds a test around this.

What it does is simply call the `getTemplateData` function twice in a row and compares the return values.

Since the `getTemplateData` function returns an object, we can compare the object reference by using the `is` test.

I've been successfully able to break my test by removing the caching mechanism. In that case, the test result says:

> Values are deeply equal to each other, but they are not the same

![image](https://user-images.githubusercontent.com/6030745/75788619-cc12fd80-5d68-11ea-937c-749b7ec48d72.png)

Which is what we would expect without caching.