### PR TITLE
Make config run async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ api-docs/
 _site/
 
 package-lock.json
+yarn.lock

--- a/cmd.js
+++ b/cmd.js
@@ -2,11 +2,11 @@
 const pkg = require("./package.json");
 const chalk = require("chalk"); // node 8+
 require("please-upgrade-node")(pkg, {
-  message: function(requiredVersion) {
+  message: function (requiredVersion) {
     return chalk.red(
       `Eleventy requires Node ${requiredVersion}. You’ll need to upgrade to use it!`
     );
-  }
+  },
 });
 
 if (process.env.DEBUG) {
@@ -19,8 +19,8 @@ try {
   const argv = require("minimist")(process.argv.slice(2), {
     boolean: ["quiet"],
     default: {
-      quiet: null
-    }
+      quiet: null,
+    },
   });
   const Eleventy = require("./src/Eleventy");
   const EleventyCommandCheck = require("./src/EleventyCommandCheck");
@@ -31,10 +31,10 @@ try {
       `Unhandled rejection in promise (${promise})`
     );
   });
-  process.on("uncaughtException", error => {
+  process.on("uncaughtException", (error) => {
     EleventyErrorHandler.fatal(error, "Uncaught exception");
   });
-  process.on("rejectionHandled", promise => {
+  process.on("rejectionHandled", (promise) => {
     EleventyErrorHandler.warn(
       promise,
       "A promise rejection was handled asynchronously"
@@ -46,29 +46,33 @@ try {
   cmdCheck.hasUnknownArguments();
 
   let elev = new Eleventy(argv.input, argv.output);
-  elev.setConfigPathOverride(argv.config);
-  elev.setPathPrefix(argv.pathprefix);
-  elev.setDryRun(argv.dryrun);
-  elev.setIncrementalBuild(argv.incremental);
-  elev.setPassthroughAll(argv.passthroughall);
-  elev.setFormats(argv.formats);
-
-  // --quiet and --quiet=true resolves to true
-  if (argv.quiet === true || argv.quiet === false) {
-    elev.setIsVerbose(!argv.quiet);
-  }
 
   // careful, we can’t use async/await here to error properly
   // with old node versions in `please-upgrade-node` above.
   elev
     .init()
-    .then(function() {
+    .then(async function () {
+      // Async config is going to require everything inside init()
+      if (argv.config) {
+        await elev.setConfigPathOverride(argv.config);
+      }
+      elev.setPathPrefix(argv.pathprefix);
+      elev.setDryRun(argv.dryrun);
+      elev.setIncrementalBuild(argv.incremental);
+      elev.setPassthroughAll(argv.passthroughall);
+      elev.setFormats(argv.formats);
+
+      // --quiet and --quiet=true resolves to true
+      if (argv.quiet === true || argv.quiet === false) {
+        elev.setIsVerbose(!argv.quiet);
+      }
+
       if (argv.version) {
         console.log(elev.getVersion());
       } else if (argv.help) {
         console.log(elev.getHelp());
       } else if (argv.serve) {
-        elev.watch().then(function() {
+        elev.watch().then(function () {
           elev.serve(argv.port);
         });
       } else if (argv.watch) {

--- a/cmd.js
+++ b/cmd.js
@@ -47,25 +47,26 @@ try {
 
   let elev = new Eleventy(argv.input, argv.output);
 
+  elev.setPathPrefix(argv.pathprefix);
+  elev.setDryRun(argv.dryrun);
+  elev.setIncrementalBuild(argv.incremental);
+  elev.setPassthroughAll(argv.passthroughall);
+  elev.setFormats(argv.formats);
+  if (argv.config) {
+    await elev.setConfigPathOverride(argv.config);
+  }
+
+  // --quiet and --quiet=true resolves to true
+  if (argv.quiet === true || argv.quiet === false) {
+    elev.setIsVerbose(!argv.quiet);
+  }
+
   // careful, we can’t use async/await here to error properly
   // with old node versions in `please-upgrade-node` above.
   elev
     .init()
     .then(async function () {
       // Async config is going to require everything inside init()
-      if (argv.config) {
-        await elev.setConfigPathOverride(argv.config);
-      }
-      elev.setPathPrefix(argv.pathprefix);
-      elev.setDryRun(argv.dryrun);
-      elev.setIncrementalBuild(argv.incremental);
-      elev.setPassthroughAll(argv.passthroughall);
-      elev.setFormats(argv.formats);
-
-      // --quiet and --quiet=true resolves to true
-      if (argv.quiet === true || argv.quiet === false) {
-        elev.setIsVerbose(!argv.quiet);
-      }
 
       if (argv.version) {
         console.log(elev.getVersion());

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -279,11 +279,11 @@ class Eleventy {
    * @returns {} - tbd.
    */
   async init() {
-    await config.init();
-
-    /** @member {Object} - tbd. */
+    if (!this.config) {
+      await config.init();
+      /** @member {Object} - tbd. */
+    }
     this.config = config.getConfig();
-
     /**
      * @member {Boolean} - Is Eleventy running in verbose mode?
      * @default true

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -281,8 +281,8 @@ class Eleventy {
   async init() {
     if (!this.config) {
       await config.init();
-      /** @member {Object} - tbd. */
     }
+    /** @member {Object} - tbd. */
     this.config = config.getConfig();
     /**
      * @member {Boolean} - Is Eleventy running in verbose mode?

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -74,6 +74,15 @@ class Eleventy {
 
     /** @member {String} - Holds the path to the output directory. */
     this.rawOutput = output;
+
+    /** @member {Object} - tbd. */
+    this.watchManager = new EleventyWatch();
+
+    /** @member {Object} - tbd. */
+    this.watchTargets = new EleventyWatchTargets();
+
+    /** @member {Object} - tbd. */
+    this.eleventyServe = new EleventyServe();
   }
 
   getNewTimestamp() {
@@ -281,16 +290,11 @@ class Eleventy {
      */
     this.isVerbose = process.env.DEBUG ? false : !this.config.quietMode;
 
-    /** @member {Object} - tbd. */
-    this.watchManager = new EleventyWatch();
-
-    /** @member {Object} - tbd. */
-    this.watchTargets = new EleventyWatchTargets();
     this.watchTargets.addAndMakeGlob(this.config.additionalWatchTargets);
     this.watchTargets.watchJavaScriptDependencies = this.config.watchJavaScriptDependencies;
 
     /** @member {Object} - tbd. */
-    this.eleventyServe = new EleventyServe(config);
+    this.eleventyServe.config = config;
 
     this.config.inputDir = this.inputDir;
 

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -2,9 +2,10 @@ const TemplateEngineManager = require("./TemplateEngineManager");
 const TemplatePath = require("./TemplatePath");
 
 class EleventyExtensionMap {
-  constructor(formatKeys) {
+  constructor(formatKeys, templateConfig) {
     this.formatKeys = formatKeys;
-
+    this.config = templateConfig.getConfig();
+    this.templateConfig = templateConfig;
     this.setFormats(formatKeys);
   }
 
@@ -23,7 +24,7 @@ class EleventyExtensionMap {
   }
 
   get config() {
-    return this.configOverride || require("./Config").getConfig();
+    return this.configOverride || this.config;
   }
   set config(cfg) {
     this.configOverride = cfg;
@@ -31,7 +32,7 @@ class EleventyExtensionMap {
 
   get engineManager() {
     if (!this._engineManager) {
-      this._engineManager = new TemplateEngineManager();
+      this._engineManager = new TemplateEngineManager(this.templateConfig);
       this._engineManager.config = this.config;
     }
 

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -6,15 +6,14 @@ const TemplateData = require("./TemplateData");
 const TemplateGlob = require("./TemplateGlob");
 const TemplatePath = require("./TemplatePath");
 const TemplatePassthroughManager = require("./TemplatePassthroughManager");
-
-const config = require("./Config");
 const debug = require("debug")("Eleventy:EleventyFiles");
 // const debugDev = require("debug")("Dev:Eleventy:EleventyFiles");
 const aggregateBench = require("./BenchmarkManager").get("Aggregate");
 
 class EleventyFiles {
-  constructor(input, outputDir, formats, passthroughAll) {
-    this.config = config.getConfig();
+  constructor(input, outputDir, formats, passthroughAll, templateConfig) {
+    this.config = templateConfig.getConfig();
+    this.templateConfig = templateConfig;
     this.input = input;
     this.inputDir = TemplatePath.getDir(this.input);
     this.outputDir = outputDir;
@@ -100,7 +99,10 @@ class EleventyFiles {
   get extensionMap() {
     // for tests
     if (!this._extensionMap) {
-      this._extensionMap = new EleventyExtensionMap(this.formats);
+      this._extensionMap = new EleventyExtensionMap(
+        this.formats,
+        this.templateConfig
+      );
       this._extensionMap.config = this.config;
     }
     return this._extensionMap;
@@ -111,7 +113,7 @@ class EleventyFiles {
   }
 
   initPassthroughManager() {
-    let mgr = new TemplatePassthroughManager();
+    let mgr = new TemplatePassthroughManager(this.templateConfig);
     mgr.setInputDir(this.inputDir);
     mgr.setOutputDir(this.outputDir);
     mgr.extensionMap = this.extensionMap;
@@ -134,7 +136,7 @@ class EleventyFiles {
   // TODO make this a getter
   getTemplateData() {
     if (!this.templateData) {
-      this.templateData = new TemplateData(this.inputDir);
+      this.templateData = new TemplateData(this.inputDir, this.templateConfig);
     }
     return this.templateData;
   }

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -1,14 +1,15 @@
 const fs = require("fs-extra");
 
 const TemplatePath = require("./TemplatePath");
-const config = require("./Config");
 const debug = require("debug")("EleventyServe");
 
 class EleventyServe {
-  constructor() {}
+  constructor(templateConfig) {
+    this.config = templateConfig.getConfig();
+  }
 
   get config() {
-    return this.configOverride || config.getConfig();
+    return this.configOverride || this.config;
   }
   set config(config) {
     this.configOverride = config;
@@ -41,7 +42,7 @@ class EleventyServe {
 
     // TODO customize this in Configuration API?
     let serverConfig = {
-      baseDir: this.outputDir
+      baseDir: this.outputDir,
     };
 
     let redirectDirName = this.getRedirectDirOverride();
@@ -68,7 +69,7 @@ class EleventyServe {
         watch: false,
         open: false,
         notify: false,
-        index: "index.html"
+        index: "index.html",
       },
       this.config.browserSyncConfig
     );
@@ -78,7 +79,7 @@ class EleventyServe {
     if (dirName && dirName !== "/") {
       let savedPathFilename = this.getRedirectFilename(dirName);
 
-      setTimeout(function() {
+      setTimeout(function () {
         if (!fs.existsSync(savedPathFilename)) {
           debug(`Cleanup redirect: Could not find ${savedPathFilename}`);
           return;
@@ -94,7 +95,7 @@ class EleventyServe {
           return;
         }
 
-        fs.unlink(savedPathFilename, err => {
+        fs.unlink(savedPathFilename, (err) => {
           if (!err) {
             debug(`Cleanup redirect: Deleted ${savedPathFilename}`);
           }

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -4,13 +4,12 @@ const TemplatePath = require("./TemplatePath");
 const debug = require("debug")("EleventyServe");
 
 class EleventyServe {
-  constructor(templateConfig) {
-    this.config = templateConfig.getConfig();
-  }
+  constructor() {}
 
   get config() {
     return this.configOverride || this.config;
   }
+
   set config(config) {
     this.configOverride = config;
   }
@@ -118,6 +117,8 @@ class EleventyServe {
     // only load on serve—this is pretty expensive
     const browserSync = require("browser-sync");
     this.server = browserSync.create();
+
+    console.log("server created");
 
     let pathPrefix = this.getPathPrefix();
 

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -118,8 +118,6 @@ class EleventyServe {
     const browserSync = require("browser-sync");
     this.server = browserSync.create();
 
-    console.log("server created");
-
     let pathPrefix = this.getPathPrefix();
 
     if (this.savedPathPrefix && pathPrefix !== this.savedPathPrefix) {

--- a/src/Engines/Custom.js
+++ b/src/Engines/Custom.js
@@ -2,8 +2,8 @@ const TemplateEngine = require("./TemplateEngine");
 const getJavaScriptData = require("../Util/GetJavaScriptData");
 
 class CustomEngine extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, eleventyConfig) {
+    super(name, includesDir, eleventyConfig);
 
     this.entry = this.getExtensionMapEntry();
     this.needsInit =

--- a/src/Engines/Ejs.js
+++ b/src/Engines/Ejs.js
@@ -2,8 +2,8 @@ const ejsLib = require("ejs");
 const TemplateEngine = require("./TemplateEngine");
 
 class Ejs extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.ejsOptions = {};
 
@@ -31,7 +31,7 @@ class Ejs extends TemplateEngine {
       {
         root: "./" + includesDir,
         compileDebug: true,
-        filename: "./" + includesDir
+        filename: "./" + includesDir,
       },
       this.ejsOptions || {}
     );
@@ -46,7 +46,7 @@ class Ejs extends TemplateEngine {
 
     let fn = this.ejsLib.compile(str, options);
 
-    return function(data) {
+    return function (data) {
       return fn(data);
     };
   }

--- a/src/Engines/Haml.js
+++ b/src/Engines/Haml.js
@@ -2,8 +2,8 @@ const HamlLib = require("hamljs");
 const TemplateEngine = require("./TemplateEngine");
 
 class Haml extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.setLibrary(this.config.libraryOverrides.haml);
   }

--- a/src/Engines/Handlebars.js
+++ b/src/Engines/Handlebars.js
@@ -2,8 +2,8 @@ const HandlebarsLib = require("handlebars");
 const TemplateEngine = require("./TemplateEngine");
 
 class Handlebars extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.setLibrary(this.config.libraryOverrides.hbs);
   }

--- a/src/Engines/Html.js
+++ b/src/Engines/Html.js
@@ -1,8 +1,8 @@
 const TemplateEngine = require("./TemplateEngine");
 
 class Html extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
     this.cacheable = true;
   }
 

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -7,8 +7,8 @@ const getJavaScriptData = require("../Util/GetJavaScriptData");
 class JavaScriptTemplateNotDefined extends EleventyBaseError {}
 
 class JavaScript extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
     this.instances = {};
   }
 

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -5,8 +5,8 @@ const TemplatePath = require("../TemplatePath");
 // const debug = require("debug")("Eleventy:Liquid");
 
 class Liquid extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.liquidOptions = {};
 

--- a/src/Engines/Markdown.js
+++ b/src/Engines/Markdown.js
@@ -3,8 +3,8 @@ const TemplateEngine = require("./TemplateEngine");
 // const debug = require("debug")("Eleventy:Markdown");
 
 class Markdown extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.markdownOptions = {};
 
@@ -20,7 +20,7 @@ class Markdown extends TemplateEngine {
     // This is separate so devs can pass in a new mdLib and still use the official eleventy plugin for markdown highlighting
     if (this.config.markdownHighlighter) {
       this.mdLib.set({
-        highlight: this.config.markdownHighlighter
+        highlight: this.config.markdownHighlighter,
       });
     }
 
@@ -39,7 +39,7 @@ class Markdown extends TemplateEngine {
 
     return Object.assign(
       {
-        html: true
+        html: true,
       },
       this.markdownOptions || {}
     );
@@ -65,11 +65,11 @@ class Markdown extends TemplateEngine {
       fn = await engine.compile(str, inputPath);
 
       if (bypassMarkdown) {
-        return async function(data) {
+        return async function (data) {
           return fn(data);
         };
       } else {
-        return async function(data) {
+        return async function (data) {
           let preTemplateEngineRender = await fn(data);
           let finishedRender = mdlib.render(preTemplateEngineRender, data);
           return finishedRender;
@@ -77,11 +77,11 @@ class Markdown extends TemplateEngine {
       }
     } else {
       if (bypassMarkdown) {
-        return function() {
+        return function () {
           return str;
         };
       } else {
-        return function(data) {
+        return function (data) {
           return mdlib.render(str, data);
         };
       }

--- a/src/Engines/Mustache.js
+++ b/src/Engines/Mustache.js
@@ -2,8 +2,8 @@ const MustacheLib = require("mustache");
 const TemplateEngine = require("./TemplateEngine");
 
 class Mustache extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.setLibrary(this.config.libraryOverrides.mustache);
   }

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -7,8 +7,8 @@ const EleventyBaseError = require("../EleventyBaseError");
 class EleventyShortcodeError extends EleventyBaseError {}
 
 class Nunjucks extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.setLibrary(this.config.libraryOverrides.njk);
 

--- a/src/Engines/Pug.js
+++ b/src/Engines/Pug.js
@@ -2,8 +2,8 @@ const PugLib = require("pug");
 const TemplateEngine = require("./TemplateEngine");
 
 class Pug extends TemplateEngine {
-  constructor(name, includesDir) {
-    super(name, includesDir);
+  constructor(name, includesDir, templateConfig) {
+    super(name, includesDir, templateConfig);
 
     this.pugOptions = {};
 

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -6,19 +6,18 @@ const debug = require("debug")("Eleventy:TemplateEngine");
 const aggregateBench = require("../BenchmarkManager").get("Aggregate");
 
 class TemplateEngine {
-  constructor(name, includesDir) {
+  constructor(name, includesDir, templateConfig) {
     this.name = name;
     this.includesDir = includesDir;
     this.partialsHaveBeenCached = false;
     this.partials = [];
     this.engineLib = null;
     this.cacheable = false;
+    this.templateConfig = templateConfig;
+    this._config = templateConfig.getConfig();
   }
 
   get config() {
-    if (!this._config) {
-      this._config = require("../Config").getConfig();
-    }
     return this._config;
   }
 
@@ -36,8 +35,8 @@ class TemplateEngine {
 
   get extensionMap() {
     if (!this._extensionMap) {
-      this._extensionMap = new EleventyExtensionMap();
-      // this._extensionMap.config = this.config;
+      this._extensionMap = new EleventyExtensionMap([], this.templateConfig);
+      this._extensionMap.config = this._config;
     }
     return this._extensionMap;
   }

--- a/src/Filters/Url.js
+++ b/src/Filters/Url.js
@@ -1,7 +1,7 @@
 const validUrl = require("valid-url");
 const TemplatePath = require("../TemplatePath");
 
-module.exports = function(url, pathPrefix) {
+module.exports = (eleventyConfig) => (url, pathPrefix) => {
   // work with undefined
   url = url || "";
 
@@ -14,7 +14,7 @@ module.exports = function(url, pathPrefix) {
   }
 
   if (pathPrefix === undefined || typeof pathPrefix !== "string") {
-    let projectConfig = require("../Config").getConfig();
+    let projectConfig = eleventyConfig.getConfig();
     pathPrefix = projectConfig.pathPrefix;
   }
 

--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -2,13 +2,12 @@ const lodashChunk = require("lodash/chunk");
 const lodashGet = require("lodash/get");
 const lodashSet = require("lodash/set");
 const EleventyBaseError = require("../EleventyBaseError");
-const config = require("../Config");
 
 class PaginationError extends EleventyBaseError {}
 
 class Pagination {
-  constructor(data) {
-    this.config = config.getConfig();
+  constructor(data, eleventyConfig) {
+    this.config = eleventyConfig.getConfig();
 
     this.setData(data);
   }

--- a/src/Template.js
+++ b/src/Template.js
@@ -20,9 +20,16 @@ const debugDev = require("debug")("Dev:Eleventy:Template");
 const bench = require("./BenchmarkManager").get("Aggregate");
 
 class Template extends TemplateContent {
-  constructor(path, inputDir, outputDir, templateData, extensionMap) {
+  constructor(
+    path,
+    inputDir,
+    outputDir,
+    templateData,
+    extensionMap,
+    templateConfig
+  ) {
     debugDev("new Template(%o)", path);
-    super(path, inputDir);
+    super(path, inputDir, templateConfig);
 
     this.parsed = parsePath(path);
 
@@ -58,6 +65,7 @@ class Template extends TemplateContent {
     );
     this.fileSlugStr = this.fileSlug.getSlug();
     this.filePathStem = this.fileSlug.getFullPathWithoutExtension();
+    this.templateConfig = templateConfig;
   }
 
   setIsVerbose(isVerbose) {
@@ -86,10 +94,11 @@ class Template extends TemplateContent {
       this._layout = TemplateLayout.getTemplate(
         layoutKey,
         this.getInputDir(),
-        this.config,
+        this.templateConfig,
         this.extensionMap
       );
     }
+
     return this._layout;
   }
 
@@ -240,7 +249,6 @@ class Template extends TemplateContent {
       let mergedLayoutData = {};
       if (layoutKey) {
         let layout = this.getLayout(layoutKey);
-
         mergedLayoutData = await layout.getData();
         debugDev(
           "%o getData() get merged layout chain front matter",
@@ -494,7 +502,7 @@ class Template extends TemplateContent {
     } else {
       // needs collections for pagination items
       // but individual pagination entries won’t be part of a collection
-      this.paging = new Pagination(data);
+      this.paging = new Pagination(data, this.templateConfig);
       this.paging.setTemplate(this);
       let pageTemplates = await this.paging.getPageTemplates();
       let pageNumber = 0;
@@ -642,7 +650,8 @@ class Template extends TemplateContent {
       this.inputDir,
       this.outputDir,
       this.templateData,
-      this.extensionMap
+      this.extensionMap,
+      this.templateConfig
     );
     tmpl.config = this.config;
 

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -76,12 +76,11 @@ class TemplateConfig {
       TemplatePath.getWorkingDir(),
       localProjectConfigPath
     );
-    console.log(`Merging config with ${path}`);
+    debug(`Merging config with ${path}`);
 
     // Note for Mike: I'm delaying the processing of plugins until here.
     // Remember to come back and have a solid think about if this could
     // results in different results when merging
-    await eleventyConfig.applyPlugins();
 
     if (fs.existsSync(path)) {
       try {
@@ -118,6 +117,7 @@ class TemplateConfig {
     } else {
       debug("Eleventy local project config file not found, skipping.");
     }
+    await eleventyConfig.applyPlugins();
 
     let eleventyConfigApiMergingObject = eleventyConfig.getMergingConfigObject();
 
@@ -155,6 +155,7 @@ class TemplateConfig {
     merged.templateFormats = lodashUniq(merged.templateFormats);
 
     debug("Current configuration: %o", merged);
+
     return merged;
   }
 }

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -117,7 +117,8 @@ class TemplateConfig {
     } else {
       debug("Eleventy local project config file not found, skipping.");
     }
-    await eleventyConfig.applyPlugins();
+
+    await eleventyConfig.applyPlugins(localConfig);
 
     let eleventyConfigApiMergingObject = eleventyConfig.getMergingConfigObject();
 

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -117,10 +117,6 @@ class TemplateConfig {
     );
     debug(`Merging config with ${path}`);
 
-    // Note for Mike: I'm delaying the processing of plugins until here.
-    // Remember to come back and have a solid think about if this could
-    // results in different results when merging
-
     if (fs.existsSync(path)) {
       try {
         // remove from require cache so it will grab a fresh copy

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -11,7 +11,6 @@ const TemplateGlob = require("./TemplateGlob");
 const EleventyExtensionMap = require("./EleventyExtensionMap");
 const EleventyBaseError = require("./EleventyBaseError");
 
-const config = require("./Config");
 const debugWarn = require("debug")("Eleventy:Warnings");
 const debug = require("debug")("Eleventy:TemplateData");
 const debugDev = require("debug")("Dev:Eleventy:TemplateData");
@@ -43,8 +42,10 @@ class FSExistsCache {
 class TemplateDataParseError extends EleventyBaseError {}
 
 class TemplateData {
-  constructor(inputDir) {
-    this.config = config.getConfig();
+  constructor(inputDir, templateConfig) {
+    this.config = templateConfig.getConfig();
+    this.templateConfig = templateConfig;
+
     this.dataTemplateEngine = this.config.dataTemplateEngine;
 
     this.inputDirNeedsCheck = false;
@@ -60,7 +61,7 @@ class TemplateData {
 
   get extensionMap() {
     if (!this._extensionMap) {
-      this._extensionMap = new EleventyExtensionMap();
+      this._extensionMap = new EleventyExtensionMap([], this.templateConfig);
       this._extensionMap.config = this.config;
     }
     return this._extensionMap;
@@ -397,7 +398,11 @@ class TemplateData {
         );
       }
     } else {
-      let tr = new TemplateRender(engineName, this.inputDir);
+      let tr = new TemplateRender(
+        engineName,
+        this.inputDir,
+        this.templateConfig
+      );
       tr.extensionMap = this.extensionMap;
 
       let fn = await tr.getCompiledTemplate(rawInput);

--- a/src/TemplateEngineManager.js
+++ b/src/TemplateEngineManager.js
@@ -1,14 +1,11 @@
-const config = require("./Config");
-
 class TemplateEngineManager {
-  constructor() {
+  constructor(templateConfig) {
     this.engineCache = {};
+    this.templateConfig = templateConfig;
+    this._config = templateConfig.getConfig();
   }
 
   get config() {
-    if (!this._config) {
-      this._config = config.getConfig();
-    }
     return this._config;
   }
 
@@ -31,8 +28,8 @@ class TemplateEngineManager {
         "11ty.js": "JavaScript",
       };
 
-      if ("extensionMap" in this.config) {
-        for (let entry of this.config.extensionMap) {
+      if ("extensionMap" in this._config) {
+        for (let entry of this._config.extensionMap) {
           this._keyToClassNameMap[entry.key] = "Custom";
         }
       }
@@ -63,9 +60,9 @@ class TemplateEngineManager {
 
     let path = "./Engines/" + this.getClassNameFromTemplateKey(name);
     const cls = require(path);
-    let instance = new cls(name, includesDir);
+    let instance = new cls(name, includesDir, this.templateConfig);
     instance.extensionMap = extensionMap;
-    instance.config = this.config;
+    instance.config = this._config;
     instance.engineManager = this;
 
     // Make sure cache key is based on name and not path

--- a/src/TemplateLayoutPathResolver.js
+++ b/src/TemplateLayoutPathResolver.js
@@ -1,11 +1,10 @@
 const fs = require("fs-extra");
-const config = require("./Config");
 const TemplatePath = require("./TemplatePath");
 // const debug = require("debug")("Eleventy:TemplateLayoutPathResolver");
 
 class TemplateLayoutPathResolver {
-  constructor(path, inputDir, extensionMap) {
-    this._config = config.getConfig();
+  constructor(path, inputDir, extensionMap, templateConfig) {
+    this._config = templateConfig.getConfig();
     this.inputDir = inputDir;
     this.originalPath = path;
     this.path = path;

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -1,4 +1,3 @@
-const config = require("./Config");
 const EleventyExtensionMap = require("./EleventyExtensionMap");
 const EleventyBaseError = require("./EleventyBaseError");
 const TemplatePassthrough = require("./TemplatePassthrough");
@@ -8,8 +7,9 @@ const debug = require("debug")("Eleventy:TemplatePassthroughManager");
 class TemplatePassthroughManagerCopyError extends EleventyBaseError {}
 
 class TemplatePassthroughManager {
-  constructor() {
-    this.config = config.getConfig();
+  constructor(templateConfig) {
+    this.config = templateConfig.getConfig();
+    this.templateConfig = templateConfig;
     this.reset();
   }
 
@@ -29,7 +29,7 @@ class TemplatePassthroughManager {
 
   get extensionMap() {
     if (!this._extensionMap) {
-      this._extensionMap = new EleventyExtensionMap();
+      this._extensionMap = new EleventyExtensionMap([], this.templateConfig);
       this._extensionMap.config = this.config;
     }
     return this._extensionMap;

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -278,7 +278,7 @@ class UserConfig {
     this.plugins.push({ plugin, options });
   }
 
-  async applyPlugins(rootConfig) {
+  async applyPlugins(templateConfig) {
     for (let index = 0; index < this.plugins.length; index++) {
       const { plugin, options } = this.plugins[index];
       // TODO support function.name in plugin config functions
@@ -287,15 +287,15 @@ class UserConfig {
       if (typeof plugin === "function") {
         pluginBench.before();
         let configFunction = plugin;
-        await configFunction(this, options, rootConfig);
+        await configFunction(this, options, templateConfig);
         pluginBench.after();
       } else if (plugin && plugin.configFunction) {
         pluginBench.before();
         if (options && typeof options.init === "function") {
-          options.init.call(this, plugin.initArguments || {}, rootConfig);
+          options.init.call(this, plugin.initArguments || {}, templateConfig);
         }
 
-        await plugin.configFunction(this, options, rootConfig);
+        await plugin.configFunction(this, options, templateConfig);
         pluginBench.after();
       } else {
         throw new UserConfigError(

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -360,11 +360,6 @@ class UserConfig {
       this.templateFormatsAdded = [];
     }
 
-    console.log({
-      templateFormatsAdded: this.templateFormatsAdded,
-      templateFormats: this.templateFormats,
-    });
-
     this.templateFormatsAdded = this.templateFormatsAdded.concat(
       this._normalizeTemplateFormats(templateFormats)
     );

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -278,7 +278,7 @@ class UserConfig {
     this.plugins.push({ plugin, options });
   }
 
-  async applyPlugins() {
+  async applyPlugins(rootConfig) {
     for (let index = 0; index < this.plugins.length; index++) {
       const { plugin, options } = this.plugins[index];
       // TODO support function.name in plugin config functions
@@ -287,15 +287,15 @@ class UserConfig {
       if (typeof plugin === "function") {
         pluginBench.before();
         let configFunction = plugin;
-        await configFunction(this, options);
+        await configFunction(this, options, rootConfig);
         pluginBench.after();
       } else if (plugin && plugin.configFunction) {
         pluginBench.before();
         if (options && typeof options.init === "function") {
-          options.init.call(this, plugin.initArguments || {});
+          options.init.call(this, plugin.initArguments || {}, rootConfig);
         }
 
-        await plugin.configFunction(this, options);
+        await plugin.configFunction(this, options, rootConfig);
         pluginBench.after();
       } else {
         throw new UserConfigError(

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -1,10 +1,10 @@
-const urlFilter = require("./Filters/Url");
+const getUrlFilter = require("./Filters/Url");
 const slugFilter = require("./Filters/Slug");
 const getCollectionItem = require("./Filters/GetCollectionItem");
 
 module.exports = function (config) {
   config.addFilter("slug", slugFilter);
-  config.addFilter("url", urlFilter);
+  config.addFilter("url", getUrlFilter(config));
   config.addFilter("log", console.log);
 
   config.addFilter("getCollectionItem", (collection, page) =>

--- a/test/EleventyExtensionMapTest.js
+++ b/test/EleventyExtensionMapTest.js
@@ -1,23 +1,29 @@
 const test = require("ava");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 test("Empty formats", (t) => {
-  let map = new EleventyExtensionMap([]);
+  let map = new EleventyExtensionMap([], templateConfig);
   t.deepEqual(map.getGlobs("."), []);
 });
 test("Single format", (t) => {
-  let map = new EleventyExtensionMap(["pug"]);
+  let map = new EleventyExtensionMap(["pug"], templateConfig);
   t.deepEqual(map.getGlobs("."), ["./**/*.pug"]);
   t.deepEqual(map.getGlobs("src"), ["./src/**/*.pug"]);
 });
 test("Multiple formats", (t) => {
-  let map = new EleventyExtensionMap(["njk", "pug"]);
+  let map = new EleventyExtensionMap(["njk", "pug"], templateConfig);
   t.deepEqual(map.getGlobs("."), ["./**/*.njk", "./**/*.pug"]);
   t.deepEqual(map.getGlobs("src"), ["./src/**/*.njk", "./src/**/*.pug"]);
 });
 
 test("Invalid keys are filtered (no passthrough copy)", (t) => {
-  let map = new EleventyExtensionMap(["lksdjfjlsk"]);
+  let map = new EleventyExtensionMap(["lksdjfjlsk"], templateConfig);
   map.config = {
     passthroughFileCopy: false,
   };
@@ -25,7 +31,7 @@ test("Invalid keys are filtered (no passthrough copy)", (t) => {
 });
 
 test("Invalid keys are filtered (using passthrough copy)", (t) => {
-  let map = new EleventyExtensionMap(["lksdjfjlsk"]);
+  let map = new EleventyExtensionMap(["lksdjfjlsk"], templateConfig);
   map.config = {
     passthroughFileCopy: true,
   };
@@ -33,27 +39,27 @@ test("Invalid keys are filtered (using passthrough copy)", (t) => {
 });
 
 test("Keys are mapped to lower case", (t) => {
-  let map = new EleventyExtensionMap(["PUG", "NJK"]);
+  let map = new EleventyExtensionMap(["PUG", "NJK"], templateConfig);
   t.deepEqual(map.getGlobs("."), ["./**/*.pug", "./**/*.njk"]);
 });
 
 test("Pruned globs", (t) => {
-  let map = new EleventyExtensionMap(["pug", "njk", "png"]);
+  let map = new EleventyExtensionMap(["pug", "njk", "png"], templateConfig);
   t.deepEqual(map.getPassthroughCopyGlobs("."), ["./**/*.png"]);
 });
 
 test("Empty path for fileList", (t) => {
-  let map = new EleventyExtensionMap(["njk", "pug"]);
+  let map = new EleventyExtensionMap(["njk", "pug"], templateConfig);
   t.deepEqual(map.getFileList(), []);
 });
 
 test("fileList", (t) => {
-  let map = new EleventyExtensionMap(["njk", "pug"]);
+  let map = new EleventyExtensionMap(["njk", "pug"], templateConfig);
   t.deepEqual(map.getFileList("filename"), ["filename.njk", "filename.pug"]);
 });
 
 test("fileList with dir", (t) => {
-  let map = new EleventyExtensionMap(["njk", "pug"]);
+  let map = new EleventyExtensionMap(["njk", "pug"], templateConfig);
   t.deepEqual(map.getFileList("filename", "_includes"), [
     "_includes/filename.njk",
     "_includes/filename.pug",
@@ -61,7 +67,7 @@ test("fileList with dir", (t) => {
 });
 
 test("fileList with dir in path", (t) => {
-  let map = new EleventyExtensionMap(["njk", "pug"]);
+  let map = new EleventyExtensionMap(["njk", "pug"], templateConfig);
   t.deepEqual(map.getFileList("layouts/filename"), [
     "layouts/filename.njk",
     "layouts/filename.pug",
@@ -69,7 +75,7 @@ test("fileList with dir in path", (t) => {
 });
 
 test("fileList with dir in path and dir", (t) => {
-  let map = new EleventyExtensionMap(["njk", "pug"]);
+  let map = new EleventyExtensionMap(["njk", "pug"], templateConfig);
   t.deepEqual(map.getFileList("layouts/filename", "_includes"), [
     "_includes/layouts/filename.njk",
     "_includes/layouts/filename.pug",
@@ -77,7 +83,7 @@ test("fileList with dir in path and dir", (t) => {
 });
 
 test("removeTemplateExtension", (t) => {
-  let map = new EleventyExtensionMap(["njk", "11ty.js"]);
+  let map = new EleventyExtensionMap(["njk", "11ty.js"], templateConfig);
   t.is(map.removeTemplateExtension("component.njk"), "component");
   t.is(map.removeTemplateExtension("component.11ty.js"), "component");
 
@@ -87,13 +93,10 @@ test("removeTemplateExtension", (t) => {
 });
 
 test("hasEngine", (t) => {
-  let map = new EleventyExtensionMap([
-    "liquid",
-    "njk",
-    "11ty.js",
-    "ejs",
-    "pug",
-  ]);
+  let map = new EleventyExtensionMap(
+    ["liquid", "njk", "11ty.js", "ejs", "pug"],
+    templateConfig
+  );
   t.true(map.hasEngine("default.ejs"));
   t.is(map.getKey("default.ejs"), "ejs");
   t.falsy(map.getKey());
@@ -111,7 +114,7 @@ test("hasEngine", (t) => {
 });
 
 test("hasEngine no formats passed in", (t) => {
-  let map = new EleventyExtensionMap([]);
+  let map = new EleventyExtensionMap([], templateConfig);
   t.true(map.hasEngine("default.ejs"));
   t.is(map.getKey("default.ejs"), "ejs");
   t.falsy(map.getKey());
@@ -130,7 +133,7 @@ test("hasEngine no formats passed in", (t) => {
 });
 
 test("getKey", (t) => {
-  let map = new EleventyExtensionMap(["njk", "11ty.js", "md"]);
+  let map = new EleventyExtensionMap(["njk", "11ty.js", "md"], templateConfig);
   t.is(map.getKey("component.njk"), "njk");
   t.is(map.getKey("component.11ty.js"), "11ty.js");
   t.is(map.getKey("11ty.js"), "11ty.js");
@@ -145,15 +148,10 @@ test("getKey", (t) => {
 });
 
 test("isFullTemplateFilename (not a passthrough copy extension)", (t) => {
-  let map = new EleventyExtensionMap([
-    "liquid",
-    "njk",
-    "11ty.js",
-    "ejs",
-    "pug",
-    "js",
-    "css",
-  ]);
+  let map = new EleventyExtensionMap(
+    ["liquid", "njk", "11ty.js", "ejs", "pug", "js", "css"],
+    templateConfig
+  );
   t.true(map.isFullTemplateFilename("template.liquid"));
   t.true(map.isFullTemplateFilename("template.njk"));
   t.true(map.isFullTemplateFilename("template.11ty.js"));

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -4,8 +4,20 @@ const EleventyFiles = require("../src/EleventyFiles");
 const TemplatePath = require("../src/TemplatePath");
 const TemplatePassthroughManager = require("../src/TemplatePassthroughManager");
 
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
+
+const getEleventyFiles = (...args) => {
+  args = args.concat(Array(4).fill(null)).slice(0, 4).concat(templateConfig);
+  return new EleventyFiles(...args);
+};
+
 test("getFiles", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/writeTest",
     "./test/stubs/_writeTestSite",
     ["ejs", "md"]
@@ -16,7 +28,7 @@ test("getFiles", async (t) => {
 });
 
 test("getFiles (without 11ty.js)", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite",
     ["ejs", "md"]
@@ -27,7 +39,7 @@ test("getFiles (without 11ty.js)", async (t) => {
 });
 
 test("getFiles (with 11ty.js)", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite",
     ["ejs", "md", "11ty.js"]
@@ -38,7 +50,7 @@ test("getFiles (with 11ty.js)", async (t) => {
 });
 
 test("getFiles (with js, treated as passthrough copy)", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite",
     ["ejs", "md", "js"]
@@ -59,7 +71,7 @@ test("getFiles (with js, treated as passthrough copy)", async (t) => {
 });
 
 test("getFiles (with case insensitivity)", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/writeTestJS-casesensitive",
     "./test/stubs/_writeTestJSCaseSensitiveSite",
     ["JS"]
@@ -86,7 +98,7 @@ test("getFiles (with case insensitivity)", async (t) => {
 });
 
 test("Mutually exclusive Input and Output dirs", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/writeTest",
     "./test/stubs/_writeTestSite",
     ["ejs", "md"]
@@ -100,7 +112,7 @@ test("Mutually exclusive Input and Output dirs", async (t) => {
 });
 
 test("Single File Input (deep path)", async (t) => {
-  let evf = new EleventyFiles("./test/stubs/index.html", "./test/stubs/_site", [
+  let evf = getEleventyFiles("./test/stubs/index.html", "./test/stubs/_site", [
     "ejs",
     "md",
   ]);
@@ -113,7 +125,7 @@ test("Single File Input (deep path)", async (t) => {
 });
 
 test("Single File Input (shallow path)", async (t) => {
-  let evf = new EleventyFiles("README.md", "./test/stubs/_site", ["md"]);
+  let evf = getEleventyFiles("README.md", "./test/stubs/_site", ["md"]);
   evf.init();
 
   let globs = evf.getFileGlobs().filter((path) => path !== "!./README.md");
@@ -124,7 +136,7 @@ test("Single File Input (shallow path)", async (t) => {
 });
 
 test("Glob Input", async (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "./test/stubs/glob-pages/!(contact.md)",
     "./test/stubs/_site",
     ["md"]
@@ -175,7 +187,7 @@ test("defaults if passed file name does not exist", (t) => {
 });
 
 test(".eleventyignore files", async (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["ejs", "md"]);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", ["ejs", "md"]);
   evf.init();
   let ignoredFiles = await fastglob("test/stubs/ignoredFolder/*.md");
   t.is(ignoredFiles.length, 1);
@@ -194,7 +206,7 @@ test(".eleventyignore files", async (t) => {
 
 /* .eleventyignore and .gitignore combos */
 test("Get ignores (no .eleventyignore no .gitignore)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore1",
     "test/stubs/ignore1/_site",
     []
@@ -213,7 +225,7 @@ test("Get ignores (no .eleventyignore no .gitignore)", (t) => {
 });
 
 test("Get ignores (no .eleventyignore)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore2",
     "test/stubs/ignore2/_site",
     []
@@ -229,7 +241,7 @@ test("Get ignores (no .eleventyignore)", (t) => {
 });
 
 test("Get ignores (no .eleventyignore, using setUseGitIgnore(false))", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore2",
     "test/stubs/ignore2/_site",
     []
@@ -251,7 +263,7 @@ test("Get ignores (no .eleventyignore, using setUseGitIgnore(false))", (t) => {
 });
 
 test("Get ignores (no .gitignore)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore3",
     "test/stubs/ignore3/_site",
     []
@@ -271,7 +283,7 @@ test("Get ignores (no .gitignore)", (t) => {
 });
 
 test("Get ignores (both .eleventyignore and .gitignore)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore4",
     "test/stubs/ignore4/_site",
     []
@@ -289,7 +301,7 @@ test("Get ignores (both .eleventyignore and .gitignore)", (t) => {
 });
 
 test("Get ignores (both .eleventyignore and .gitignore, using setUseGitIgnore(false))", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore4",
     "test/stubs/ignore4/_site",
     []
@@ -313,7 +325,7 @@ test("Get ignores (both .eleventyignore and .gitignore, using setUseGitIgnore(fa
 });
 
 test("Get ignores (no .eleventyignore  .gitignore exists but empty)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore5",
     "test/stubs/ignore5/_site",
     []
@@ -332,7 +344,7 @@ test("Get ignores (no .eleventyignore  .gitignore exists but empty)", (t) => {
 });
 
 test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore is empty)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore6",
     "test/stubs/ignore6/_site",
     []
@@ -352,7 +364,7 @@ test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore is
 });
 
 test("Get ignores (no .eleventyignore  .gitignore exists but has spaces inside)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore7",
     "test/stubs/ignore7/_site",
     []
@@ -371,7 +383,7 @@ test("Get ignores (no .eleventyignore  .gitignore exists but has spaces inside)"
 });
 
 test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore has spaces inside)", (t) => {
-  let evf = new EleventyFiles(
+  let evf = getEleventyFiles(
     "test/stubs/ignore8",
     "test/stubs/ignore8/_site",
     []
@@ -392,7 +404,7 @@ test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore ha
 /* End .eleventyignore and .gitignore combos */
 
 test("getTemplateData caching", (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", []);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", []);
   evf.init();
   let templateDataFirstCall = evf.getTemplateData();
   let templateDataSecondCall = evf.getTemplateData();
@@ -400,19 +412,19 @@ test("getTemplateData caching", (t) => {
 });
 
 test("getDataDir", (t) => {
-  let evf = new EleventyFiles(".", "_site", []);
+  let evf = getEleventyFiles(".", "_site", []);
   evf.init();
   t.is(evf.getDataDir(), "_data");
 });
 
 test("getDataDir subdir", (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", []);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", []);
   evf.init();
   t.is(evf.getDataDir(), "test/stubs/_data");
 });
 
 test("Include and Data Dirs", (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", []);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", []);
   evf.init();
 
   t.deepEqual(evf._getIncludesAndDataDirs(), [
@@ -422,7 +434,7 @@ test("Include and Data Dirs", (t) => {
 });
 
 test("Ignore Include and Data Dirs", (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", []);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", []);
   evf.init();
 
   t.deepEqual(evf._getIncludesAndDataDirIgnores(), [
@@ -432,7 +444,7 @@ test("Ignore Include and Data Dirs", (t) => {
 });
 
 test("Input to 'src' and empty includes dir (issue #403)", (t) => {
-  let evf = new EleventyFiles("src", "src/_site", ["md", "liquid", "html"]);
+  let evf = getEleventyFiles("src", "src/_site", ["md", "liquid", "html"]);
   evf._setConfig({
     useGitIgnore: false,
     eleventyignoreOverride: "!./src/_includes/**",
@@ -456,7 +468,7 @@ test("Input to 'src' and empty includes dir (issue #403)", (t) => {
 });
 
 test("Bad expected output, this indicates a bug upstream in a dependency.  Input to 'src' and empty includes dir (issue #403, full paths in eleventyignore)", async (t) => {
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", [
+  let evf = getEleventyFiles("test/stubs-403", "test/stubs-403/_site", [
     "liquid",
   ]);
   evf._setConfig({
@@ -480,7 +492,7 @@ test("Bad expected output, this indicates a bug upstream in a dependency.  Input
 });
 
 test("Workaround for Bad expected output, this indicates a bug upstream in a dependency.  Input to 'src' and empty includes dir (issue #403, full paths in eleventyignore)", async (t) => {
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", [
+  let evf = getEleventyFiles("test/stubs-403", "test/stubs-403/_site", [
     "liquid",
   ]);
   evf._setConfig({
@@ -499,7 +511,7 @@ test("Workaround for Bad expected output, this indicates a bug upstream in a dep
 });
 
 test("Issue #403: all .eleventyignores should be relative paths not absolute paths", async (t) => {
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", [
+  let evf = getEleventyFiles("test/stubs-403", "test/stubs-403/_site", [
     "liquid",
   ]);
   evf._setConfig({
@@ -523,7 +535,7 @@ test("Issue #403: all .eleventyignores should be relative paths not absolute pat
 });
 
 test("Glob Watcher Files", async (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk"]);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", ["njk"]);
   evf.init();
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -534,7 +546,7 @@ test("Glob Watcher Files", async (t) => {
 });
 
 test("Glob Watcher Files with File Extension Passthroughs", async (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk", "png"]);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", ["njk", "png"]);
   evf.init();
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -546,10 +558,10 @@ test("Glob Watcher Files with File Extension Passthroughs", async (t) => {
 });
 
 test("Glob Watcher Files with Config Passthroughs (one template format)", async (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk"]);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", ["njk"]);
   evf.init();
 
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setInputDir("test/stubs");
   mgr.setOutputDir("test/stubs/_site");
   mgr.setConfig({
@@ -569,7 +581,7 @@ test("Glob Watcher Files with Config Passthroughs (one template format)", async 
 });
 
 test("Glob Watcher Files with Config Passthroughs (no template formats)", async (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", []);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", []);
   evf.init();
 
   t.deepEqual(await evf.getGlobWatcherTemplateDataFiles(), [
@@ -580,7 +592,7 @@ test("Glob Watcher Files with Config Passthroughs (no template formats)", async 
 });
 
 test("Glob Watcher Files with passthroughAll", async (t) => {
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", [], true);
+  let evf = getEleventyFiles("test/stubs", "test/stubs/_site", [], true);
   evf.init();
 
   t.is((await evf.getFileGlobs())[0], "./test/stubs/**");

--- a/test/EleventyServeTest.js
+++ b/test/EleventyServeTest.js
@@ -1,20 +1,26 @@
 const test = require("ava");
 const EleventyServe = require("../src/EleventyServe");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 test("Constructor", (t) => {
-  let es = new EleventyServe();
+  let es = new EleventyServe(templateConfig);
   t.is(es.getPathPrefix(), "/");
 });
 
 test("Directories", (t) => {
-  let es = new EleventyServe();
+  let es = new EleventyServe(templateConfig);
   es.setOutputDir("_site");
   t.is(es.getRedirectDir("test"), "_site/test");
   t.is(es.getRedirectFilename("test"), "_site/test/index.html");
 });
 
 test("Get Options", (t) => {
-  let es = new EleventyServe();
+  let es = new EleventyServe(templateConfig);
   es.config = {
     pathPrefix: "/",
   };
@@ -34,7 +40,7 @@ test("Get Options", (t) => {
 });
 
 test("Get Options (with a pathPrefix)", (t) => {
-  let es = new EleventyServe();
+  let es = new EleventyServe(templateConfig);
   es.config = {
     pathPrefix: "/web/",
   };
@@ -57,7 +63,7 @@ test("Get Options (with a pathPrefix)", (t) => {
 });
 
 test("Get Options (override in config)", (t) => {
-  let es = new EleventyServe();
+  let es = new EleventyServe(templateConfig);
   es.config = {
     pathPrefix: "/",
     browserSyncConfig: {

--- a/test/EleventyServeTest.js
+++ b/test/EleventyServeTest.js
@@ -8,19 +8,22 @@ test.before(async () => {
 });
 
 test("Constructor", (t) => {
-  let es = new EleventyServe(templateConfig);
+  let es = new EleventyServe();
+  es.config = templateConfig;
   t.is(es.getPathPrefix(), "/");
 });
 
 test("Directories", (t) => {
-  let es = new EleventyServe(templateConfig);
+  let es = new EleventyServe();
+  es.config = templateConfig;
   es.setOutputDir("_site");
   t.is(es.getRedirectDir("test"), "_site/test");
   t.is(es.getRedirectFilename("test"), "_site/test/index.html");
 });
 
 test("Get Options", (t) => {
-  let es = new EleventyServe(templateConfig);
+  let es = new EleventyServe();
+  es.config = templateConfig;
   es.config = {
     pathPrefix: "/",
   };
@@ -40,7 +43,8 @@ test("Get Options", (t) => {
 });
 
 test("Get Options (with a pathPrefix)", (t) => {
-  let es = new EleventyServe(templateConfig);
+  let es = new EleventyServe();
+  es.config = templateConfig;
   es.config = {
     pathPrefix: "/web/",
   };
@@ -63,7 +67,8 @@ test("Get Options (with a pathPrefix)", (t) => {
 });
 
 test("Get Options (override in config)", (t) => {
-  let es = new EleventyServe(templateConfig);
+  let es = new EleventyServe();
+  es.config = templateConfig;
   es.config = {
     pathPrefix: "/",
     browserSyncConfig: {

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -3,10 +3,17 @@ const Eleventy = require("../src/Eleventy");
 const EleventyWatchTargets = require("../src/EleventyWatchTargets");
 const templateConfig = require("../src/Config");
 
-const config = templateConfig.getConfig();
+let config = {};
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+  config = templateConfig.getConfig();
+});
 
 test("Eleventy, defaults inherit from config", async (t) => {
   let elev = new Eleventy();
+  await elev.init();
 
   t.truthy(elev.input);
   t.truthy(elev.outputDir);
@@ -14,32 +21,35 @@ test("Eleventy, defaults inherit from config", async (t) => {
   t.is(elev.outputDir, config.dir.output);
 });
 
-test("Eleventy, get version", (t) => {
+test("Eleventy, get version", async (t) => {
   let elev = new Eleventy();
+  await elev.init();
 
   t.truthy(elev.getVersion());
 });
 
-test("Eleventy, get help", (t) => {
+test("Eleventy, get help", async (t) => {
   let elev = new Eleventy();
+  await elev.init();
 
   t.truthy(elev.getHelp());
 });
 
-test("Eleventy, set is verbose", (t) => {
+test("Eleventy, set is verbose", async (t) => {
   let elev = new Eleventy();
   elev.setIsVerbose(true);
+  await elev.init();
 
   t.true(elev.isVerbose);
 });
 
 test("Eleventy set input/output", async (t) => {
   let elev = new Eleventy("./test/stubs", "./test/stubs/_site");
+  await elev.init();
 
   t.is(elev.input, "./test/stubs");
   t.is(elev.outputDir, "./test/stubs/_site");
 
-  await elev.init();
   t.truthy(elev.templateData);
   t.truthy(elev.writer);
 });
@@ -86,6 +96,7 @@ test("Eleventy file watching (no JS dependencies)", async (t) => {
   elev.setWatchTargets(wt);
 
   await elev.init();
+  await elev.eleventyFiles.getFiles();
   await elev.initWatch();
   t.deepEqual(await elev.getWatchedFiles(), [
     "./test/stubs/**/*.njk",
@@ -100,6 +111,7 @@ test("Eleventy file watching (no JS dependencies)", async (t) => {
 
 test("Eleventy set input/output, one file input", async (t) => {
   let elev = new Eleventy("./test/stubs/index.html", "./test/stubs/_site");
+  await elev.init();
 
   t.is(elev.input, "./test/stubs/index.html");
   t.is(elev.inputDir, "./test/stubs");
@@ -108,7 +120,7 @@ test("Eleventy set input/output, one file input", async (t) => {
 
 test("Eleventy set input/output, one file input root dir", async (t) => {
   let elev = new Eleventy("./README.md", "./test/stubs/_site");
-
+  await elev.init();
   t.is(elev.input, "./README.md");
   t.is(elev.inputDir, ".");
   t.is(elev.outputDir, "./test/stubs/_site");
@@ -116,6 +128,7 @@ test("Eleventy set input/output, one file input root dir", async (t) => {
 
 test("Eleventy set input/output, one file input root dir without leading dot/slash", async (t) => {
   let elev = new Eleventy("README.md", "./test/stubs/_site");
+  await elev.init();
 
   t.is(elev.input, "README.md");
   t.is(elev.inputDir, ".");

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -57,8 +57,8 @@ test("Eleventy set input/output", async (t) => {
 test("Eleventy file watching", async (t) => {
   let elev = new Eleventy("./test/stubs", "./test/stubs/_site");
   elev.setFormats("njk");
-
   await elev.init();
+
   await elev.eleventyFiles.getFiles();
   await elev.initWatch();
   t.deepEqual(await elev.getWatchedFiles(), [
@@ -77,8 +77,8 @@ test("Eleventy file watching", async (t) => {
 test("Eleventy file watching (don’t watch deps of passthrough copy .js files)", async (t) => {
   let elev = new Eleventy("./test/stubs-1325", "./test/stubs-1325/_site");
   elev.setFormats("11ty.js,js");
-
   await elev.init();
+
   await elev.eleventyFiles.getFiles();
   await elev.initWatch();
 
@@ -87,18 +87,19 @@ test("Eleventy file watching (don’t watch deps of passthrough copy .js files)"
   ]);
 });
 
-test("Eleventy file watching (no JS dependencies)", async (t) => {
+test.only("Eleventy file watching (no JS dependencies)", async (t) => {
   let elev = new Eleventy("./test/stubs", "./test/stubs/_site");
   elev.setFormats("njk");
+  await elev.init();
 
   let wt = new EleventyWatchTargets();
   wt.watchJavaScriptDependencies = false;
   elev.setWatchTargets(wt);
 
-  await elev.init();
   await elev.eleventyFiles.getFiles();
   await elev.initWatch();
-  t.deepEqual(await elev.getWatchedFiles(), [
+  const watchedFiles = await elev.getWatchedFiles();
+  t.deepEqual(watchedFiles, [
     "./test/stubs/**/*.njk",
     "./test/stubs/_includes/**",
     "./test/stubs/_data/**",

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -2,15 +2,24 @@ const test = require("ava");
 const Template = require("../src/Template");
 const TemplateData = require("../src/TemplateData");
 const Pagination = require("../src/Plugins/Pagination");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 test("No data passed to pagination", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/notpaged.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
-  let paging = new Pagination();
+  let paging = new Pagination(undefined, templateConfig);
   paging.setTemplate(tmpl);
 
   t.is(paging.getPagedItems().length, 0);
@@ -21,11 +30,14 @@ test("No pagination", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/notpaged.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
-  let paging = new Pagination(data);
+  let paging = new Pagination(data, templateConfig);
   paging.setTemplate(tmpl);
 
   t.falsy(data.pagination);
@@ -38,11 +50,14 @@ test("Pagination enabled in frontmatter", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedresolve.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
-  let paging = new Pagination(data);
+  let paging = new Pagination(data, templateConfig);
   paging.setTemplate(tmpl);
 
   t.truthy(data.testdata);
@@ -58,11 +73,14 @@ test("Resolve paged data in frontmatter", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedresolve.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
-  let paging = new Pagination(data);
+  let paging = new Pagination(data, templateConfig);
   paging.setTemplate(tmpl);
   t.is(paging._resolveItems().length, 8);
   t.is(paging.getPageCount(), 2);
@@ -73,7 +91,10 @@ test("Paginate data in frontmatter", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedinlinedata.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -94,14 +115,16 @@ test("Paginate data in frontmatter", async (t) => {
 });
 
 test("Paginate external data file", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   await dataObj.cacheData();
 
   let tmpl = new Template(
     "./test/stubs/paged/paged.njk",
     "./test/stubs/",
     "./dist",
-    dataObj
+    dataObj,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -136,7 +159,10 @@ test("Permalink with pagination variables", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalink.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -150,7 +176,10 @@ test("Permalink with pagination variables (numeric)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinknumeric.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -181,7 +210,10 @@ test("Permalink with pagination variables (numeric, one indexed)", async (t) => 
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinknumericoneindexed.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -208,7 +240,10 @@ test("Permalink first and last page link with pagination variables (numeric)", a
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinknumeric.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -225,7 +260,10 @@ test("Permalink first and last page link with pagination variables (numeric, one
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinknumericoneindexed.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -242,7 +280,10 @@ test("Alias to page data", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedalias.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -259,7 +300,10 @@ test("Alias to page data (size 2)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedaliassize2.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -276,7 +320,10 @@ test("Permalink with pagination variables (and an if statement, nunjucks)", asyn
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinkif.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -290,7 +337,10 @@ test("Permalink with pagination variables (and an if statement, liquid)", async 
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinkif.liquid",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -304,7 +354,10 @@ test("Template with Pagination, getRenderedTemplates", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinkif.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let outputPath = await tmpl.getOutputPath();
@@ -316,14 +369,16 @@ test("Template with Pagination, getRenderedTemplates", async (t) => {
 });
 
 test("Issue 135", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   await dataObj.cacheData();
 
   let tmpl = new Template(
     "./test/stubs/issue-135/template.njk",
     "./test/stubs/",
     "./dist",
-    dataObj
+    dataObj,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -344,7 +399,10 @@ test("Template with Pagination, getTemplates has page variables set", async (t) 
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinkif.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -360,7 +418,10 @@ test("Template with Pagination, getRenderedTemplates has page variables set", as
   let tmpl = new Template(
     "./test/stubs/paged/pagedpermalinkif.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -376,7 +437,10 @@ test("Page over an object (use keys)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedobject.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -400,7 +464,10 @@ test("Page over an object (use values)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedobjectvalues.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -424,7 +491,10 @@ test("Page over an object (filtered, array)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedobjectfilterarray.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -445,7 +515,10 @@ test("Page over an object (filtered, string)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedobjectfilterstring.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -467,7 +540,10 @@ test("Pagination with deep data merge #147", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedinlinedata.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
   tmpl.config = {
     keys: {
@@ -497,7 +573,10 @@ test("Pagination with deep data merge with alias #147", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedalias.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
   tmpl.config = {
     keys: {
@@ -522,7 +601,10 @@ test("Paginate data in frontmatter (reversed)", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedinlinedata-reverse.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -546,23 +628,46 @@ test("Paginate data in frontmatter (reversed)", async (t) => {
 });
 
 test("No circular dependency (does not throw)", (t) => {
-  new Pagination({
-    collections: {
-      tag1: [],
+  new Pagination(
+    {
+      collections: {
+        tag1: [],
+      },
+      pagination: {
+        data: "collections.tag1",
+        size: 1,
+      },
+      tags: ["tag2"],
     },
-    pagination: {
-      data: "collections.tag1",
-      size: 1,
-    },
-    tags: ["tag2"],
-  });
+    templateConfig
+  );
 
   t.true(true);
 });
 
 test("Circular dependency (pagination iterates over tag1 but also supplies pages to tag1)", (t) => {
   t.throws(() => {
-    new Pagination({
+    new Pagination(
+      {
+        collections: {
+          tag1: [],
+          tag2: [],
+        },
+        pagination: {
+          data: "collections.tag1",
+          size: 1,
+        },
+        tags: ["tag1"],
+      },
+      templateConfig
+    );
+  });
+});
+
+test("Circular dependency but should not error because it uses eleventyExcludeFromCollections", (t) => {
+  new Pagination(
+    {
+      eleventyExcludeFromCollections: true,
       collections: {
         tag1: [],
         tag2: [],
@@ -572,23 +677,9 @@ test("Circular dependency (pagination iterates over tag1 but also supplies pages
         size: 1,
       },
       tags: ["tag1"],
-    });
-  });
-});
-
-test("Circular dependency but should not error because it uses eleventyExcludeFromCollections", (t) => {
-  new Pagination({
-    eleventyExcludeFromCollections: true,
-    collections: {
-      tag1: [],
-      tag2: [],
     },
-    pagination: {
-      data: "collections.tag1",
-      size: 1,
-    },
-    tags: ["tag1"],
-  });
+    templateConfig
+  );
 
   t.true(true);
 });
@@ -597,7 +688,10 @@ test("Pagination `before` Callback", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/paged-before.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -610,7 +704,10 @@ test("Pagination `before` Callback with a Filter", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/paged-before-filter.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -623,7 +720,10 @@ test("Pagination `before` Callback with `reverse: true` (test order of operation
   let tmpl = new Template(
     "./test/stubs/paged/paged-before-and-reverse.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -632,14 +732,16 @@ test("Pagination `before` Callback with `reverse: true` (test order of operation
 });
 
 test("Pagination new v0.10.0 href/hrefs", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   await dataObj.cacheData();
 
   let tmpl = new Template(
     "./test/stubs/paged/paged.njk",
     "./test/stubs/",
     "./dist",
-    dataObj
+    dataObj,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -658,14 +760,16 @@ test("Pagination new v0.10.0 href/hrefs", async (t) => {
 });
 
 test("Pagination new v0.10.0 page/pages", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   await dataObj.cacheData();
 
   let tmpl = new Template(
     "./test/stubs/paged/paged.njk",
     "./test/stubs/",
     "./dist",
-    dataObj
+    dataObj,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -692,7 +796,10 @@ test("Pagination new v0.10.0 alias", async (t) => {
   let tmpl = new Template(
     "./test/stubs/paged/pagedalias.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();
@@ -706,7 +813,10 @@ test("Pagination make sure pageNumber is numeric for {{ pageNumber + 1 }} Issue 
   let tmpl = new Template(
     "./test/stubs/paged/pagedinlinedata.njk",
     "./test/stubs/",
-    "./dist"
+    "./dist",
+    null,
+    null,
+    templateConfig
   );
 
   let data = await tmpl.getData();

--- a/test/TemplateCacheTest.js
+++ b/test/TemplateCacheTest.js
@@ -1,11 +1,23 @@
 const test = require("ava");
 const Template = require("../src/Template");
 const templateCache = require("../src/TemplateCache");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
+
+const getNewTemplate = (...args) => {
+  // monkey patching to add templateConfig to the end of every call
+  args = args.concat(Array(5).fill(null)).slice(0, 5).concat(templateConfig);
+  return new Template(...args);
+};
 
 test("Cache can save templates", (t) => {
   templateCache.clear();
 
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/template.ejs",
     "./test/stubs/",
     "./dist"
@@ -18,7 +30,7 @@ test("Cache can save templates", (t) => {
 test("TemplateCache clear", (t) => {
   templateCache.clear();
 
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/template.ejs",
     "./test/stubs/",
     "./dist"
@@ -33,7 +45,7 @@ test("TemplateCache clear", (t) => {
 test("TemplateCache has", (t) => {
   templateCache.clear();
 
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/template.ejs",
     "./test/stubs/",
     "./dist"
@@ -46,7 +58,7 @@ test("TemplateCache has", (t) => {
 test("TemplateCache get success", (t) => {
   templateCache.clear();
 
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/template.ejs",
     "./test/stubs/",
     "./dist"
@@ -59,7 +71,7 @@ test("TemplateCache get success", (t) => {
 test("TemplateCache get fail", (t) => {
   templateCache.clear();
 
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/template.ejs",
     "./test/stubs/",
     "./dist"

--- a/test/TemplateCollectionTest.js
+++ b/test/TemplateCollectionTest.js
@@ -3,42 +3,70 @@ const multimatch = require("multimatch");
 const Template = require("../src/Template");
 const Collection = require("../src/TemplateCollection");
 const Sortable = require("../src/Util/Sortable");
+const templateConfig = require("../src/Config");
 
-let tmpl1 = new Template(
-  "./test/stubs/collection/test1.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl2 = new Template(
-  "./test/stubs/collection/test2.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl3 = new Template(
-  "./test/stubs/collection/test3.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl4 = new Template(
-  "./test/stubs/collection/test4.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl5 = new Template(
-  "./test/stubs/collection/test5.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl6 = new Template(
-  "./test/stubs/collection/test6.html",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl7 = new Template(
-  "./test/stubs/collection/test7.njk",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
+let tmpl1, tmpl2, tmpl3, tmpl4, tmpl5, tmpl6, tmpl7;
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+
+  tmpl1 = new Template(
+    "./test/stubs/collection/test1.md",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+  tmpl2 = new Template(
+    "./test/stubs/collection/test2.md",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+  tmpl3 = new Template(
+    "./test/stubs/collection/test3.md",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+  tmpl4 = new Template(
+    "./test/stubs/collection/test4.md",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+  tmpl5 = new Template(
+    "./test/stubs/collection/test5.md",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+  tmpl6 = new Template(
+    "./test/stubs/collection/test6.html",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+  tmpl7 = new Template(
+    "./test/stubs/collection/test7.njk",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
+  );
+});
 
 test("Basic setup", async (t) => {
   let c = new Collection();
@@ -179,12 +207,18 @@ test("partial match on tag string, issue 95", async (t) => {
   let cat = new Template(
     "./test/stubs/issue-95/cat.md",
     "./test/stubs/",
-    "./test/stubs/_site"
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
   );
   let notacat = new Template(
     "./test/stubs/issue-95/notacat.md",
     "./test/stubs/",
-    "./test/stubs/_site"
+    "./test/stubs/_site",
+    null,
+    null,
+    templateConfig
   );
 
   let c = new Collection();

--- a/test/TemplateConfigTest.js
+++ b/test/TemplateConfigTest.js
@@ -3,11 +3,12 @@ const md = require("markdown-it");
 const TemplateConfig = require("../src/TemplateConfig");
 const eleventyConfig = require("../src/EleventyConfig");
 
-test("Template Config local config overrides base config", async (t) => {
+test.serial("Template Config local config overrides base config", async (t) => {
   let templateCfg = new TemplateConfig(
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
 
   t.is(cfg.markdownTemplateEngine, "ejs");
@@ -33,7 +34,7 @@ test("Template Config local config overrides base config", async (t) => {
   );
 });
 
-test("Add liquid tag", (t) => {
+test.serial("Add liquid tag", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addLiquidTag("myTagName", function () {});
 
@@ -41,11 +42,12 @@ test("Add liquid tag", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.liquidTags).indexOf("myTagName"), -1);
 });
 
-test("Add nunjucks tag", (t) => {
+test.serial("Add nunjucks tag", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addNunjucksTag("myNunjucksTag", function () {});
 
@@ -53,11 +55,12 @@ test("Add nunjucks tag", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.nunjucksTags).indexOf("myNunjucksTag"), -1);
 });
 
-test("Add liquid filter", (t) => {
+test.serial("Add liquid filter", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addLiquidFilter("myFilterName", function (liquidEngine) {
     return {};
@@ -67,11 +70,12 @@ test("Add liquid filter", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.liquidFilters).indexOf("myFilterName"), -1);
 });
 
-test("Add handlebars helper", (t) => {
+test.serial("Add handlebars helper", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addHandlebarsHelper("myHelperName", function () {});
 
@@ -79,11 +83,12 @@ test("Add handlebars helper", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.handlebarsHelpers).indexOf("myHelperName"), -1);
 });
 
-test("Add nunjucks filter", (t) => {
+test.serial("Add nunjucks filter", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addNunjucksFilter("myFilterName", function () {});
 
@@ -91,11 +96,12 @@ test("Add nunjucks filter", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
 });
 
-test("Add universal filter", (t) => {
+test.serial("Add universal filter", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addFilter("myFilterName", function () {});
 
@@ -103,12 +109,13 @@ test("Add universal filter", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.liquidFilters).indexOf("myFilterName"), -1);
   t.not(Object.keys(cfg.handlebarsHelpers).indexOf("myFilterName"), -1);
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
 });
-test("Add namespaced universal filter", (t) => {
+test.serial("Add namespaced universal filter", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.namespace("testNamespace", function () {
     eleventyConfig.addFilter("MyFilterName", function () {});
@@ -118,6 +125,7 @@ test("Add namespaced universal filter", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(
     Object.keys(cfg.liquidFilters).indexOf("testNamespaceMyFilterName"),
@@ -133,7 +141,7 @@ test("Add namespaced universal filter", (t) => {
   );
 });
 
-test("Add namespaced universal filter using underscore", (t) => {
+test.serial("Add namespaced universal filter using underscore", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.namespace("testNamespace_", function () {
     eleventyConfig.addFilter("myFilterName", function () {});
@@ -143,6 +151,7 @@ test("Add namespaced universal filter using underscore", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(
     Object.keys(cfg.liquidFilters).indexOf("testNamespace_myFilterName"),
@@ -158,7 +167,7 @@ test("Add namespaced universal filter using underscore", (t) => {
   );
 });
 
-test("Empty namespace", (t) => {
+test.serial("Empty namespace", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.namespace("", function () {
     eleventyConfig.addNunjucksFilter("myFilterName", function () {});
@@ -168,11 +177,12 @@ test("Empty namespace", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
 });
 
-test("Nested Empty Inner namespace", (t) => {
+test.serial("Nested Empty Inner namespace", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.namespace("testNs", function () {
     eleventyConfig.namespace("", function () {
@@ -184,11 +194,12 @@ test("Nested Empty Inner namespace", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("testNsmyFilterName"), -1);
 });
 
-test("Nested Empty Outer namespace", (t) => {
+test.serial("Nested Empty Outer namespace", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.namespace("", function () {
     eleventyConfig.namespace("testNs", function () {
@@ -200,6 +211,7 @@ test("Nested Empty Outer namespace", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("testNsmyFilterName"), -1);
 });
@@ -207,7 +219,7 @@ test("Nested Empty Outer namespace", (t) => {
 // important for backwards compatibility with old
 // `module.exports = function (eleventyConfig, pluginNamespace) {`
 // plugin code
-test("Non-string namespaces are ignored", (t) => {
+test.serial("Non-string namespaces are ignored", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.namespace(["lkdsjflksd"], function () {
     eleventyConfig.addNunjucksFilter("myFilterName", function () {});
@@ -217,37 +229,46 @@ test("Non-string namespaces are ignored", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
 });
 
-test(".addPlugin oddity: I don’t think pluginNamespace was ever passed in here, but we don’t want this to break", (t) => {
-  eleventyConfig.reset();
-  eleventyConfig.addPlugin(function (eleventyConfig, pluginNamespace) {
-    eleventyConfig.namespace(pluginNamespace, () => {
-      eleventyConfig.addNunjucksFilter("myFilterName", function () {});
+test.serial(
+  ".addPlugin oddity: I don’t think pluginNamespace was ever passed in here, but we don’t want this to break",
+  async (t) => {
+    eleventyConfig.reset();
+    eleventyConfig.addPlugin(function (eleventyConfig, pluginNamespace) {
+      eleventyConfig.namespace(pluginNamespace, () => {
+        eleventyConfig.addNunjucksFilter("myFilterName", function () {});
+      });
     });
-  });
 
-  let templateCfg = new TemplateConfig(
-    require("../src/defaultConfig.js"),
-    "./test/stubs/config.js"
-  );
-  let cfg = templateCfg.getConfig();
-  t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
-});
+    let templateCfg = new TemplateConfig(
+      require("../src/defaultConfig.js"),
+      "./test/stubs/config.js"
+    );
+    await templateCfg.init();
+    let cfg = templateCfg.getConfig();
+    t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
+  }
+);
 
-test("Test url universal filter with custom pathPrefix (no slash)", (t) => {
-  let templateCfg = new TemplateConfig(
-    require("../src/defaultConfig.js"),
-    "./test/stubs/config.js"
-  );
-  templateCfg.setPathPrefix("/testdirectory/");
-  let cfg = templateCfg.getConfig();
-  t.is(cfg.pathPrefix, "/testdirectory/");
-});
+test.serial(
+  "Test url universal filter with custom pathPrefix (no slash)",
+  async (t) => {
+    let templateCfg = new TemplateConfig(
+      require("../src/defaultConfig.js"),
+      "./test/stubs/config.js"
+    );
+    await templateCfg.init();
+    templateCfg.setPathPrefix("/testdirectory/");
+    let cfg = templateCfg.getConfig();
+    t.is(cfg.pathPrefix, "/testdirectory/");
+  }
+);
 
-test("setTemplateFormats(string)", (t) => {
+test.serial("setTemplateFormats(string)", async (t) => {
   eleventyConfig.reset();
   // 0.11.0 removes dupes
   eleventyConfig.setTemplateFormats("ejs,njk, liquid, njk");
@@ -256,11 +277,12 @@ test("setTemplateFormats(string)", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.templateFormats, ["ejs", "njk", "liquid"]);
 });
 
-test("setTemplateFormats(array)", (t) => {
+test.serial("setTemplateFormats(array)", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.setTemplateFormats(["ejs", "njk", "liquid"]);
 
@@ -268,11 +290,12 @@ test("setTemplateFormats(array)", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.templateFormats, ["ejs", "njk", "liquid"]);
 });
 
-test("setTemplateFormats(array, size 1)", (t) => {
+test.serial("setTemplateFormats(array, size 1)", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.setTemplateFormats(["liquid"]);
 
@@ -280,11 +303,12 @@ test("setTemplateFormats(array, size 1)", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.templateFormats, ["liquid"]);
 });
 
-test("setTemplateFormats(empty array)", (t) => {
+test.serial("setTemplateFormats(empty array)", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.setTemplateFormats([]);
 
@@ -292,11 +316,12 @@ test("setTemplateFormats(empty array)", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.templateFormats, []);
 });
 
-test("setTemplateFormats(null)", (t) => {
+test.serial("setTemplateFormats(null)", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.setTemplateFormats(null);
 
@@ -304,11 +329,12 @@ test("setTemplateFormats(null)", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.true(cfg.templateFormats.length > 0);
 });
 
-test("multiple setTemplateFormats calls", (t) => {
+test.serial("multiple setTemplateFormats calls", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.setTemplateFormats("njk");
   eleventyConfig.setTemplateFormats("pug");
@@ -317,11 +343,13 @@ test("multiple setTemplateFormats calls", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.templateFormats, ["pug"]);
 });
 
-test("addTemplateFormats()", (t) => {
+test.serial("addTemplateFormats()", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addTemplateFormats("vue");
 
@@ -329,12 +357,13 @@ test("addTemplateFormats()", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   // should have ALL of the original defaults
   t.deepEqual(cfg.templateFormats, ["md", "njk", "vue"]);
 });
 
-test("both setTemplateFormats and addTemplateFormats", (t) => {
+test.serial("both setTemplateFormats and addTemplateFormats", async (t) => {
   // Template Formats can come from three places
   // defaultConfig.js config API (not used yet)
   // defaultConfig.js config return object
@@ -349,11 +378,12 @@ test("both setTemplateFormats and addTemplateFormats", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.templateFormats, ["pug", "vue"]);
 });
 
-test("libraryOverrides", (t) => {
+test.serial("libraryOverrides", async (t) => {
   let mdLib = md();
   eleventyConfig.setLibrary("md", mdLib);
 
@@ -361,6 +391,8 @@ test("libraryOverrides", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.falsy(cfg.libraryOverrides.ldkja);
   t.falsy(cfg.libraryOverrides.njk);
@@ -368,7 +400,7 @@ test("libraryOverrides", (t) => {
   t.deepEqual(mdLib, cfg.libraryOverrides.md);
 });
 
-test("addGlobalData", (t) => {
+test.serial("addGlobalData", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addGlobalData("function", () => new Date());
 
@@ -376,29 +408,32 @@ test("addGlobalData", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.globalData).indexOf("function"), -1);
 });
 
-test("Properly throws error on missing module #182", (t) => {
-  t.throws(function () {
-    new TemplateConfig(
+test("Properly throws error on missing module #182", async (t) => {
+  await t.throwsAsync(async () => {
+    const cfg = new TemplateConfig(
       require("../src/defaultConfig.js"),
       "./test/stubs/broken-config.js"
     );
+    return await cfg.init();
   });
 });
 
-test("Properly throws error when config returns a Promise", (t) => {
-  t.throws(function () {
+test("Properly throws error when config returns a Promise", async (t) => {
+  await t.throwsAsync(async () => {
     new TemplateConfig(
       require("../src/defaultConfig.js"),
       "./test/stubs/config-promise.js"
     );
+    return await cfg.init();
   });
 });
 
-test(".addWatchTarget adds a watch target", (t) => {
+test.serial(".addWatchTarget adds a watch target", async (t) => {
   eleventyConfig.reset();
   eleventyConfig.addWatchTarget("/testdirectory/");
 
@@ -406,6 +441,7 @@ test(".addWatchTarget adds a watch target", (t) => {
     require("../src/defaultConfig.js"),
     "./test/stubs/config.js"
   );
+  await templateCfg.init();
   let cfg = templateCfg.getConfig();
   t.deepEqual(cfg.additionalWatchTargets, ["/testdirectory/"]);
 });

--- a/test/TemplateDataTest.js
+++ b/test/TemplateDataTest.js
@@ -2,17 +2,23 @@ const test = require("ava");
 const TemplateData = require("../src/TemplateData");
 const templateConfig = require("../src/Config");
 
-const config = templateConfig.getConfig();
+let config = {};
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+  config = templateConfig.getConfig();
+});
 
 test("Create", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let data = await dataObj.getData();
 
   t.true(Object.keys(data[config.keys.package]).length > 0);
 });
 
 test("getData()", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   dataObj.setDataTemplateEngine("liquid");
 
   t.is(dataObj.getData().toString(), "[object Promise]");
@@ -32,7 +38,7 @@ test("getData()", async (t) => {
 });
 
 test("getData() use default processing (false)", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let data = await dataObj.getData();
   t.is(
     data.globalData.datakey2,
@@ -43,13 +49,16 @@ test("getData() use default processing (false)", async (t) => {
 
 test("Data dir does not exist", async (t) => {
   await t.throwsAsync(async () => {
-    let dataObj = new TemplateData("./test/thisdirectorydoesnotexist");
+    let dataObj = new TemplateData(
+      "./test/thisdirectorydoesnotexist",
+      templateConfig
+    );
     await dataObj.getData();
   });
 });
 
 test("Add local data", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   dataObj.setDataTemplateEngine("liquid");
 
   let data = await dataObj.getData();
@@ -72,7 +81,7 @@ test("Add local data", async (t) => {
 });
 
 test("Get local data async JS", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
 
   let withLocalData = await dataObj.getLocalData(
     "./test/stubs/component-async/component.njk"
@@ -84,7 +93,7 @@ test("Get local data async JS", async (t) => {
 });
 
 test("addLocalData() doesn’t exist but doesn’t fail (template file does exist)", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   dataObj.setDataTemplateEngine("liquid");
 
   let data = await dataObj.getData();
@@ -100,7 +109,7 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does exis
 });
 
 test("addLocalData() doesn’t exist but doesn’t fail (template file does not exist)", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   dataObj.setDataTemplateEngine("liquid");
 
   let data = await dataObj.getData();
@@ -115,7 +124,7 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does not 
 });
 
 test("Global Dir Directory", async (t) => {
-  let dataObj = new TemplateData("./");
+  let dataObj = new TemplateData("./", templateConfig);
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), [
     "./_data/**/*.(json|cjs|js)",
@@ -123,7 +132,7 @@ test("Global Dir Directory", async (t) => {
 });
 
 test("Global Dir Directory with Constructor Path Arg", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), [
     "./test/stubs/_data/**/*.(json|cjs|js)",
@@ -131,7 +140,7 @@ test("Global Dir Directory with Constructor Path Arg", async (t) => {
 });
 
 test("getAllGlobalData() with other data files", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let data = await dataObj.cacheData();
   let dataFilePaths = await dataObj.getGlobalDataFiles();
 
@@ -155,7 +164,7 @@ test("getAllGlobalData() with other data files", async (t) => {
 });
 
 test("getAllGlobalData() with js object data file", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let data = await dataObj.cacheData();
   let dataFilePaths = await dataObj.getGlobalDataFiles();
 
@@ -170,7 +179,7 @@ test("getAllGlobalData() with js object data file", async (t) => {
 });
 
 test("getAllGlobalData() with js function data file", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let data = await dataObj.cacheData();
   let dataFilePaths = await dataObj.getGlobalDataFiles();
 
@@ -185,7 +194,7 @@ test("getAllGlobalData() with js function data file", async (t) => {
 });
 
 test("getAllGlobalData() with config globalData", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
 
   dataObj._setConfig({
     ...dataObj.config,
@@ -208,7 +217,7 @@ test("getAllGlobalData() with config globalData", async (t) => {
 });
 
 test("getAllGlobalData() with common js function data file", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let data = await dataObj.cacheData();
   let dataFilePaths = await dataObj.getGlobalDataFiles();
 
@@ -223,7 +232,7 @@ test("getAllGlobalData() with common js function data file", async (t) => {
 });
 
 test("getDataValue() without a dataTemplateEngine", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   dataObj.setDataTemplateEngine(false);
 
   let data = await dataObj.getDataValue("./test/stubs/_data/testDataEjs.json", {
@@ -237,7 +246,7 @@ test("getDataValue() without a dataTemplateEngine", async (t) => {
 });
 
 test("getDataValue() without dataTemplateEngine changed to `ejs`", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   dataObj.setDataTemplateEngine("ejs");
 
   let data = await dataObj.getDataValue("./test/stubs/_data/testDataEjs.json", {
@@ -251,7 +260,7 @@ test("getDataValue() without dataTemplateEngine changed to `ejs`", async (t) => 
 });
 
 test("getLocalDataPaths", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let paths = await dataObj.getLocalDataPaths(
     "./test/stubs/component/component.liquid"
   );
@@ -269,7 +278,7 @@ test("getLocalDataPaths", async (t) => {
 });
 
 test("Deeper getLocalDataPaths", async (t) => {
-  let dataObj = new TemplateData("./");
+  let dataObj = new TemplateData("./", templateConfig);
   let paths = await dataObj.getLocalDataPaths(
     "./test/stubs/component/component.liquid"
   );
@@ -291,7 +300,7 @@ test("Deeper getLocalDataPaths", async (t) => {
 });
 
 test("getLocalDataPaths with an 11ty js template", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let paths = await dataObj.getLocalDataPaths(
     "./test/stubs/component/component.11ty.js"
   );
@@ -309,7 +318,7 @@ test("getLocalDataPaths with an 11ty js template", async (t) => {
 });
 
 test("getLocalDataPaths with inputDir passed in (trailing slash)", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let paths = await dataObj.getLocalDataPaths(
     "./test/stubs/component/component.liquid"
   );
@@ -327,7 +336,7 @@ test("getLocalDataPaths with inputDir passed in (trailing slash)", async (t) => 
 });
 
 test("getLocalDataPaths with inputDir passed in (no trailing slash)", async (t) => {
-  let dataObj = new TemplateData("./test/stubs/");
+  let dataObj = new TemplateData("./test/stubs/", templateConfig);
   let paths = await dataObj.getLocalDataPaths(
     "./test/stubs/component/component.liquid"
   );
@@ -345,7 +354,7 @@ test("getLocalDataPaths with inputDir passed in (no trailing slash)", async (t) 
 });
 
 test("getLocalDataPaths with inputDir passed in (no leading slash)", async (t) => {
-  let dataObj = new TemplateData("test/stubs");
+  let dataObj = new TemplateData("test/stubs", templateConfig);
   let paths = await dataObj.getLocalDataPaths(
     "./test/stubs/component/component.liquid"
   );
@@ -363,14 +372,14 @@ test("getLocalDataPaths with inputDir passed in (no leading slash)", async (t) =
 });
 
 test("getRawImports", async (t) => {
-  let dataObj = new TemplateData("test/stubs");
+  let dataObj = new TemplateData("test/stubs", templateConfig);
   let data = dataObj.getRawImports();
 
   t.is(data.pkg.name, "@11ty/eleventy");
 });
 
 test("getTemplateDataFileGlob", async (t) => {
-  let tw = new TemplateData("test/stubs");
+  let tw = new TemplateData("test/stubs", templateConfig);
 
   t.deepEqual(await tw.getTemplateDataFileGlob(), [
     "./test/stubs/**/*.json",
@@ -405,7 +414,11 @@ test("TemplateData.cleanupData", (t) => {
 });
 
 test("Parent directory for data (Issue #337)", async (t) => {
-  let dataObj = new TemplateData("./test/stubs-337/src/");
+  let dataObj = new TemplateData(
+    "./test/stubs-337/src/",
+    templateConfig,
+    templateConfig
+  );
   dataObj._setConfig({
     dataTemplateEngine: false,
     dir: {

--- a/test/TemplateEngineManagerTest.js
+++ b/test/TemplateEngineManagerTest.js
@@ -1,22 +1,29 @@
 const test = require("ava");
 const TemplateEngineManager = require("../src/TemplateEngineManager");
 const templateConfig = require("../src/Config");
-const config = templateConfig.getConfig();
+
+let config = {};
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+  config = templateConfig.getConfig();
+});
 
 test("Unsupported engine", async (t) => {
   t.throws(() => {
-    let tem = new TemplateEngineManager();
+    let tem = new TemplateEngineManager(templateConfig);
     tem.getEngine("doesnotexist");
   });
 });
 
 test("Supported engine", async (t) => {
-  let tem = new TemplateEngineManager();
+  let tem = new TemplateEngineManager(templateConfig);
   t.truthy(tem.hasEngine("ejs"));
 });
 
 test("Supported custom engine", async (t) => {
-  let tem = new TemplateEngineManager();
+  let tem = new TemplateEngineManager(templateConfig);
   tem.config = Object.assign({}, config);
   tem.config.extensionMap.add({
     extension: "txt",
@@ -38,7 +45,7 @@ test("Supported custom engine", async (t) => {
 test("Custom engine with custom init", async (t) => {
   let initCount = 0;
   let compileCount = 0;
-  let tem = new TemplateEngineManager();
+  let tem = new TemplateEngineManager(templateConfig);
   tem.config = Object.assign({}, config);
   tem.config.extensionMap.add({
     extension: "custom1",
@@ -69,7 +76,7 @@ test("Custom engine with custom init", async (t) => {
 });
 
 test("Handlebars Helpers", async (t) => {
-  let tem = new TemplateEngineManager();
+  let tem = new TemplateEngineManager(templateConfig);
   let engine = tem.getEngine("hbs");
   engine.addHelpers({
     uppercase: function (name) {
@@ -82,6 +89,6 @@ test("Handlebars Helpers", async (t) => {
 });
 
 test("getEngineLib", async (t) => {
-  let tem = new TemplateEngineManager();
+  let tem = new TemplateEngineManager(templateConfig);
   t.truthy(tem.getEngine("md").getEngineLib());
 });

--- a/test/TemplateEngineTest.js
+++ b/test/TemplateEngineTest.js
@@ -1,10 +1,19 @@
 const test = require("ava");
 const TemplateEngine = require("../src/Engines/TemplateEngine");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 test("Unsupported engine", async (t) => {
-  t.is(new TemplateEngine("doesnotexist").getName(), "doesnotexist");
+  t.is(
+    new TemplateEngine("doesnotexist", null, templateConfig).getName(),
+    "doesnotexist"
+  );
 });
 
 test("Supported engine", async (t) => {
-  t.is(new TemplateEngine("ejs").getName(), "ejs");
+  t.is(new TemplateEngine("ejs", null, templateConfig).getName(), "ejs");
 });

--- a/test/TemplateFileSlugTest.js
+++ b/test/TemplateFileSlugTest.js
@@ -1,9 +1,15 @@
 const test = require("ava");
 const TemplateFileSlug = require("../src/TemplateFileSlug");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewSlugInstance(path, inputDir) {
-  let extensionMap = new EleventyExtensionMap();
+  let extensionMap = new EleventyExtensionMap([], templateConfig);
   let fs = new TemplateFileSlug(path, inputDir, extensionMap);
   return fs;
 }

--- a/test/TemplateLayoutPathResolverTest.js
+++ b/test/TemplateLayoutPathResolverTest.js
@@ -1,23 +1,32 @@
 const test = require("ava");
 const TemplateLayoutPathResolver = require("../src/TemplateLayoutPathResolver");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getResolverInstance(path, inputDir, map) {
   if (!map) {
-    map = new EleventyExtensionMap([
-      "liquid",
-      "ejs",
-      "md",
-      "hbs",
-      "mustache",
-      "haml",
-      "pug",
-      "njk",
-      "html",
-      "11ty.js",
-    ]);
+    map = new EleventyExtensionMap(
+      [
+        "liquid",
+        "ejs",
+        "md",
+        "hbs",
+        "mustache",
+        "haml",
+        "pug",
+        "njk",
+        "html",
+        "11ty.js",
+      ],
+      templateConfig
+    );
   }
-  return new TemplateLayoutPathResolver(path, inputDir, map);
+  return new TemplateLayoutPathResolver(path, inputDir, map, templateConfig);
 }
 
 test("Layout", (t) => {

--- a/test/TemplateLayoutTest.js
+++ b/test/TemplateLayoutTest.js
@@ -1,23 +1,32 @@
 const test = require("ava");
 const TemplateLayout = require("../src/TemplateLayout");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getTemplateLayoutInstance(key, inputDir, map) {
   if (!map) {
-    map = new EleventyExtensionMap([
-      "liquid",
-      "ejs",
-      "md",
-      "hbs",
-      "mustache",
-      "haml",
-      "pug",
-      "njk",
-      "html",
-      "11ty.js",
-    ]);
+    map = new EleventyExtensionMap(
+      [
+        "liquid",
+        "ejs",
+        "md",
+        "hbs",
+        "mustache",
+        "haml",
+        "pug",
+        "njk",
+        "html",
+        "11ty.js",
+      ],
+      templateConfig
+    );
   }
-  let layout = new TemplateLayout(key, inputDir, map);
+  let layout = new TemplateLayout(key, inputDir, map, templateConfig);
   return layout;
 }
 

--- a/test/TemplateMapTest-ComputedData.js
+++ b/test/TemplateMapTest-ComputedData.js
@@ -1,13 +1,27 @@
 const test = require("ava");
-const Template = require("../src/Template");
 const TemplateData = require("../src/TemplateData");
+const Template = require("../src/Template");
 const TemplateMap = require("../src/TemplateMap");
-const getNewTemplate = require("./_getNewTemplateForTests");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
+
+const getNewTemplate = (...args) => {
+  // monkey patching to add templateConfig to the end of every call
+  args = args.concat(Array(5).fill(null)).slice(0, 5).concat(templateConfig);
+  return new Template(...args);
+};
 
 test("Computed data can see tag generated collections", async (t) => {
   let tm = new TemplateMap();
 
-  let dataObj = new TemplateData("./test/stubs-computed-collections/");
+  let dataObj = new TemplateData(
+    "./test/stubs-computed-collections/",
+    templateConfig
+  );
   let tmpl = getNewTemplate(
     "./test/stubs-computed-collections/collections.njk",
     "./test/stubs-computed-collections/",
@@ -17,7 +31,10 @@ test("Computed data can see tag generated collections", async (t) => {
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-collections/");
+  let dataObj2 = new TemplateData(
+    "./test/stubs-computed-collections/",
+    templateConfig
+  );
   let tmpl2 = getNewTemplate(
     "./test/stubs-computed-collections/dog.njk",
     "./test/stubs-computed-collections/",
@@ -48,7 +65,10 @@ test("Computed data can see tag generated collections", async (t) => {
 test("Computed data can see paginated data, Issue #1138", async (t) => {
   let tm = new TemplateMap();
 
-  let dataObj = new TemplateData("./test/stubs-computed-pagination/");
+  let dataObj = new TemplateData(
+    "./test/stubs-computed-pagination/",
+    templateConfig
+  );
   let tmpl = getNewTemplate(
     "./test/stubs-computed-pagination/paginated.njk",
     "./test/stubs-computed-pagination/",
@@ -58,7 +78,10 @@ test("Computed data can see paginated data, Issue #1138", async (t) => {
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-pagination/");
+  let dataObj2 = new TemplateData(
+    "./test/stubs-computed-pagination/",
+    templateConfig
+  );
   let tmpl2 = getNewTemplate(
     "./test/stubs-computed-pagination/child.11ty.js",
     "./test/stubs-computed-pagination/",
@@ -101,7 +124,10 @@ test("Computed data can see paginated data, Issue #1138", async (t) => {
 test("Computed data in directory data file consumes data file data, Issue #1137", async (t) => {
   let tm = new TemplateMap();
 
-  let dataObj = new TemplateData("./test/stubs-computed-dirdata/");
+  let dataObj = new TemplateData(
+    "./test/stubs-computed-dirdata/",
+    templateConfig
+  );
   let tmpl = getNewTemplate(
     "./test/stubs-computed-dirdata/dir/first.11ty.js",
     "./test/stubs-computed-dirdata/",
@@ -111,7 +137,10 @@ test("Computed data in directory data file consumes data file data, Issue #1137"
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-dirdata/");
+  let dataObj2 = new TemplateData(
+    "./test/stubs-computed-dirdata/",
+    templateConfig
+  );
   let tmpl2 = getNewTemplate(
     "./test/stubs-computed-dirdata/dir/second.11ty.js",
     "./test/stubs-computed-dirdata/",
@@ -133,7 +162,10 @@ test("Computed data in directory data file consumes data file data, Issue #1137"
 test("Computed data can filter collections (and other array methods)", async (t) => {
   let tm = new TemplateMap();
 
-  let dataObj = new TemplateData("./test/stubs-computed-collections-filter/");
+  let dataObj = new TemplateData(
+    "./test/stubs-computed-collections-filter/",
+    templateConfig
+  );
   let tmpl = getNewTemplate(
     "./test/stubs-computed-collections-filter/collections.njk",
     "./test/stubs-computed-collections-filter/",
@@ -143,7 +175,10 @@ test("Computed data can filter collections (and other array methods)", async (t)
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-collections-filter/");
+  let dataObj2 = new TemplateData(
+    "./test/stubs-computed-collections-filter/",
+    templateConfig
+  );
   let tmpl2 = getNewTemplate(
     "./test/stubs-computed-collections-filter/dog.njk",
     "./test/stubs-computed-collections-filter/",

--- a/test/TemplateMapTest.js
+++ b/test/TemplateMapTest.js
@@ -4,27 +4,40 @@ const TemplateMap = require("../src/TemplateMap");
 const TemplateCollection = require("../src/TemplateCollection");
 const UsingCircularTemplateContentReferenceError = require("../src/Errors/UsingCircularTemplateContentReferenceError");
 const normalizeNewLines = require("./Util/normalizeNewLines");
+const templateConfig = require("../src/Config");
 
-let tmpl1 = new Template(
-  "./test/stubs/templateMapCollection/test1.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl2 = new Template(
-  "./test/stubs/templateMapCollection/test2.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl4 = new Template(
-  "./test/stubs/templateMapCollection/test4.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
-let tmpl5 = new Template(
-  "./test/stubs/templateMapCollection/test5.md",
-  "./test/stubs/",
-  "./test/stubs/_site"
-);
+const getNewTemplate = (...args) => {
+  // monkey patching to add templateConfig to the end of every call
+  args = args.concat(Array(5).fill(null)).slice(0, 5).concat(templateConfig);
+  return new Template(...args);
+};
+
+let tmpl1, tmpl2, tmpl4, tmpl5;
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+
+  tmpl1 = getNewTemplate(
+    "./test/stubs/templateMapCollection/test1.md",
+    "./test/stubs/",
+    "./test/stubs/_site"
+  );
+  tmpl2 = getNewTemplate(
+    "./test/stubs/templateMapCollection/test2.md",
+    "./test/stubs/",
+    "./test/stubs/_site"
+  );
+  tmpl4 = getNewTemplate(
+    "./test/stubs/templateMapCollection/test4.md",
+    "./test/stubs/",
+    "./test/stubs/_site"
+  );
+  tmpl5 = getNewTemplate(
+    "./test/stubs/templateMapCollection/test5.md",
+    "./test/stubs/",
+    "./test/stubs/_site"
+  );
+});
 
 test("TemplateMap has collections added", async (t) => {
   let tm = new TemplateMap();
@@ -102,7 +115,7 @@ test("TemplateMap adds collections data and has templateContent values", async (
 test("TemplateMap circular references (map without templateContent)", async (t) => {
   let tm = new TemplateMap();
   await tm.add(
-    new Template(
+    getNewTemplate(
       "./test/stubs/templateMapCollection/test3.md",
       "./test/stubs/",
       "./test/stubs/_site"
@@ -126,7 +139,7 @@ test("TemplateMap circular references (map without templateContent)", async (t) 
 test("TemplateMap circular references (map.templateContent)", async (t) => {
   let tm = new TemplateMap();
   await tm.add(
-    new Template(
+    getNewTemplate(
       "./test/stubs/templateMapCollection/templateContent.md",
       "./test/stubs/",
       "./test/stubs/_site"
@@ -147,17 +160,17 @@ test("TemplateMap circular references (map.templateContent)", async (t) => {
 });
 
 test("Issue #115, mixing pagination and collections", async (t) => {
-  let tmplFoos = new Template(
+  let tmplFoos = getNewTemplate(
     "./test/stubs/issue-115/template-foos.liquid",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmplBars = new Template(
+  let tmplBars = getNewTemplate(
     "./test/stubs/issue-115/template-bars.liquid",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmplIndex = new Template(
+  let tmplIndex = getNewTemplate(
     "./test/stubs/issue-115/index.liquid",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -208,17 +221,17 @@ This page is bars
 });
 
 test("Issue #115 with layout, mixing pagination and collections", async (t) => {
-  let tmplFoos = new Template(
+  let tmplFoos = getNewTemplate(
     "./test/stubs/issue-115/template-foos.liquid",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmplBars = new Template(
+  let tmplBars = getNewTemplate(
     "./test/stubs/issue-115/template-bars.liquid",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmplIndex = new Template(
+  let tmplIndex = getNewTemplate(
     "./test/stubs/issue-115/index-with-layout.liquid",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -372,7 +385,7 @@ test("Should be able to paginate a tag generated collection", async (t) => {
   await tm.add(tmpl1);
   await tm.add(tmpl2);
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-tag.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -389,7 +402,7 @@ test("Should be able to paginate a user config collection", async (t) => {
   await tm.add(tmpl1);
   await tm.add(tmpl2);
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-cfg.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -413,7 +426,7 @@ test("Should be able to paginate a user config collection (uses rendered permali
   await tm.add(tmpl1);
   await tm.add(tmpl2);
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-cfg-permalink.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -449,7 +462,7 @@ test("Should be able to paginate a user config collection (paged template is als
   await tm.add(tmpl2); // does not have dog tag
   await tm.add(tmpl4); // has dog tag
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-cfg-tagged.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -477,7 +490,7 @@ test("Should be able to paginate a user config collection (paged template is als
   await tm.add(tmpl2); // does not have dog tag
   await tm.add(tmpl4); // has dog tag
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-cfg-tagged-apply-to-all.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -512,7 +525,7 @@ test("Should be able to paginate a user config collection (paged template is als
   await tm.add(tmpl2); // does not have dog tag
   await tm.add(tmpl4); // has dog tag
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-cfg-tagged-permalink.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -538,7 +551,7 @@ test("Should be able to paginate a user config collection (paged template is als
   await tm.add(tmpl2); // does not have dog tag
   await tm.add(tmpl4); // has dog tag
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-cfg-tagged-permalink-apply-to-all.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -561,7 +574,7 @@ test("Should be able to paginate a user config collection (paged template is als
 
 test("TemplateMap render and templateContent are the same (templateContent doesn’t have layout but makes proper use of layout front matter data)", async (t) => {
   let tm = new TemplateMap();
-  let tmplLayout = new Template(
+  let tmplLayout = getNewTemplate(
     "./test/stubs/templateMapCollection/testWithLayout.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -581,7 +594,7 @@ test("Should be able to paginate a tag generated collection (and it has template
   await tm.add(tmpl2); // does not have dog tag
   await tm.add(tmpl4); // has dog tag
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-tag-dogs-templateContent.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -621,7 +634,7 @@ test("Should be able to paginate a tag generated collection when aliased (and it
   await tm.add(tmpl2); // does not have dog tag
   await tm.add(tmpl4); // has dog tag
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/templateMapCollection/paged-tag-dogs-templateContent-alias.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -655,7 +668,7 @@ test("Issue #253: Paginated template with a tag should put multiple pages into a
   await tm.add(tmpl2);
   await tm.add(tmpl4);
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/tagged-pagination-multiples/test.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -751,7 +764,7 @@ test("Dependency Map should have include orphan user config collections (in the 
 
 test("Template pages should not have layouts when added to collections", async (t) => {
   let tm = new TemplateMap();
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/collection-layout-wrap.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -767,7 +780,7 @@ test("Template pages should not have layouts when added to collections", async (
 test("Paginated template pages should not have layouts when added to collections", async (t) => {
   let tm = new TemplateMap();
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/tagged-pagination-multiples-layout/test.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -785,7 +798,7 @@ test("Paginated template pages should not have layouts when added to collections
 test("Tag pages. Allow pagination over all collections a la `data: collections`", async (t) => {
   let tm = new TemplateMap();
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/page-target-collections/tagpages.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -812,7 +825,7 @@ test("Tag pages. Allow pagination over all collections a la `data: collections`"
 test("Tag pages (all pages added to collections). Allow pagination over all collections a la `data: collections`", async (t) => {
   let tm = new TemplateMap();
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/page-target-collections/tagpagesall.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -843,7 +856,7 @@ test("eleventyExcludeFromCollections", async (t) => {
   let tm = new TemplateMap();
   await tm.add(tmpl1);
 
-  let excludedTmpl = new Template(
+  let excludedTmpl = getNewTemplate(
     "./test/stubs/eleventyExcludeFromCollections.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -863,7 +876,7 @@ test("eleventyExcludeFromCollections", async (t) => {
 test("Paginate over collections.all", async (t) => {
   let tm = new TemplateMap();
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/page-target-collections/paginateall.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -916,12 +929,12 @@ test("Paginate over collections.all", async (t) => {
 test("Paginate over collections.all WITH a paginate over collections (tag pages)", async (t) => {
   let tm = new TemplateMap();
 
-  let pagedTmpl = new Template(
+  let pagedTmpl = getNewTemplate(
     "./test/stubs/page-target-collections/paginateall.njk",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tagPagesTmpl = new Template(
+  let tagPagesTmpl = getNewTemplate(
     "./test/stubs/page-target-collections/tagpagesall.njk",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -939,7 +952,7 @@ test("Paginate over collections.all WITH a paginate over collections (tag pages)
 test("Test a transform with a layout (via templateMap)", async (t) => {
   t.plan(7);
   let tm = new TemplateMap();
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs-475/transform-layout/transform-layout.njk",
     "./test/stubs-475/",
     "./test/stubs-475/_site"
@@ -993,12 +1006,12 @@ test("Async user collection addCollection method", async (t) => {
 });
 
 test("Duplicate permalinks in template map", async (t) => {
-  let tmpl1 = new Template(
+  let tmpl1 = getNewTemplate(
     "./test/stubs/permalink-conflicts/test1.md",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmpl2 = new Template(
+  let tmpl2 = getNewTemplate(
     "./test/stubs/permalink-conflicts/test2.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -1013,12 +1026,12 @@ test("Duplicate permalinks in template map", async (t) => {
 });
 
 test("No duplicate permalinks in template map, using false", async (t) => {
-  let tmpl1 = new Template(
+  let tmpl1 = getNewTemplate(
     "./test/stubs/permalink-conflicts-false/test1.md",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmpl2 = new Template(
+  let tmpl2 = getNewTemplate(
     "./test/stubs/permalink-conflicts-false/test2.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -1032,12 +1045,12 @@ test("No duplicate permalinks in template map, using false", async (t) => {
 });
 
 test("Duplicate permalinks in template map, no leading slash", async (t) => {
-  let tmpl1 = new Template(
+  let tmpl1 = getNewTemplate(
     "./test/stubs/permalink-conflicts/test1.md",
     "./test/stubs/",
     "./test/stubs/_site"
   );
-  let tmpl3 = new Template(
+  let tmpl3 = getNewTemplate(
     "./test/stubs/permalink-conflicts/test3.md",
     "./test/stubs/",
     "./test/stubs/_site"
@@ -1055,7 +1068,7 @@ test("Duplicate permalinks in template map, no leading slash", async (t) => {
 test("TemplateMap circular references (map.templateContent) using eleventyExcludeFromCollections and collections.all", async (t) => {
   let tm = new TemplateMap();
   await tm.add(
-    new Template(
+    getNewTemplate(
       "./test/stubs/issue-522/excluded.md",
       "./test/stubs/",
       "./test/stubs/_site"
@@ -1063,7 +1076,7 @@ test("TemplateMap circular references (map.templateContent) using eleventyExclud
   );
 
   await tm.add(
-    new Template(
+    getNewTemplate(
       "./test/stubs/issue-522/template.md",
       "./test/stubs/",
       "./test/stubs/_site"

--- a/test/TemplatePassthroughManagerTest.js
+++ b/test/TemplatePassthroughManagerTest.js
@@ -1,9 +1,15 @@
 const test = require("ava");
 const fs = require("fs-extra");
 const TemplatePassthroughManager = require("../src/TemplatePassthroughManager");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 test("Get paths from Config", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
     passthroughCopies: {
@@ -15,7 +21,7 @@ test("Get paths from Config", async (t) => {
 });
 
 test("isPassthroughCopyFile", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
     passthroughCopies: {
@@ -37,7 +43,7 @@ test("isPassthroughCopyFile", async (t) => {
 });
 
 test("Empty config paths when disabled in config", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: false,
     passthroughCopies: {
@@ -49,7 +55,7 @@ test("Empty config paths when disabled in config", async (t) => {
 });
 
 test("Get glob paths from config", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
     passthroughCopies: {
@@ -67,7 +73,7 @@ test("Get glob paths from config", async (t) => {
 });
 
 test("Get file paths", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
   });
@@ -76,7 +82,7 @@ test("Get file paths", async (t) => {
 });
 
 test("Get file paths (filter out real templates)", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
   });
@@ -85,7 +91,7 @@ test("Get file paths (filter out real templates)", async (t) => {
 });
 
 test("Get file paths (filter out real templates), multiple", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
   });
@@ -94,7 +100,7 @@ test("Get file paths (filter out real templates), multiple", async (t) => {
 });
 
 test("Get file paths with a js file (filter out real templates), multiple", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
   });
@@ -103,7 +109,7 @@ test("Get file paths with a js file (filter out real templates), multiple", asyn
 });
 
 test("Get file paths when disabled in config", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: false,
   });
@@ -112,7 +118,7 @@ test("Get file paths when disabled in config", async (t) => {
 });
 
 test("Naughty paths outside of project dir", async (t) => {
-  let mgr = new TemplatePassthroughManager();
+  let mgr = new TemplatePassthroughManager(templateConfig);
   mgr.setConfig({
     passthroughFileCopy: true,
     passthroughCopies: {

--- a/test/TemplateRenderCustomTest.js
+++ b/test/TemplateRenderCustomTest.js
@@ -1,20 +1,27 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
-const templateConfig = require("../src/Config");
 const Vue = require("vue");
 const renderer = require("vue-server-renderer").createRenderer();
+const templateConfig = require("../src/Config");
+
+let config = {};
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+  config = templateConfig.getConfig();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 
 test("Custom plaintext Render", async (t) => {
   let tr = getNewTemplateRender("txt");
 
-  const config = templateConfig.getConfig();
   tr.config = Object.assign({}, config);
   tr.config.extensionMap.add({
     extension: "txt",
@@ -35,7 +42,6 @@ test("Custom plaintext Render", async (t) => {
 test("Custom Vue Render", async (t) => {
   let tr = getNewTemplateRender("vue");
 
-  const config = templateConfig.getConfig();
   tr.config = Object.assign({}, config);
   tr.config.extensionMap.add({
     extension: "vue",
@@ -60,7 +66,6 @@ test("Custom Sass Render", async (t) => {
   const sass = require("node-sass");
   let tr = getNewTemplateRender("sass");
 
-  const config = templateConfig.getConfig();
   tr.config = Object.assign({}, config);
   tr.config.extensionMap.add({
     extension: "sass",

--- a/test/TemplateRenderEJSTest.js
+++ b/test/TemplateRenderEJSTest.js
@@ -1,10 +1,16 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 

--- a/test/TemplateRenderHTMLTest.js
+++ b/test/TemplateRenderHTMLTest.js
@@ -1,13 +1,18 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
-
 // HTML
 test("HTML", (t) => {
   t.is(getNewTemplateRender("html").getEngineName(), "html");

--- a/test/TemplateRenderHamlTest.js
+++ b/test/TemplateRenderHamlTest.js
@@ -1,13 +1,18 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
-
 // Haml
 test("Haml", (t) => {
   t.is(getNewTemplateRender("haml").getEngineName(), "haml");

--- a/test/TemplateRenderHandlebarsTest.js
+++ b/test/TemplateRenderHandlebarsTest.js
@@ -1,13 +1,18 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
-
 // Handlebars
 test("Handlebars", (t) => {
   t.is(getNewTemplateRender("hbs").getEngineName(), "hbs");
@@ -313,7 +318,11 @@ test("Handlebars Render Raw Output (Issue #436 with if statement)", async (t) =>
 });
 
 test("Handlebars Render #each with Global Variable (Issue #759)", async (t) => {
-  let fn = await new TemplateRender("hbs", "./test/stubs/").getCompiledTemplate(
+  let fn = await new TemplateRender(
+    "hbs",
+    "./test/stubs/",
+    templateConfig
+  ).getCompiledTemplate(
     `<ul>{{#each navigation as |navItem|}}<li><a href={{navItem.link}}>{{../name}}{{navItem.text}}</a></li>{{/each}}</ul>`
   );
   t.is(

--- a/test/TemplateRenderJavaScriptTest.js
+++ b/test/TemplateRenderJavaScriptTest.js
@@ -1,10 +1,16 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 
@@ -14,9 +20,16 @@ test("JS", (t) => {
     getNewTemplateRender("./test/stubs/filename.11ty.js").getEngineName(),
     "11ty.js"
   );
-  t.is(new TemplateRender("11ty.cjs").getEngineName(), "11ty.js");
   t.is(
-    new TemplateRender("./test/stubs/filename.11ty.cjs").getEngineName(),
+    new TemplateRender("11ty.cjs", null, templateConfig).getEngineName(),
+    "11ty.js"
+  );
+  t.is(
+    new TemplateRender(
+      "./test/stubs/filename.11ty.cjs",
+      null,
+      templateConfig
+    ).getEngineName(),
     "11ty.js"
   );
 });
@@ -213,7 +226,11 @@ test.skip("Issue #934: JS Render with an arrow function and javascript function"
 test("JS Render with a function and async filter", async (t) => {
   t.plan(4);
 
-  let tr = new TemplateRender("./test/stubs/function-async-filter.11ty.js");
+  let tr = new TemplateRender(
+    "./test/stubs/function-async-filter.11ty.js",
+    null,
+    templateConfig
+  );
   tr.config = {
     javascriptFunctions: {
       upper: function (val) {
@@ -291,7 +308,11 @@ test("JS Class Async Render with a function", async (t) => {
 });
 
 test("JS Class Async Render with a function (sync function, throws error)", async (t) => {
-  let tr = new TemplateRender("./test/stubs/function-throws.11ty.js");
+  let tr = new TemplateRender(
+    "./test/stubs/function-throws.11ty.js",
+    null,
+    templateConfig
+  );
   tr.config = {
     javascriptFunctions: {
       upper: function (val) {
@@ -314,7 +335,11 @@ test("JS Class Async Render with a function (sync function, throws error)", asyn
 });
 
 test("JS Class Async Render with a function (async function, throws error)", async (t) => {
-  let tr = new TemplateRender("./test/stubs/function-throws-async.11ty.js");
+  let tr = new TemplateRender(
+    "./test/stubs/function-throws-async.11ty.js",
+    null,
+    templateConfig
+  );
   tr.config = {
     javascriptFunctions: {
       upper: async function (val) {

--- a/test/TemplateRenderMarkdownPluginTest.js
+++ b/test/TemplateRenderMarkdownPluginTest.js
@@ -1,6 +1,12 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const md = require("markdown-it");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 const createTestMarkdownPlugin = () => {
   const plugin = (md) => {
@@ -16,7 +22,7 @@ const createTestMarkdownPlugin = () => {
 };
 
 test("Markdown Render: with HTML prerender, sends context data to the markdown library", async (t) => {
-  let tr = new TemplateRender("md");
+  let tr = new TemplateRender("md", null, templateConfig);
 
   const plugin = createTestMarkdownPlugin();
   let mdLib = md().use(plugin);
@@ -31,7 +37,7 @@ test("Markdown Render: with HTML prerender, sends context data to the markdown l
 });
 
 test("Markdown Render: without HTML prerender, sends context data to the markdown library", async (t) => {
-  let tr = new TemplateRender("md");
+  let tr = new TemplateRender("md", null, templateConfig);
 
   const plugin = createTestMarkdownPlugin();
   let mdLib = md().use(plugin);

--- a/test/TemplateRenderMarkdownTest.js
+++ b/test/TemplateRenderMarkdownTest.js
@@ -145,6 +145,7 @@ test("Markdown Render: use prism highlighter (no language)", async (t) => {
   let tr = getNewTemplateRender("md");
   let userConfig = new UserConfig();
   userConfig.addPlugin(eleventySyntaxHighlightPlugin);
+  await userConfig.applyPlugins();
 
   let markdownHighlight = userConfig.getMergingConfigObject()
     .markdownHighlighter;
@@ -169,6 +170,7 @@ test("Markdown Render: use prism highlighter", async (t) => {
   let tr = getNewTemplateRender("md");
   let userConfig = new UserConfig();
   userConfig.addPlugin(eleventySyntaxHighlightPlugin);
+  await userConfig.applyPlugins();
 
   let markdownHighlight = userConfig.getMergingConfigObject()
     .markdownHighlighter;
@@ -192,6 +194,7 @@ test("Markdown Render: use prism highlighter (no space before language)", async 
   let tr = getNewTemplateRender("md");
   let userConfig = new UserConfig();
   userConfig.addPlugin(eleventySyntaxHighlightPlugin);
+  await userConfig.applyPlugins();
 
   let markdownHighlight = userConfig.getMergingConfigObject()
     .markdownHighlighter;
@@ -215,6 +218,7 @@ test("Markdown Render: use prism highlighter, line highlighting", async (t) => {
   let tr = getNewTemplateRender("md");
   let userConfig = new UserConfig();
   userConfig.addPlugin(eleventySyntaxHighlightPlugin);
+  await userConfig.applyPlugins();
 
   let markdownHighlight = userConfig.getMergingConfigObject()
     .markdownHighlighter;
@@ -238,6 +242,7 @@ test("Markdown Render: use prism highlighter, line highlighting with fallback `t
   let tr = getNewTemplateRender("md");
   let userConfig = new UserConfig();
   userConfig.addPlugin(eleventySyntaxHighlightPlugin);
+  await userConfig.applyPlugins();
 
   let markdownHighlight = userConfig.getMergingConfigObject()
     .markdownHighlighter;
@@ -251,6 +256,7 @@ test("Markdown Render: use prism highlighter, line highlighting with fallback `t
   let fn = await tr.getCompiledTemplate(`\`\`\` text/0
 var key = "value";
 \`\`\``);
+
   t.is(
     (await fn()).trim(),
     `<pre class="language-text"><code class="language-text"><mark class="highlight-line highlight-line-active">var key = "value";</mark></code></pre>`

--- a/test/TemplateRenderMarkdownTest.js
+++ b/test/TemplateRenderMarkdownTest.js
@@ -5,10 +5,16 @@ const md = require("markdown-it");
 const mdEmoji = require("markdown-it-emoji");
 const UserConfig = require("../src/UserConfig");
 const eleventySyntaxHighlightPlugin = require("@11ty/eleventy-plugin-syntaxhighlight");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 
@@ -255,7 +261,7 @@ test("Markdown Render: use Markdown inside of a Liquid shortcode (Issue #536)", 
   let tr = getNewTemplateRender("md");
 
   let cls = require("../src/Engines/Liquid");
-  let liquidEngine = new cls("liquid", tr.getIncludesDir());
+  let liquidEngine = new cls("liquid", tr.getIncludesDir(), templateConfig);
   liquidEngine.addShortcode("testShortcode", function () {
     return "## My Other Title";
   });
@@ -279,7 +285,7 @@ test("Markdown Render: use Markdown inside of a Nunjucks shortcode (Issue #536)"
   let tr = getNewTemplateRender("md");
 
   let cls = require("../src/Engines/Nunjucks");
-  let nunjucksEngine = new cls("njk", tr.getIncludesDir());
+  let nunjucksEngine = new cls("njk", tr.getIncludesDir(), templateConfig);
   nunjucksEngine.addShortcode("testShortcode", function () {
     return "## My Other Title";
   });
@@ -303,7 +309,7 @@ test("Markdown Render: use Markdown inside of a Liquid paired shortcode (Issue #
   let tr = getNewTemplateRender("md");
 
   let cls = require("../src/Engines/Liquid");
-  let liquidEngine = new cls("liquid", tr.getIncludesDir());
+  let liquidEngine = new cls("liquid", tr.getIncludesDir(), templateConfig);
   liquidEngine.addPairedShortcode("testShortcode", function (content) {
     return content;
   });
@@ -327,7 +333,7 @@ test("Markdown Render: use Markdown inside of a Nunjucks paired shortcode (Issue
   let tr = getNewTemplateRender("md");
 
   let cls = require("../src/Engines/Nunjucks");
-  let nunjucksEngine = new cls("njk", tr.getIncludesDir());
+  let nunjucksEngine = new cls("njk", tr.getIncludesDir(), templateConfig);
   nunjucksEngine.addPairedShortcode("testShortcode", function (content) {
     return content;
   });

--- a/test/TemplateRenderMustacheTest.js
+++ b/test/TemplateRenderMustacheTest.js
@@ -1,10 +1,16 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 

--- a/test/TemplateRenderPugTest.js
+++ b/test/TemplateRenderPugTest.js
@@ -1,10 +1,16 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 

--- a/test/TemplateRenderTest.js
+++ b/test/TemplateRenderTest.js
@@ -1,10 +1,16 @@
 const test = require("ava");
 const TemplateRender = require("../src/TemplateRender");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function getNewTemplateRender(name, inputDir) {
-  let tr = new TemplateRender(name, inputDir);
-  tr.extensionMap = new EleventyExtensionMap();
+  let tr = new TemplateRender(name, inputDir, templateConfig);
+  tr.extensionMap = new EleventyExtensionMap([], templateConfig);
   return tr;
 }
 

--- a/test/TemplateTest-JavaScript.js
+++ b/test/TemplateTest-JavaScript.js
@@ -1,9 +1,21 @@
 const test = require("ava");
 const Template = require("../src/Template");
 const semver = require("semver");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
+
+const getNewTemplate = (...args) => {
+  // monkey patching to add templateConfig to the end of every call
+  args = args.concat(Array(5).fill(null)).slice(0, 5).concat(templateConfig);
+  return new Template(...args);
+};
 
 test("JavaScript template type (function)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/function.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -18,7 +30,7 @@ test("JavaScript template type (function)", async (t) => {
 });
 
 test("JavaScript template type (class with data getter)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -32,7 +44,7 @@ test("JavaScript template type (class with data getter)", async (t) => {
 });
 
 test("JavaScript template type (class with data method)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-fn.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -47,7 +59,7 @@ test("JavaScript template type (class with data method)", async (t) => {
 
 if (semver.gte(process.version, "12.4.0")) {
   test("JavaScript template type (class fields)", async (t) => {
-    let tmpl = new Template(
+    let tmpl = getNewTemplate(
       "./test/stubs/classfields-data.11ty.js",
       "./test/stubs/",
       "./dist"
@@ -62,7 +74,7 @@ if (semver.gte(process.version, "12.4.0")) {
 }
 
 test("JavaScript template type (class with shorthand data method)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-fn-shorthand.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -76,7 +88,7 @@ test("JavaScript template type (class with shorthand data method)", async (t) =>
 });
 
 test("JavaScript template type (class with async data method)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-async-data-fn.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -90,7 +102,7 @@ test("JavaScript template type (class with async data method)", async (t) => {
 });
 
 test("JavaScript template type (class with data getter and a javascriptFunction)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-filter.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -110,7 +122,7 @@ test("JavaScript template type (class with data getter and a javascriptFunction)
 });
 
 test("JavaScript template type (class with data method and a javascriptFunction)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-fn-filter.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -130,7 +142,7 @@ test("JavaScript template type (class with data method and a javascriptFunction)
 });
 
 test("JavaScript template type (class with data permalink)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-permalink.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -140,7 +152,7 @@ test("JavaScript template type (class with data permalink)", async (t) => {
 });
 
 test("JavaScript template type (class with data permalink using a buffer)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-permalink-buffer.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -150,7 +162,7 @@ test("JavaScript template type (class with data permalink using a buffer)", asyn
 });
 
 test("JavaScript template type (class with data permalink function)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-permalink-fn.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -160,7 +172,7 @@ test("JavaScript template type (class with data permalink function)", async (t) 
 });
 
 test("JavaScript template type (class with data permalink function using a buffer)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-permalink-fn-buffer.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -170,7 +182,7 @@ test("JavaScript template type (class with data permalink function using a buffe
 });
 
 test("JavaScript template type (class with data permalink async function)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-permalink-async-fn.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -180,7 +192,7 @@ test("JavaScript template type (class with data permalink async function)", asyn
 });
 
 test("JavaScript template type (class with data permalink function using a filter)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-permalink-fn-filter.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -193,7 +205,7 @@ test("JavaScript template type (class with data permalink function using a filte
 });
 
 test("JavaScript template type (class with renderData)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-data-renderdata.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -208,7 +220,7 @@ test("JavaScript template type (class with renderData)", async (t) => {
 });
 
 test("JavaScript template type (should use the same class instance for data and render)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/oneinstance.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -223,7 +235,7 @@ test("JavaScript template type (should use the same class instance for data and 
 });
 
 test("JavaScript template type (multiple exports)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/multipleexports.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -235,7 +247,7 @@ test("JavaScript template type (multiple exports)", async (t) => {
 });
 
 test("JavaScript template type (multiple exports, promises)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/multipleexports-promises.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -249,7 +261,7 @@ test("JavaScript template type (multiple exports, promises)", async (t) => {
 });
 
 test("JavaScript template type (object)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/object.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -263,7 +275,7 @@ test("JavaScript template type (object)", async (t) => {
 });
 
 test("JavaScript template type (object, no render method)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/object-norender.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -277,7 +289,7 @@ test("JavaScript template type (object, no render method)", async (t) => {
 });
 
 test("JavaScript template type (class, no render method)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/class-norender.11ty.js",
     "./test/stubs/",
     "./dist"
@@ -290,7 +302,7 @@ test("JavaScript template type (class, no render method)", async (t) => {
   t.is(pages[0].templateContent.trim(), "");
 });
 test("JavaScript template type (data returns a string)", async (t) => {
-  let tmpl = new Template(
+  let tmpl = getNewTemplate(
     "./test/stubs/exports-flatdata.11ty.js",
     "./test/stubs/",
     "./dist"

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -10,19 +10,32 @@ const TemplateWriter = require("../src/TemplateWriter");
 // import Template from "../src/Template";
 const eleventyConfig = require("../src/EleventyConfig");
 const normalizeNewLines = require("./Util/normalizeNewLines");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 // TODO make sure if output is a subdir of input dir that they don’t conflict.
 test("Output is a subdir of input", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/writeTest",
-    "./test/stubs/writeTest/_writeTestSite"
+    "./test/stubs/writeTest/_writeTestSite",
+    [],
+    null,
+    null,
+    templateConfig
   );
   let evf = new EleventyFiles(
     "./test/stubs/writeTest",
     "./test/stubs/writeTest/_writeTestSite",
-    ["ejs", "md"]
+    ["ejs", "md"],
+    null,
+    templateConfig
   );
   evf.init();
+  tw.setEleventyFiles(evf);
 
   let files = await fastglob(evf.getFileGlobs());
   t.is(evf.getRawFiles().length, 2);
@@ -40,7 +53,10 @@ test("_createTemplateMap", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/writeTest",
     "./test/stubs/_writeTestSite",
-    ["ejs", "md"]
+    ["ejs", "md"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -58,7 +74,10 @@ test("_createTemplateMap (no leading dot slash)", async (t) => {
   let tw = new TemplateWriter(
     "test/stubs/writeTest",
     "test/stubs/_writeTestSite",
-    ["ejs", "md"]
+    ["ejs", "md"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -67,9 +86,14 @@ test("_createTemplateMap (no leading dot slash)", async (t) => {
 });
 
 test("_testGetCollectionsData", async (t) => {
-  let tw = new TemplateWriter("./test/stubs/collection", "./test/stubs/_site", [
-    "md",
-  ]);
+  let tw = new TemplateWriter(
+    "./test/stubs/collection",
+    "./test/stubs/_site",
+    ["md"],
+    null,
+    null,
+    templateConfig
+  );
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -81,9 +105,14 @@ test("_testGetCollectionsData", async (t) => {
 
 // TODO remove this (used by other test things)
 test("_testGetAllTags", async (t) => {
-  let tw = new TemplateWriter("./test/stubs/collection", "./test/stubs/_site", [
-    "md",
-  ]);
+  let tw = new TemplateWriter(
+    "./test/stubs/collection",
+    "./test/stubs/_site",
+    ["md"],
+    null,
+    null,
+    templateConfig
+  );
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -93,9 +122,14 @@ test("_testGetAllTags", async (t) => {
 });
 
 test("Collection of files sorted by date", async (t) => {
-  let tw = new TemplateWriter("./test/stubs/dates", "./test/stubs/_site", [
-    "md",
-  ]);
+  let tw = new TemplateWriter(
+    "./test/stubs/dates",
+    "./test/stubs/_site",
+    ["md"],
+    null,
+    null,
+    templateConfig
+  );
 
   let paths = await tw._getAllPaths();
   let templateMap = await tw._createTemplateMap(paths);
@@ -107,7 +141,10 @@ test("__testGetCollectionsData with custom collection (ascending)", async (t) =>
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
     "./test/stubs/_site",
-    ["md"]
+    ["md"],
+    null,
+    null,
+    templateConfig
   );
 
   /* Careful here, eleventyConfig is a global */
@@ -129,7 +166,10 @@ test("__testGetCollectionsData with custom collection (descending)", async (t) =
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
     "./test/stubs/_site",
-    ["md"]
+    ["md"],
+    null,
+    null,
+    templateConfig
   );
 
   /* Careful here, eleventyConfig is a global */
@@ -151,7 +191,10 @@ test("__testGetCollectionsData with custom collection (filter only to markdown i
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
     "./test/stubs/_site",
-    ["md"]
+    ["md"],
+    null,
+    null,
+    templateConfig
   );
 
   /* Careful here, eleventyConfig is a global */
@@ -174,7 +217,10 @@ test("Pagination with a Collection", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/paged/collection",
     "./test/stubs/_site",
-    ["njk"]
+    ["njk"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -204,7 +250,10 @@ test("Pagination with a Collection from another Paged Template", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/paged/cfg-collection-tag-cfg-collection",
     "./test/stubs/_site",
-    ["njk"]
+    ["njk"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -237,7 +286,10 @@ test("Pagination with a Collection (apply all pages to collections)", async (t) 
   let tw = new TemplateWriter(
     "./test/stubs/paged/collection-apply-to-all",
     "./test/stubs/_site",
-    ["njk"]
+    ["njk"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -288,7 +340,10 @@ test("Use a collection inside of a template", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/collection-template",
     "./test/stubs/collection-template/_site",
-    ["ejs"]
+    ["ejs"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -330,7 +385,10 @@ test("Use a collection inside of a layout", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/collection-layout",
     "./test/stubs/collection-layout/_site",
-    ["ejs"]
+    ["ejs"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -365,8 +423,16 @@ Layout 1 dog`
   );
 });
 
-test("Glob Watcher Files with Passthroughs", (t) => {
-  let tw = new TemplateWriter("test/stubs", "test/stubs/_site", ["njk", "png"]);
+test("Glob Watcher Files with Passthroughs", async (t) => {
+  let tw = new TemplateWriter(
+    "test/stubs",
+    "test/stubs/_site",
+    ["njk", "png"],
+    null,
+    null,
+    templateConfig
+  );
+
   t.deepEqual(tw.eleventyFiles.passthroughGlobs, ["./test/stubs/**/*.png"]);
 });
 
@@ -374,7 +440,10 @@ test("Pagination and TemplateContent", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/pagination-templatecontent",
     "./test/stubs/pagination-templatecontent/_site",
-    ["njk", "md"]
+    ["njk", "md"],
+    null,
+    null,
+    templateConfig
   );
 
   tw.setVerboseOutput(false);
@@ -397,7 +466,10 @@ test("Custom collection returns array", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
     "./test/stubs/_site",
-    ["md"]
+    ["md"],
+    null,
+    null,
+    templateConfig
   );
 
   /* Careful here, eleventyConfig is a global */
@@ -419,7 +491,10 @@ test("Custom collection returns a string", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
     "./test/stubs/_site",
-    ["md"]
+    ["md"],
+    null,
+    null,
+    templateConfig
   );
 
   /* Careful here, eleventyConfig is a global */
@@ -437,7 +512,10 @@ test("Custom collection returns an object", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
     "./test/stubs/_site",
-    ["md"]
+    ["md"],
+    null,
+    null,
+    templateConfig
   );
 
   /* Careful here, eleventyConfig is a global */
@@ -455,7 +533,10 @@ test("fileSlug should exist in a collection", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/collection-slug",
     "./test/stubs/collection-slug/_site",
-    ["njk"]
+    ["njk"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -478,7 +559,10 @@ test("renderData should exist and be resolved in a collection (Issue #289)", asy
   let tw = new TemplateWriter(
     "./test/stubs/collection-renderdata",
     "./test/stubs/collection-renderdata/_site",
-    ["njk"]
+    ["njk"],
+    null,
+    null,
+    templateConfig
   );
 
   let paths = await tw._getAllPaths();
@@ -500,14 +584,21 @@ test("renderData should exist and be resolved in a collection (Issue #289)", asy
 test("Write Test 11ty.js", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite"
+    "./test/stubs/_writeTestJSSite",
+    [],
+    null,
+    null,
+    templateConfig
   );
   let evf = new EleventyFiles(
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite",
-    ["11ty.js"]
+    ["11ty.js"],
+    null,
+    templateConfig
   );
   evf.init();
+  tw.setEleventyFiles(evf);
 
   let files = await fastglob(evf.getFileGlobs());
   t.deepEqual(evf.getRawFiles(), [
@@ -549,7 +640,11 @@ test.skip("Markdown with alias", async (t) => {
 
   let tw = new TemplateWriter(
     "./test/stubs/writeTestMarkdown",
-    "./test/stubs/_writeTestMarkdownSite"
+    "./test/stubs/_writeTestMarkdownSite",
+    [],
+    null,
+    null,
+    templateConfig
   );
   tw.setEleventyFiles(evf);
 
@@ -579,7 +674,10 @@ test.skip("JavaScript with alias", async (t) => {
   let evf = new EleventyFiles(
     "./test/stubs/writeTestJS",
     "./test/stubs/_writeTestJSSite",
-    ["11ty.js"]
+    ["11ty.js"],
+    null,
+    null,
+    templateConfig
   );
   evf._setExtensionMap(map);
   evf.init();
@@ -602,7 +700,11 @@ test.skip("JavaScript with alias", async (t) => {
 
   let tw = new TemplateWriter(
     "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite"
+    "./test/stubs/_writeTestJSSite",
+    [],
+    null,
+    null,
+    templateConfig
   );
   tw.setEleventyFiles(evf);
 
@@ -617,7 +719,10 @@ test("Passthrough file output", async (t) => {
   let tw = new TemplateWriter(
     "./test/stubs/template-passthrough/",
     "./test/stubs/template-passthrough/_site",
-    ["njk", "md"]
+    ["njk", "md"],
+    null,
+    null,
+    templateConfig
   );
 
   const mgr = tw.eleventyFiles.getPassthroughManager();
@@ -648,7 +753,7 @@ test("Passthrough file output", async (t) => {
 
   let results = await Promise.all(
     output.map(function (path) {
-      return fs.exists(path);
+      return fs.existsSync(path);
     })
   );
 

--- a/test/UrlTest.js
+++ b/test/UrlTest.js
@@ -1,9 +1,19 @@
 const test = require("ava");
-const url = require("../src/Filters/Url.js");
+const getURLFilter = require("../src/Filters/Url.js");
+const templateConfig = require("../src/Config");
+
+let config = {},
+  url;
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+  config = templateConfig.getConfig();
+  url = getURLFilter(templateConfig);
+});
 
 test("Test url filter without passing in pathPrefix", (t) => {
-  let projectConfig = require("../src/Config").getConfig();
-  t.is(projectConfig.pathPrefix, "/");
+  t.is(config.pathPrefix, "/");
 
   t.is(url("test"), "test");
   t.is(url("/test"), "/test");

--- a/test/UserDataExtensionsTest.js
+++ b/test/UserDataExtensionsTest.js
@@ -1,6 +1,12 @@
 const test = require("ava");
 const TemplateData = require("../src/TemplateData");
 let yaml = require("js-yaml");
+const templateConfig = require("../src/Config");
+
+test.before(async () => {
+  // This runs concurrently with the above
+  await templateConfig.init();
+});
 
 function injectDataExtensions(dataObj) {
   dataObj.config.dataExtensions = new Map([
@@ -10,7 +16,7 @@ function injectDataExtensions(dataObj) {
 }
 
 test("Local data", async (t) => {
-  let dataObj = new TemplateData("./test/stubs-630/");
+  let dataObj = new TemplateData("./test/stubs-630/", templateConfig);
   injectDataExtensions(dataObj);
   dataObj.setDataTemplateEngine("liquid");
 
@@ -39,7 +45,7 @@ test("Local data", async (t) => {
 });
 
 test("Local files", async (t) => {
-  let dataObj = new TemplateData("./test/stubs-630/");
+  let dataObj = new TemplateData("./test/stubs-630/", templateConfig);
   injectDataExtensions(dataObj);
   let files = await dataObj.getLocalDataPaths(
     "./test/stubs-630/component-yaml/component.njk"
@@ -73,7 +79,7 @@ test("Local files", async (t) => {
 });
 
 test("Global data", async (t) => {
-  let dataObj = new TemplateData("./test/stubs-630/");
+  let dataObj = new TemplateData("./test/stubs-630/", templateConfig);
   injectDataExtensions(dataObj);
   dataObj.setDataTemplateEngine("liquid");
 
@@ -105,7 +111,7 @@ test("Global data", async (t) => {
 });
 
 test("Global data merging and priority", async (t) => {
-  let dataObj = new TemplateData("./test/stubs-630/");
+  let dataObj = new TemplateData("./test/stubs-630/", templateConfig);
   injectDataExtensions(dataObj);
 
   let data = await dataObj.getData();

--- a/test/_getNewTemplateForTests.js
+++ b/test/_getNewTemplateForTests.js
@@ -6,22 +6,33 @@ module.exports = function getNewTemplate(
   inputDir,
   outputDir,
   templateData = null,
-  map = null
+  map = null,
+  templateConfig
 ) {
   if (!map) {
-    map = new EleventyExtensionMap([
-      "liquid",
-      "ejs",
-      "md",
-      "hbs",
-      "mustache",
-      "haml",
-      "pug",
-      "njk",
-      "html",
-      "11ty.js",
-    ]);
+    map = new EleventyExtensionMap(
+      [
+        "liquid",
+        "ejs",
+        "md",
+        "hbs",
+        "mustache",
+        "haml",
+        "pug",
+        "njk",
+        "html",
+        "11ty.js",
+      ],
+      templateConfig
+    );
   }
-  let tmpl = new Template(path, inputDir, outputDir, templateData, map);
+  let tmpl = new Template(
+    path,
+    inputDir,
+    outputDir,
+    templateData,
+    map,
+    templateConfig
+  );
   return tmpl;
 };

--- a/test/stubs/broken-config.js
+++ b/test/stubs/broken-config.js
@@ -1,7 +1,7 @@
 const missingModule = require("this-is-a-module-that-does-not-exist");
 
-module.exports = function(eleventyConfig) {
-  eleventyConfig.addFilter("cssmin", function(code) {
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addFilter("cssmin", function (code) {
     return missingModule(code);
   });
 


### PR DESCRIPTION
This allows for acync config. Such as: 

```js
module.exports = async (eleventyConfig) => {
   const data = await something();
   eleventyConfig.doSomethingWith(data)
}
```

I know this looks like a HEFTY PR please ignore the number of files changed and look at the types of changes. Significan't changes to the way tests are structure and how `templateConfig` is handled but the changes to the core core are relatively small.

The main changes are to `cmd.js` and the main `Eleventy` class. A number of calls in main 11ty runner are now delayed until after the config has been initialised. Other significant changes include the way plugins are added. These are now also async so they are resisted and resolved when config is run. 

Finally the way the global template config is managed has changed. Previously this could be imported from `src/Config.js` into anywhere and this would work since it is global. Now, since config is async we need to ensure that it is passed explicitly to each classes that uses it after it has been initialised.

Because of this there were also significant changes to tests to ensure that the config has been initialised before tests that depend on it.

There are a few todos including:

- [x] More tests of async config functionality
- [x] Tests to ensure the merging of plugins always occurs in the order added

Throwing this up here for feedback and to test the CI. Since 11ty doesn't ship a lock file I sometimes get differences with the way prism does highlighting.

I think the passing around of `templateConfig` could be improved by adding a base class that sets and manages these global properties. Tests could then override this property for individual classes. Happy to consider these type of suggestions or for future improvement to 11ty in general.