### PR TITLE
allow registering Nunjucks globals

### DIFF
--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -36,6 +36,7 @@ class Nunjucks extends TemplateEngine {
       this.config.nunjucksAsyncPairedShortcodes,
       true
     );
+    this.addGlobals(this.config.nunjucksGlobals);
   }
 
   addFilters(helpers, isAsync) {
@@ -61,6 +62,16 @@ class Nunjucks extends TemplateEngine {
     }
 
     this.njkEnv.addExtension(name, tagObj);
+  }
+
+  addGlobals(globals) {
+    for (let name in globals) {
+      this.addGlobal(name, globals[name]);
+    }
+  }
+
+  addGlobal(name, globalFn) {
+    this.njkEnv.addGlobal(name, globalFn);
   }
 
   addAllShortcodes(shortcodes, isAsync = false) {

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -29,6 +29,7 @@ class UserConfig {
     this.nunjucksFilters = {};
     this.nunjucksAsyncFilters = {};
     this.nunjucksTags = {};
+    this.nunjucksGlobals = {};
     this.nunjucksShortcodes = {};
     this.nunjucksAsyncShortcodes = {};
     this.nunjucksPairedShortcodes = {};
@@ -224,6 +225,21 @@ class UserConfig {
     }
 
     this.nunjucksTags[name] = bench.add(`"${name}" Nunjucks Custom Tag`, tagFn);
+  }
+
+  addNunjucksGlobal(name, globalFn) {
+    name = this.getNamespacedName(name);
+
+    if (this.nunjucksGlobals[name]) {
+      debug(
+        chalk.yellow(
+          "Warning, overwriting a Nunjucks global with `addNunjucksGlobal(%o)`"
+        ),
+        name
+      );
+    }
+
+    this.nunjucksGlobals[name] = bench.add(`"${name}" Nunjucks Global`, globalFn);
   }
 
   addTransform(name, callback) {
@@ -649,6 +665,7 @@ class UserConfig {
       nunjucksFilters: this.nunjucksFilters,
       nunjucksAsyncFilters: this.nunjucksAsyncFilters,
       nunjucksTags: this.nunjucksTags,
+      nunjucksGlobals: this.nunjucksGlobals,
       nunjucksAsyncShortcodes: this.nunjucksAsyncShortcodes,
       nunjucksShortcodes: this.nunjucksShortcodes,
       nunjucksAsyncPairedShortcodes: this.nunjucksAsyncPairedShortcodes,

--- a/test/TemplateConfigTest.js
+++ b/test/TemplateConfigTest.js
@@ -57,6 +57,20 @@ test("Add nunjucks tag", t => {
   t.not(Object.keys(cfg.nunjucksTags).indexOf("myNunjucksTag"), -1);
 });
 
+test("Add nunjucks global", t => {
+  eleventyConfig.reset();
+  eleventyConfig.addNunjucksGlobal("myNunjucksGlobal1", function() {});
+  eleventyConfig.addNunjucksGlobal("myNunjucksGlobal2", 42);
+
+  let templateCfg = new TemplateConfig(
+    require("../src/defaultConfig.js"),
+    "./test/stubs/config.js"
+  );
+  let cfg = templateCfg.getConfig();
+  t.not(Object.keys(cfg.nunjucksGlobals).indexOf("myNunjucksGlobal1"), -1);
+  t.not(Object.keys(cfg.nunjucksGlobals).indexOf("myNunjucksGlobal2"), -1);
+});
+
 test("Add liquid filter", t => {
   eleventyConfig.reset();
   eleventyConfig.addLiquidFilter("myFilterName", function(liquidEngine) {


### PR DESCRIPTION
This PR allows registering Nunjucks globals through the eleventy config. The purpose of this is mainly to allow creating global template functions where filters and tags aren’t enough. 

A simple example:


in .eleventy.js
```js
eleventyConfig.addNunjucksGlobal("foobar", (str) => `foo ${str} bar`)
```

usage in a template file:
```nunjucks
{{ foobar("hello world") }}
```

Result:
```nunjucks
foo hello world bar
```
