### PR TITLE
Allow to configure an object tree for the permalink key

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -182,7 +182,7 @@ class Pagination {
       let cloned = tmpl.clone();
 
       // TODO maybe also move this permalink additions up into the pagination class
-      if (pageNumber > 0 && !this.data[this.config.keys.permalink]) {
+      if (pageNumber > 0 && !lodashGet(this.data, this.config.keys.permalink)) {
         cloned.setExtraOutputSubdirectory(pageNumber);
       }
 

--- a/src/Template.js
+++ b/src/Template.js
@@ -2,6 +2,7 @@ const fs = require("fs-extra");
 const parsePath = require("parse-filepath");
 const normalize = require("normalize-path");
 const lodashIsObject = require("lodash/isObject");
+const lodashGet = require("lodash/get");
 const { DateTime } = require("luxon");
 
 const TemplateData = require("./TemplateData");
@@ -119,7 +120,7 @@ class Template extends TemplateContent {
       data = await this.getData();
     }
 
-    let permalink = data[this.config.keys.permalink];
+    let permalink = lodashGet(data, this.config.keys.permalink);
     if (permalink) {
       // render variables inside permalink front matter, bypass markdown
       let permalinkValue;


### PR DESCRIPTION
This permits to put the permalink key outside of data root instead
to search the key only as a field at the root of the data object.

The use case, for me, is that I want to override the permalink value globally.