### PR TITLE
chore: update minimum Node.js LTS version to v10 rather than the EOL v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
+  - 14
 before_script:
   - npm install
 script: npm run test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "src/Eleventy.js",
   "license": "MIT",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
Currently, the minimum supported version is Node.js v8. Node.js v8 went EOL on December 31, 2019.

This PR updates both `engines` to check for at least Node.js 10 and the CI to only test on 10 and 12 (14 should be added at some point, since it'll be going LTS in ~October).

It seems that the docs may need to be updated, too.

I searched open PRs and couldn't find anything. Feel free to close this if it's unwelcome 🙇🏻‍♂️