### PR TITLE
Prevent build errors from breaking the watcher

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -451,7 +451,13 @@ Arguments:
       this.resetConfig();
     }
 
-    await this.restart();
+    try {
+      await this.restart();
+    } catch (e) {
+      EleventyErrorHandler.error(e, "Eleventy watch error");
+      this.watchManager.setBuildFinished();
+      return;
+    }
 
     this.watchTargets.clearDependencyRequireCache();
 


### PR DESCRIPTION
I think this will close #833, but there are a few concerns I have:

1. I'm not sure if this is the correct way to "abort" this particular run.

    Should I be wrapping this whole call in a try/catch? Should I specifically catch the error that's raised instead? My thinking is that no build error should crash the watcher.

1. I have no idea how to test this. Guidance is welcome!

## In action

<img width="1002" alt="" src="https://user-images.githubusercontent.com/1724000/78458605-86976800-7667-11ea-8ebc-f00dfb440dce.png">

Introducing a syntax error shows the exception, aborts the build, and doesn't livereload, but it also keeps the watcher running. Fixing the error then continues the build as normal.