### PR TITLE
fix: pass inputPath to transforms

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -606,7 +606,11 @@ class Template extends TemplateContent {
     }
 
     await this.runLinters(content, page.inputPath, page.outputPath);
-    content = await this.runTransforms(content, page.outputPath); // pass in page.inputPath?
+    content = await this.runTransforms(
+      content,
+      page.outputPath,
+      page.inputPath
+    );
     return content;
   }
 


### PR DESCRIPTION
closes #789 

Could we merge and release this? 🙏

once a breaking change happens the params could be switched to align with "linting" and or imho even better making all "options" an object.