### PR TITLE
provide JavaScript Layout Templates' `data` and `permalink` class members with some useful info

### DIFF
--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -89,13 +89,13 @@ class JavaScript extends TemplateEngine {
     }
   }
 
-  async getExtraDataFromFile(inputPath) {
+  async getExtraDataFromFile(inputPath, template) {
     let inst = this.getInstanceFromInputPath(inputPath);
     if (inst && "data" in inst) {
       // get extra data from `data` method,
       // either as a function or getter or object literal
       let result = await (typeof inst.data === "function"
-        ? inst.data()
+        ? inst.data(inputPath, this, template)
         : inst.data);
       if (typeof result !== "object") {
         throw new JavaScriptTemplateInvalidDataFormatError(

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -119,7 +119,7 @@ class TemplateEngine {
     return true;
   }
 
-  getExtraDataFromFile(inputPath) {
+  getExtraDataFromFile(inputPath, template) {
     return {};
   }
 

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -135,7 +135,7 @@ class TemplateContent {
       await this.read();
     }
 
-    let extraData = await this.engine.getExtraDataFromFile(this.inputPath);
+    let extraData = await this.engine.getExtraDataFromFile(this.inputPath, this);
     let data = TemplateData.mergeDeep({}, this.frontMatter.data, extraData);
     return TemplateData.cleanupData(data);
   }
@@ -174,7 +174,7 @@ class TemplateContent {
       debugDev("%o getCompiledTemplate function created", this.inputPath);
       return fn;
     } catch (e) {
-      debug(`Having trouble compiling template ${this.inputPath}: %O`, str);
+      debug(`Having trouble compiling template ${this.inputPath}: %O --> %O`, str, e);
       throw new TemplateContentCompileError(
         `Having trouble compiling template ${this.inputPath}`,
         e


### PR DESCRIPTION
Provide JavaScript Layout Templates' `data` and `permalink` class members with some useful info: the inputPath (template), the invoking template instance and the current engine instance. 

## permalink

Relevant documentation which drove this change: https://www.11ty.dev/docs/languages/javascript/#permalink-function -- without the change, the `permalink` member in a `_data/layouts/layout.js` layout template will fail when it's made a function like the documentation says it can. (The magic line there being https://github.com/11ty/eleventy/compare/master...GerHobbelt:custom-permalinks?expand=1#diff-af43fd5417c10edb3b7199d7c847be65R119)

## data

Extra are the extra parameters passed into such a class' `data` member function: template and engine. For that, a few other classes needed to have their APIs changed as well.
(Magic line: https://github.com/11ty/eleventy/compare/master...GerHobbelt:custom-permalinks?expand=1#diff-34fe2185370965f1cbbd2d8e5e0f3e97R98)

---

The meat for making the `permalink` member work as a member function type is in src/Template.js, while the meat for the `data` member function is in src/Engines/JavaScript.js (the `inst.data(...)` call in there).

## Related issues

While working on this I did an issue search (including closed ones) on the 11ty repo in hopes to find someone had encountered the same and tackled it. Alas, not entirely: what I wanted was 11ty to produce URIs which are not exactly "cool" in the perception of 11ty, but which are at least pre/postfixed with a content hash for each page, kinda like 'immutable URIs': every URI has guaranteed never changing content.

After a few iterations I went for the custom dynamic permalink + JavaScript Layout Template approach, defining a site-global template in `_data/layouts/default.11ty.js` along the lines of https://www.11ty.dev/docs/languages/javascript/#optional-data-method (and onwards in that page). The result was a number of failures, including the lack of template (and engine) info in both the `data` and `permalink` members of said `_data/layouts/default.11ty.js`.

> Also there was the surprise mistake of naming the bugger `_data/layout/default.js` and only finding out it MUST be with `.11ty.js` extension (another one where #1079 was needed to help me out).

Anyway, these issues look like they come close/near:

- https://github.com/11ty/eleventy/issues/213
- https://github.com/11ty/eleventy/issues/913 (as that's rather closer to the sort of URI set I was looking for than default 11ty behaviour)
- https://github.com/11ty/eleventy/issues/1076 (not the same as #1081 as far as I understood, but darn close, is my hunch after the fact)

