### PR TITLE
Add a cache for getTemplates as asked in TODO

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -425,9 +425,16 @@ class Template extends TemplateContent {
       );
     }
   }
+  
+  setTemplates(templates) {
+    this.templates = templates;
+  }
 
   async getTemplates(data) {
-    // TODO cache this
+    if (this.templates) {
+      return this.templates;
+    }
+    
     let results = [];
 
     if (!Pagination.hasPagination(data)) {
@@ -497,6 +504,7 @@ class Template extends TemplateContent {
       }
     }
 
+    this.setTemplates(results);
     return results;
   }
 


### PR DESCRIPTION
In the `getTemplates` function, @zachleat had a comment saying `// TODO cache this`.

I've implemented my understanding of how the cache should work, if this can be helpful in any way.

If my PR gets accepted, I will add a unit test that tests this caching logic.