### PR TITLE
Add config option to setEleventyIgnoreFile

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -271,11 +271,11 @@ class EleventyFiles {
 
     if (this.config.eleventyignoreOverride !== false) {
       let eleventyIgnores = [
-        TemplatePath.join(rootDirectory, ".eleventyignore")
+        TemplatePath.join(rootDirectory, this.config.eleventyIgnoreFile)
       ];
       if (rootDirectory !== absoluteInputDir) {
         eleventyIgnores.push(
-          TemplatePath.join(this.inputDir, ".eleventyignore")
+          TemplatePath.join(this.inputDir, this.config.eleventyIgnoreFile)
         );
       }
 

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -384,6 +384,10 @@ class UserConfig {
     this.useGitIgnore = !!enabled;
   }
 
+  setEleventyIgnoreFile(file) {
+    this.eleventyIgnoreFile = file;
+  }
+
   addShortcode(name, callback) {
     debug("Adding universal shortcode %o", this.getNamespacedName(name));
     this.addNunjucksShortcode(name, callback);
@@ -680,6 +684,7 @@ class UserConfig {
       libraryOverrides: this.libraryOverrides,
       dynamicPermalinks: this.dynamicPermalinks,
       useGitIgnore: this.useGitIgnore,
+      eleventyIgnoreFile: this.eleventyIgnoreFile,
       dataDeepMerge: this.dataDeepMerge,
       watchJavaScriptDependencies: this.watchJavaScriptDependencies,
       additionalWatchTargets: this.additionalWatchTargets,

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -38,6 +38,7 @@ module.exports = function (config) {
     passthroughFileCopy: true,
     htmlOutputSuffix: "-o",
     jsDataFileSuffix: ".11tydata",
+    eleventyIgnoreFile: ".eleventyignore",
     keys: {
       package: "pkg",
       layout: "layout",


### PR DESCRIPTION
Eleventy Config option to define what `.eleventyignore` file users would like to use. The reference to the `.eleventyignore` file is currently hardcoded, adding this options makes it slightly more flexible while maintaining the default with zero-config.  

This will allow people to define what files Eleventy ignores based on environments it's running in. [See initial Twitter discussion here for a bit of background](https://twitter.com/scottishstoater/status/1302914523788173312).

## Example use case

A project has a folder with 10,000 markdown articles that all share a single template. The developer would like to speed up development by defining a development set of 10-20 markdown articles that represents the larger folder on a smaller scale. 

## Problem 

At present there is no way to tell Eleventy to ignore files based on the environment it's running. 

## Solution 

Allow developers to define a custom ignore file within the EleventyConfig.

## Example Solution

_.dev.eleventyignore_
```
src/_articles/
```

_.eleventyignore_
```
src/_example_articles/
```

_.eleventy.js_
```js
const isProduction = process.env.ELEVENTY_ENV === 'production';

module.exports = function (eleventyConfig) {
    ...

    if(!isProduction) {
        eleventyConfig.setEleventyIgnoreFile(".dev.eleventyignore");
    }

    ...
};
```