### PR TITLE
Add error overlay to the core

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "debug": "^4.1.1",
     "dependency-graph": "^0.9.0",
     "ejs": "^2.7.4",
+    "error-stack-parser": "^2.0.6",
     "fast-glob": "^3.2.2",
     "fs-extra": "^8.1.0",
     "gray-matter": "^4.0.2",

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -548,6 +548,14 @@ Arguments:
     benchmark.before();
     await this._initWatchDependencies();
     benchmark.after();
+
+    // Error overlay in development
+    this.config.events.on("beforeWatch", () => {
+      this.eleventyServe.clearError();
+    });
+    EleventyErrorHandler.events.on("errorLogged", error => {
+      this.eleventyServe.showError(error);
+    });
   }
 
   /**

--- a/src/EleventyErrorHandler.js
+++ b/src/EleventyErrorHandler.js
@@ -1,3 +1,4 @@
+const EventEmitter = require("events");
 const chalk = require("chalk");
 const EleventyErrorUtil = require("./EleventyErrorUtil");
 const debug = require("debug")("Eleventy:EleventyErrorHandler");
@@ -27,6 +28,8 @@ class EleventyErrorHandler {
   }
 
   static error(e, msg) {
+    EleventyErrorHandler.events.emit("errorLogged", e);
+
     if (msg) {
       EleventyErrorHandler.initialMessage(msg, "error", "red");
     }
@@ -98,5 +101,7 @@ class EleventyErrorHandler {
     }
   }
 }
+
+EleventyErrorHandler.events = new EventEmitter();
 
 module.exports = EleventyErrorHandler;

--- a/src/EleventyErrorHandler.js
+++ b/src/EleventyErrorHandler.js
@@ -4,6 +4,8 @@ const EleventyErrorUtil = require("./EleventyErrorUtil");
 const debug = require("debug")("Eleventy:EleventyErrorHandler");
 
 class EleventyErrorHandler {
+  static events = new EventEmitter();
+
   static get isChalkEnabled() {
     if (this._isChalkEnabled !== undefined) {
       return this._isChalkEnabled;
@@ -101,7 +103,5 @@ class EleventyErrorHandler {
     }
   }
 }
-
-EleventyErrorHandler.events = new EventEmitter();
 
 module.exports = EleventyErrorHandler;

--- a/src/EleventyErrorHandler.js
+++ b/src/EleventyErrorHandler.js
@@ -4,8 +4,6 @@ const EleventyErrorUtil = require("./EleventyErrorUtil");
 const debug = require("debug")("Eleventy:EleventyErrorHandler");
 
 class EleventyErrorHandler {
-  static events = new EventEmitter();
-
   static get isChalkEnabled() {
     if (this._isChalkEnabled !== undefined) {
       return this._isChalkEnabled;
@@ -103,5 +101,7 @@ class EleventyErrorHandler {
     }
   }
 }
+
+EleventyErrorHandler.events = new EventEmitter();
 
 module.exports = EleventyErrorHandler;

--- a/src/Middleware/ErrorOverlayMiddleware.js
+++ b/src/Middleware/ErrorOverlayMiddleware.js
@@ -1,0 +1,145 @@
+const ErrorStackParser = require("error-stack-parser");
+const debug = require("debug")("Eleventy:ErrorOverlayMiddleware");
+
+/**
+ * A browser-sync middleware that pipes build errors to a browser view regardless of the requested
+ * path.
+ *
+ * @param {() => Error | null} getError a callback evaluated on every request that should return an
+ *  error to be shown (if any). Returning `null` bypasses the middleware.
+ *
+ * @returns {Function} the middleware
+ */
+module.exports = function ErrorOverlayMiddleware(getError) {
+  return function(_req, res, next) {
+    const error = getError();
+
+    if (!error) {
+      next();
+      return;
+    }
+
+    debug("Showing error", error);
+    const stacktrace = ErrorStackParser.parse(error).map(item => ({
+      ...item,
+      fileName: item.fileName
+        .replace(process.cwd(), ".")
+        .replace(process.env.HOME, "~")
+    }));
+
+    res.status = 500;
+    res.setHeader("content-type", "text/html");
+    res.end(
+      template({
+        errorName: error.name,
+        errorMessage: error.message,
+        stacktrace
+      })
+    );
+  };
+};
+
+const template = ({ errorName, errorMessage, stacktrace }) => `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${errorName}: ${errorMessage}</title>
+
+    <style>
+      :root {
+        --foreground: 0, 0, 0;
+        --background: 255, 255, 255;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --foreground: 204, 204, 204;
+          --background: 34, 34, 34;
+        }
+      }
+
+      *,
+      *:before,
+      *:after {
+        box-sizing: border-box;
+        position: relative;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        border-top: 0.5em solid rgb(197, 26, 26);
+        font-family: system-ui;
+        font-size: 18px;
+        background: rgb(var(--background));
+        color: rgb(var(--foreground));
+      }
+
+      main {
+        padding: 4em 2em;
+        max-width: 40em;
+        margin: 0 auto;
+      }
+
+      main > * + * {
+        margin-block-start: 2em;
+      }
+
+      code {
+        font-size: inherit;
+        font-family: source-code-pro, monaco, monospace;
+      }
+
+      .stacktrace {
+        border: 1px solid rgba(var(--foreground), 0.2);
+        background: rgba(var(--foreground), 0.05);
+        border-radius: 2px;
+        list-style: none;
+      }
+
+      .stacktrace > * + * {
+        border-block-start: 1px solid rgba(var(--foreground), 0.2);
+      }
+
+      .stacktrace li {
+        padding: 0.5em;
+        overflow-y: auto;
+      }
+
+      .stacktrace li > * + * {
+        margin-block-start: 0.3em;
+      }
+
+      .stacktrace .source {
+        font-size: 0.8em;
+        color: rgba(var(--foreground), 0.6);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>${errorName}</h1>
+      <p>${errorMessage}</p>
+
+      <ul class="stacktrace">
+        ${stacktrace
+          .map(
+            ({ fileName, functionName, lineNumber }) => `
+          <li>
+            <p>
+              in <code>${functionName}</code>
+            </p>
+            <p class="source">
+              <code>${fileName}:${lineNumber}</code>
+            </p>
+          </li>
+        `
+          )
+          .join("\n")}
+      </ul>
+    </main>
+  </body>
+</html>
+`;

