### PR TITLE
Add Node 15 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["10", "12", "14"]
+        node: ["10", "12", "14", "15"]
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 10
   - 12
   - 14
+  - 15
 before_script:
   - npm install
 script: npm run test


### PR DESCRIPTION
Node 15 is now released and [officially supported](https://nodejs.org/en/about/releases/) Node version.