### PR TITLE
Use getter for pagedItems in Pagination class ("TODO" fix)

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -63,7 +63,7 @@ class Pagination {
     this.alias = data.pagination.alias;
 
     this.target = this._resolveItems();
-    this.items = this.getPagedItems();
+    this.items = this.pagedItems;
   }
 
   setTemplate(tmpl) {
@@ -134,8 +134,7 @@ class Pagination {
     return result;
   }
 
-  getPagedItems() {
-    // TODO switch to a getter
+  get pagedItems() {
     if (!this.data) {
       throw new Error("Missing `setData` call for Pagination object.");
     }

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -13,7 +13,7 @@ test("No data passed to pagination", async t => {
   let paging = new Pagination();
   paging.setTemplate(tmpl);
 
-  t.is(paging.getPagedItems().length, 0);
+  t.is(paging.pagedItems.length, 0);
   t.is((await paging.getPageTemplates()).length, 0);
 });
 
@@ -30,7 +30,7 @@ test("No pagination", async t => {
 
   t.falsy(data.pagination);
   t.is(paging.getPageCount(), 0);
-  t.is(paging.getPagedItems().length, 0);
+  t.is(paging.pagedItems.length, 0);
   t.is((await paging.getPageTemplates()).length, 0);
 });
 
@@ -66,7 +66,7 @@ test("Resolve paged data in frontmatter", async t => {
   paging.setTemplate(tmpl);
   t.is(paging._resolveItems().length, 8);
   t.is(paging.getPageCount(), 2);
-  t.is(paging.getPagedItems().length, 2);
+  t.is(paging.pagedItems.length, 2);
 });
 
 test("Paginate data in frontmatter", async t => {


### PR DESCRIPTION
Simply to have one less "TODO" in the code that could be fixed by a quick PR :).

The TODO said above the `getPagedItems` function:

> // TODO switch to a getter