### PR TITLE
Add `beforeBuild` and `afterBuild` events

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -736,10 +736,13 @@ Arguments:
       EleventyErrorHandler.logger = this.logger;
     }
 
+    this.config.events.emit("beforeBuild");
+
     try {
       let promise = this.writer.write();
 
       ret = await promise;
+      this.config.events.emit("afterBuild");
     } catch (e) {
       EleventyErrorHandler.initialMessage(
         "Problem writing Eleventy templates",


### PR DESCRIPTION
While looking for a way to run code after a build has completed, either from watch or from a normal build, I came across `beforeWatch` code in the codebase. This extends that pattern to output `beforeBuild` and `afterBuild` events, too. Usecase for `afterBuild` is to trigger events only after Eleventy has run, for instance live reloading from a third-party server, or building a search index.

I'm also going to make a corresponding PR 11ty-website to document this functionality and `beforeWatch` (#1042)