### PR TITLE
Prevent unhandled errors from breaking watch mode

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -658,8 +658,8 @@ Arguments:
         await new Promise((resolve, reject) => {
           watchDelay = setTimeout(async () => {
             this._watch().then(resolve, reject);
-          });
-        }, this.config.watchThrottleWaitTime);
+          }, this.config.watchThrottleWaitTime);
+        });
       } catch (e) {
         if (e instanceof EleventyBaseError) {
           EleventyErrorHandler.error(e, "Eleventy watch error");


### PR DESCRIPTION
This closes #833 and replaces #1066 as a solution. When I did some digging, I found out that the real problem here is that some errors are never caught by the `watchRun` callback. The `try` / `catch` is unused because the error is thrown inside of a `setTimeout`.

The fact that an exception is thrown means the build never gets marked as finished, causing `_watch` to do nothing:

https://github.com/11ty/eleventy/blob/8ffbb9927ea8482c5a46515f3a2ed25cd8830ad8/src/Eleventy.js#L441-L443

_But_ since the `try` / `catch` also doesn't work, Eleventy doesn't crash. Instead, it remains in this weird limbo state where the watcher continues to run but builds cease.

The fix has two parts:

1. Awaiting the `setTimeout` so that `try/catch` works
2. Making sure that we catch non-fatal errors and mark the build as finished.