### PR TITLE
Add configuration to support serve middlewares.

### DIFF
--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -59,6 +59,7 @@ class UserConfig {
     this.browserSyncConfig = {};
     this.chokidarConfig = {};
     this.watchThrottleWaitTime = 0; //ms
+    this.middlewares = [];
 
     // using Map to preserve insertion order
     this.dataExtensions = new Map();
@@ -640,6 +641,14 @@ class UserConfig {
     this.dataExtensions.set(formatExtension, formatParser);
   }
 
+  addAsyncMiddleware(callback) {
+    this.middlewares.push({ callback, isAsync: true });
+  }
+
+  addMiddleware(callback, isAsync = false) {
+    this.middlewares.push({ callback, isAsync });
+  }
+
   getMergingConfigObject() {
     return {
       templateFormats: this.templateFormats,
@@ -680,7 +689,8 @@ class UserConfig {
       dataExtensions: this.dataExtensions,
       extensionMap: this.extensionMap,
       quietMode: this.quietMode,
-      events: this.events
+      events: this.events,
+      middlewares: this.middlewares
     };
   }
 }

--- a/test/EleventyConfigTest.js
+++ b/test/EleventyConfigTest.js
@@ -3,8 +3,8 @@ import eleventyConfig from "../src/EleventyConfig";
 
 // more in TemplateConfigTest.js
 
-test.cb("Events", t => {
-  eleventyConfig.on("testEvent", function(arg1, arg2, arg3) {
+test.cb("Events", (t) => {
+  eleventyConfig.on("testEvent", function (arg1, arg2, arg3) {
     t.is(arg1, "arg1");
     t.is(arg2, "arg2");
     t.is(arg3, "arg3");
@@ -14,30 +14,30 @@ test.cb("Events", t => {
   eleventyConfig.emit("testEvent", "arg1", "arg2", "arg3");
 });
 
-test("Add Collections", t => {
-  eleventyConfig.addCollection("myCollection", function(collection) {});
+test("Add Collections", (t) => {
+  eleventyConfig.addCollection("myCollection", function (collection) {});
   t.deepEqual(Object.keys(eleventyConfig.getCollections()), ["myCollection"]);
 });
 
-test("Add Collections throws error on key collision", t => {
-  eleventyConfig.addCollection("myCollectionCollision", function(
+test("Add Collections throws error on key collision", (t) => {
+  eleventyConfig.addCollection("myCollectionCollision", function (
     collection
   ) {});
 
   t.throws(() => {
-    eleventyConfig.addCollection("myCollectionCollision", function(
+    eleventyConfig.addCollection("myCollectionCollision", function (
       collection
     ) {});
   });
 });
 
-test("Set manual Pass-through File Copy (single call)", t => {
+test("Set manual Pass-through File Copy (single call)", (t) => {
   eleventyConfig.addPassthroughCopy("img");
 
   t.is(eleventyConfig.passthroughCopies["img"], true);
 });
 
-test("Set manual Pass-through File Copy (chained calls)", t => {
+test("Set manual Pass-through File Copy (chained calls)", (t) => {
   eleventyConfig
     .addPassthroughCopy("css")
     .addPassthroughCopy("js")
@@ -50,10 +50,10 @@ test("Set manual Pass-through File Copy (chained calls)", t => {
   t.is(eleventyConfig.passthroughCopies["./src/empty"], "./");
 });
 
-test("Set manual Pass-through File Copy (glob patterns)", t => {
+test("Set manual Pass-through File Copy (glob patterns)", (t) => {
   eleventyConfig.addPassthroughCopy({
     "./src/static/**/*": "renamed",
-    "./src/markdown/*.md": ""
+    "./src/markdown/*.md": "",
   });
 
   // does not exist
@@ -65,27 +65,50 @@ test("Set manual Pass-through File Copy (glob patterns)", t => {
   t.is(eleventyConfig.passthroughCopies["./src/markdown/*.md"], "");
 });
 
-test("Set Template Formats (string)", t => {
+test("Set Template Formats (string)", (t) => {
   eleventyConfig.setTemplateFormats("ejs, njk, liquid");
   t.deepEqual(eleventyConfig.templateFormats, ["ejs", "njk", "liquid"]);
 });
 
-test("Set Template Formats (array)", t => {
+test("Set Template Formats (array)", (t) => {
   eleventyConfig.setTemplateFormats(["ejs", "njk", "liquid"]);
   t.deepEqual(eleventyConfig.templateFormats, ["ejs", "njk", "liquid"]);
 });
 
-test("Set Template Formats (js passthrough copy)", t => {
+test("Set Template Formats (js passthrough copy)", (t) => {
   eleventyConfig.setTemplateFormats("ejs, njk, liquid, js");
   t.deepEqual(eleventyConfig.templateFormats, ["ejs", "njk", "liquid", "js"]);
 });
 
-test("Set Template Formats (11ty.js)", t => {
+test("Set Template Formats (11ty.js)", (t) => {
   eleventyConfig.setTemplateFormats("ejs, njk, liquid, 11ty.js");
   t.deepEqual(eleventyConfig.templateFormats, [
     "ejs",
     "njk",
     "liquid",
-    "11ty.js"
+    "11ty.js",
   ]);
+});
+
+test("Add sync middleware", (t) => {
+  cb = (config) => {};
+
+  eleventyConfig.addMiddleware(cb);
+  const { callback, isAsync } = eleventyConfig.middlewares[0];
+  t.assertEqual(cb, callback);
+  t.is(isAsync, false);
+});
+
+test("Add async middleware", (t) => {
+  cb = async (config) => {};
+
+  eleventyConfig.addAsyncMiddleware(cb);
+  const { callback, isAsync } = eleventyConfig.middlewares[0];
+  t.assertEqual(cb, callback);
+  t.is(isAsync, true);
+
+  eleventyConfig.addMiddleware(cb, true);
+  const { callback2, isAsync2 } = eleventyConfig.middlewares[1];
+  t.assertEqual(cb, callback2);
+  t.is(isAsync2, true);
 });


### PR DESCRIPTION
This allows people to configure server middlewares for serving different content besides static assets. The middlewares are expected to be compatible with http-proxy-middleware, that's fully supported by browserSync.

@zachleat I'm not super familiar with the codebase, and some logic might be better handled in a different way, so please feel free to make suggestions.

I can add docs with examples on how to use this, but I was not sure what the best place was.

Signed-off-by: David Calavera <david.calavera@gmail.com>