### PR TITLE
Showcase silent crash: this demos the type of crash fixed with pullreq #1079

### DIFF
--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -43,9 +43,15 @@ class TemplateLayout extends TemplateContent {
     }
 
     try {
-      throw new Error("arg")
-    } catch (ex) { console.error("Showcase silent crashes inside 11ty: this one will NOT b0rk the run!", ex); /* silently crashes... */}
-    
+      throw new Error("arg");
+    } catch (ex) {
+      console.error(
+        "Showcase silent crashes inside 11ty: this one will NOT b0rk the run!",
+        ex
+      );
+      /* silently crashes... */
+      throw ex; // rethrow should be caught by app-level registered handler...
+    }
 
     return rv;
   }
@@ -54,7 +60,7 @@ class TemplateLayout extends TemplateContent {
     return {
       key: this.dataKeyLayoutPath,
       template: this,
-      frontMatterData: await this.getFrontMatterData()
+      frontMatterData: await this.getFrontMatterData(),
     };
   }
 
@@ -105,7 +111,7 @@ class TemplateLayout extends TemplateContent {
   }
 
   async getLayoutChain() {
-    if(!this.layoutChain) {
+    if (!this.layoutChain) {
       await this.getData();
     }
     return this.layoutChain;

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -30,16 +30,24 @@ class TemplateLayout extends TemplateContent {
 
   static getTemplate(key, inputDir, config) {
     let fullKey = TemplateLayout.resolveFullKey(key, inputDir);
+    let rv;
     if (templateCache.has(fullKey)) {
       debugDev("Found %o in TemplateCache", key);
-      return templateCache.get(fullKey);
+      rv = templateCache.get(fullKey);
+    } else {
+      let tmpl = new TemplateLayout(key, inputDir);
+      tmpl.config = config;
+      templateCache.add(fullKey, tmpl);
+
+      rv = tmpl;
     }
 
-    let tmpl = new TemplateLayout(key, inputDir);
-    tmpl.config = config;
-    templateCache.add(fullKey, tmpl);
+    try {
+      throw new Error("arg")
+    } catch (ex) { console.error("Showcase silent crashes inside 11ty: this one will NOT b0rk the run!", ex); /* silently crashes... */}
+    
 
-    return tmpl;
+    return rv;
   }
 
   async getTemplateLayoutMapEntry() {


### PR DESCRIPTION
This crux is the rethrow (`throw ex;`) in there: such a deliberate exception (or any other failure in this code) should cause the app-level registered exception handler to kick in but no such luck.

The fix is #1079

# WARNING:

do NOT merge this pullreq. It's only there to showcase the issue.
