### PR TITLE
Improve user feedback when 11ty reports 'Unsupported engine'

### DIFF
--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -53,7 +53,7 @@ class TemplateRender {
     this._engineName = this.extensionMap.getKey(engineNameOrPath);
     if (!this._engineName) {
       throw new TemplateRenderUnknownEngineError(
-        `Unknown engine for ${engineNameOrPath}`
+        `Unknown engine for ${engineNameOrPath} (supported extensions: ${Object.keys(this.extensionMap.extensionToKeyMap).join(' ')})`
       );
     }
 


### PR DESCRIPTION
List the supported engine extensions too as part of the error report, when you happen to feed 11ty an unsupported layout template file, e.g. `_data/layout/default.js` (note the lack of `.11ty` in that filename).

As also mentioned in #1081 this one had me thwarted for quite a while until I found out I had missed the **mandatory** `11ty` in `11ty.js` JavaScript Layout Template file naming -- it didn't help then that I hadn't found #1079 yet: once 11ty began to b0rk properly, this patch was the bit that would have sped me along the way a tad faster.
