### PR TITLE
Improve template clone by using constructor logic ("TODO" fix)

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -19,7 +19,17 @@ const debug = require("debug")("Eleventy:Template");
 const debugDev = require("debug")("Dev:Eleventy:Template");
 
 class Template extends TemplateContent {
-  constructor(path, inputDir, outputDir, templateData) {
+  constructor(
+    path,
+    inputDir,
+    outputDir,
+    templateData,
+    config,
+    transforms = [],
+    linters = [],
+    isVerbose = true,
+    isDryRun = false
+  ) {
     debugDev("new Template(%o)", path);
     super(path, inputDir);
 
@@ -34,8 +44,8 @@ class Template extends TemplateContent {
       this.outputDir = false;
     }
 
-    this.linters = [];
-    this.transforms = [];
+    this.transforms = transforms;
+    this.linters = linters;
     this.plugins = {};
     this.templateData = templateData;
     if (this.templateData) {
@@ -43,14 +53,18 @@ class Template extends TemplateContent {
     }
     this.paginationData = {};
 
-    this.isVerbose = true;
-    this.isDryRun = false;
+    this.setIsVerbose(isVerbose);
+    this.setDryRun(isDryRun);
     this.writeCount = 0;
     this.skippedCount = 0;
     this.wrapWithLayouts = true;
     this.fileSlug = new TemplateFileSlug(this.inputPath, this.inputDir);
     this.fileSlugStr = this.fileSlug.getSlug();
     this.filePathStem = this.fileSlug.getFullPathWithoutExtension();
+
+    if (config) {
+      this.config = config;
+    }
   }
 
   setIsVerbose(isVerbose) {
@@ -595,26 +609,18 @@ class Template extends TemplateContent {
     return Promise.all(promises);
   }
 
-  // TODO this but better
   clone() {
-    let tmpl = new Template(
+    return new Template(
       this.inputPath,
       this.inputDir,
       this.outputDir,
-      this.templateData
+      this.templateData,
+      this.config,
+      this.transforms,
+      this.linters,
+      this.isVerbose,
+      this.isDryRun
     );
-    tmpl.config = this.config;
-
-    for (let transform of this.transforms) {
-      tmpl.addTransform(transform);
-    }
-    for (let linter of this.linters) {
-      tmpl.addLinter(linter);
-    }
-    tmpl.setIsVerbose(this.isVerbose);
-    tmpl.setDryRun(this.isDryRun);
-
-    return tmpl;
   }
 
   getWriteCount() {


### PR DESCRIPTION
Above the `clone()` function in `Template.js`, @zachleat said:

> // TODO this but better

I wasn't exactly sure what was meant by "better", so I tried to implement a way that seems slightly cleaner to me. But since cleanliness in code is subjective, I might have missed what Zach truly meant by "better" :).

Now the `clone()` function simply returns a new Template, using the template to be cloned's values as input parameters. I've then updated the constructor to take into account these new params, while also defaulting them to the value initially set in the constructor before some of them where parameterized.

Before doing this refactor, I tried to go even further by ditching the `clone()` function altogether, and replace all its calls by Lodash's `cloneDeep`, but it messed up plenty of tests by throwing a `TemplateContentPrematureUseError` error. So it seems to me that we don't want a perfect deep clone, but I still haven't figured out why, and in what ways our clone passes the tests but not Lodash's…