### PR TITLE
fix silent crashes in 11ty

### DIFF
--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -153,10 +153,9 @@ class TemplateWriter {
     for (let path of paths) {
       if (this.extensionMap.hasEngine(path)) {
         promises.push(
-          this.templateMap.add(this._createTemplate(path)).then(() => {
-            debug(`${path} added to map.`);
-          })
+          await this.templateMap.add(this._createTemplate(path))
         );
+        debug(`${path} added to map.`);
       }
     }
 


### PR DESCRIPTION
fix silent crashes in 11ty: any failures with fatal consequences for the build process MUST be reported to the user for diagnosis.

Fixes #1081.