### PR TITLE
Added inputPath as an environment option for markdown engine

### DIFF
--- a/src/Engines/Markdown.js
+++ b/src/Engines/Markdown.js
@@ -71,7 +71,7 @@ class Markdown extends TemplateEngine {
         return async function (data) {
           let fn = await fnReady;
           let preTemplateEngineRender = await fn(data);
-          let finishedRender = mdlib.render(preTemplateEngineRender, data);
+          let finishedRender = mdlib.render(preTemplateEngineRender,{inputPath:inputPath});
           return finishedRender;
         };
       }


### PR DESCRIPTION
Solves #1510

Adding the inputPath to the markdown renderer so markdown it can be referenced by plugins.