### PR TITLE
Move Template.write to TemplateTest, since only used there ("TODO" fix)

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -584,17 +584,6 @@ class Template extends TemplateContent {
     return Promise.all(promises);
   }
 
-  // TODO is this still used by anything but tests?
-  async write(outputPath, data) {
-    let templates = await this.getRenderedTemplates(data);
-    let promises = [];
-    for (let tmpl of templates) {
-      promises.push(this._write(tmpl.outputPath, tmpl.templateContent));
-    }
-
-    return Promise.all(promises);
-  }
-
   // TODO this but better
   clone() {
     let tmpl = new Template(

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -16,6 +16,15 @@ async function getRenderedData(tmpl, pageNumber = 0) {
   return templates[pageNumber].data;
 }
 
+async function write(tmpl, data) {
+  let templates = await tmpl.getRenderedTemplates(data);
+  let promises = [];
+  for (let template of templates) {
+    promises.push(tmpl._write(template.outputPath, template.templateContent));
+  }
+  return Promise.all(promises);
+}
+
 function cleanHtml(str) {
   return pretty(str, { ocd: true });
 }
@@ -1330,7 +1339,7 @@ test("permalink: false", async t => {
   t.is(await tmpl.getOutputHref(), false);
 
   let data = await tmpl.getData();
-  await tmpl.write(false, data);
+  await write(tmpl, data);
 
   // Input file exists (sanity check for paths)
   t.is(fs.existsSync("./test/stubs/permalink-false/"), true);


### PR DESCRIPTION
In `Template.js`, @zachleat asked of the `write` function:

> // TODO is this still used by anything but tests?

The answer is clearly no, so this function belongs to `TemplateTest.js` instead (the same way the local helper function `getRenderedData` does).

So I cut the function from `Template.js` where it was unused and pasted it to `TemplateTest.js`.

I had some adaptations to make regarding the input parameters and the value of `this`, as is often the case when porting a function from a file to another.