### PR TITLE
Pagination: pass metadata to before callback

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -120,7 +120,7 @@ class Pagination {
       typeof this.data.pagination.before === "function"
     ) {
       // we don’t need to make a copy of this because we already .filter() above
-      result = this.data.pagination.before(result);
+      result = this.data.pagination.before(result, this.data);
     }
 
     if (this.data.pagination.reverse === true) {

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -606,6 +606,18 @@ test("Pagination `before` Callback", async t => {
   t.deepEqual(templates[0].data.myalias, "item6");
 });
 
+test("Pagination `before` Callback with metadata", async t => {
+  let tmpl = new Template(
+    "./test/stubs/paged/paged-before-metadata.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let templates = await tmpl.getTemplates(data);
+  t.deepEqual(templates[0].data.pagination.items, ["item3"]);
+});
+
 test("Pagination `before` Callback with a Filter", async t => {
   let tmpl = new Template(
     "./test/stubs/paged/paged-before-filter.njk",

--- a/test/stubs/paged/paged-before-metadata.njk
+++ b/test/stubs/paged/paged-before-metadata.njk
@@ -1,0 +1,14 @@
+---js
+{
+  keyword: "item3",
+  pagination: {
+    data: "items",
+    size: 1,
+    before: function(data, metadata) {
+      return data.filter(el => el === metadata.keyword);
+    }
+  },
+  items: ["item1", "item2", "item3", "item4", "item5", "item6"]
+}
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>


### PR DESCRIPTION
This PR adds a second argument for passing page data in the paginations' `before` callback.

This is useful (especially when leveraging the Data Cascade, where a piece of metadata might be elsewhere in the cascade) when you want to process (filter or modify) based on a value in the frontmatter:
```js
---js
{
  keyword: "item3",
  pagination: {
    data: "items",
    size: 1,
    before: function(data, metadata) {
      return data.filter(el => el === metadata.keyword);
    }
  },
  items: ["item1", "item2", "item3", "item4", "item5", "item6"]
}
---
{{ pagination.items[0] }} <- item3

```