### PR TITLE
Fix "[object Object]" in TemplatePassthrough debug message

### DIFF
--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -189,7 +189,7 @@ class TemplatePassthroughManager {
     for (let path of passthroughPaths) {
       let normalizedPath = this._normalizePaths(path);
       debug(
-        `TemplatePassthrough copying from non-matching file extension: ${normalizedPath}`
+        `TemplatePassthrough copying from non-matching file extension: ${normalizedPath.inputPath}`
       );
       promises.push(this.copyPath(normalizedPath));
     }


### PR DESCRIPTION
No big thang, just something I noticed when running in debug mode. It's useful to see this path properly.

### Before

<img width="1129" alt="" src="https://user-images.githubusercontent.com/1724000/78413847-27394980-75ce-11ea-80d3-3bb277846011.png">

### After

![image](https://user-images.githubusercontent.com/1724000/78413854-34eecf00-75ce-11ea-802f-454b15c85b63.png)