--- a/test/EleventyErrorHandlerTest.js
+++ b/test/EleventyErrorHandlerTest.js
@@ -54,3 +54,14 @@ test("Log a warning, error", t => {
     Error: Test error`;
   t.is(output.join("\n").substr(0, expected.length), expected);
 });
+
+test.cb("Events", t => {
+  const testError = new Error();
+
+  EleventyErrorHandler.events.on("errorLogged", function(error) {
+    t.is(error, testError);
+    t.end();
+  });
+
+  EleventyErrorHandler.error(testError);
+});

--- a/test/EleventyServeTest.js
+++ b/test/EleventyServeTest.js
@@ -20,7 +20,8 @@ test("Get Options", t => {
   };
   es.setOutputDir("_site");
 
-  t.deepEqual(es.getOptions(), {
+  const options = es.getOptions();
+  t.deepEqual(options, {
     ignore: ["node_modules"],
     index: "index.html",
     notify: false,
@@ -29,6 +30,7 @@ test("Get Options", t => {
     server: {
       baseDir: "_site"
     },
+    middleware: options.middleware,
     watch: false
   });
 });
@@ -40,7 +42,8 @@ test("Get Options (with a pathPrefix)", t => {
   };
   es.setOutputDir("_site");
 
-  t.deepEqual(es.getOptions(), {
+  const options = es.getOptions();
+  t.deepEqual(options, {
     ignore: ["node_modules"],
     index: "index.html",
     notify: false,
@@ -52,6 +55,7 @@ test("Get Options (with a pathPrefix)", t => {
         "/web/": "_site"
       }
     },
+    middleware: options.middleware,
     watch: false
   });
 });
@@ -66,7 +70,8 @@ test("Get Options (override in config)", t => {
   };
   es.setOutputDir("_site");
 
-  t.deepEqual(es.getOptions(), {
+  const options = es.getOptions();
+  t.deepEqual(options, {
     ignore: ["node_modules"],
     index: "index.html",
     notify: true,
@@ -75,6 +80,7 @@ test("Get Options (override in config)", t => {
     server: {
       baseDir: "_site"
     },
+    middleware: options.middleware,
     watch: false
   });
 });

--- a/test/ErrorOverlayMiddlewareTest.js
+++ b/test/ErrorOverlayMiddlewareTest.js
@@ -1,0 +1,61 @@
+import test from "ava";
+import ErrorOverlayMiddleware from "../src/Middleware/ErrorOverlayMiddleware";
+
+test("Aborts rendering and shows the error when one exists", t => {
+  const error = new Error("hey it's me");
+
+  const middleware = ErrorOverlayMiddleware(() => error);
+
+  let headers = {};
+  let response = "";
+  let continuedRendering = false;
+
+  const res = {
+    status: 200,
+    setHeader(key, value) {
+      headers[key] = value;
+    },
+    end(body) {
+      response = body;
+    }
+  };
+
+  function next() {
+    continuedRendering = true;
+  }
+
+  middleware(undefined, res, next);
+
+  t.truthy(response.includes("Error"));
+  t.truthy(response.includes("hey it's me"));
+  t.is(headers["content-type"], "text/html");
+  t.is(res.status, 500);
+  t.falsy(continuedRendering);
+});
+
+test("Acts as a no-op when there's no error", t => {
+  const middleware = ErrorOverlayMiddleware(() => null);
+
+  let headers = {};
+  let response = "";
+  let continuedRendering = false;
+
+  const res = {
+    status: 200,
+    setHeader(key, value) {
+      headers[key] = value;
+    },
+    end(body) {
+      response = body;
+    }
+  };
+
+  function next() {
+    continuedRendering = true;
+  }
+
+  middleware(undefined, res, next);
+
+  t.is(response, "");
+  t.truthy(continuedRendering);
+});


### PR DESCRIPTION
Closes #525. Bringing [eleventy-plugin-error-overlay](https://github.com/stevenpetryk/eleventy-plugin-error-overlay) into the core.

The main way I went about implementing this was with the EventEmitter pattern, which is already present in some parts of the code.

- `beginWatch` on the EleventyConfig events clears the error object
- A new event, `errorLogged`, on the ErrorHandler, is used to set the object (this way we have full parity between what's logged and what goes to the browser)

The middleware does something a bit hacky: it's initialized with a getter callback that is expected to return an error or null. This is so that EleventyServe can easily forward error information to it without having to pass something mutable or pass itself. Happy to rework this if it seems warranted.