### PR TITLE
Don't ignore output paths that contain all input (fixes #1129)

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -285,7 +285,10 @@ class EleventyFiles {
       );
     }
 
-    files = files.concat(TemplateGlob.map("!" + this.outputDir + "/**"));
+    // ignore output dir unless that would occlude all input
+    if (!TemplatePath.startsWithSubPath(this.inputDir, this.outputDir)) {
+      files = files.concat(TemplateGlob.map("!" + this.outputDir + "/**"));
+    }
 
     return files;
   }


### PR DESCRIPTION
This fixes Eleventy for configurations that output to the same directory as their input, or to a superdirectory of the input directory (ie. where the templates are kept in a subdirectory of the site).