### PR TITLE
Cache intermediate NJK template compiles

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -18,6 +18,7 @@ const deleteRequireCache = require("./Util/DeleteRequireCache");
 const config = require("./Config");
 const bench = require("./BenchmarkManager");
 const debug = require("debug")("Eleventy");
+const eventBus = require("./EventBus");
 
 /**
  * @module 11ty/eleventy/Eleventy
@@ -449,7 +450,7 @@ Arguments:
    * @param {String} changedFilePath - File that triggered a re-run (added or modified)
    */
   async _addFileToWatchQueue(changedFilePath) {
-    TemplateContent.deleteCached(changedFilePath);
+    eventBus.emit("resourceModified", changedFilePath);
     this.watchManager.addToPendingQueue(changedFilePath);
   }
 

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -4,6 +4,34 @@ const TemplatePath = require("../TemplatePath");
 const EleventyErrorUtil = require("../EleventyErrorUtil");
 const EleventyBaseError = require("../EleventyBaseError");
 
+/*
+// HACKITYHACKHACKHACKHACK
+*/
+let pathMap = new Map();
+let tc = NunjucksLib.Template.prototype._compile;
+let getKey = (obj) => {
+  return `${obj.path} :: ${obj.tmplStr.length}`;
+};
+NunjucksLib.Template.prototype._compile = function (...args) {
+  if (!this.tmplProps && pathMap.has(getKey(this))) {
+    // console.log(`### cached ${getKey(this)}`);
+    let pathProps = pathMap.get(getKey(this));
+    this.blocks = pathProps.blocks;
+    this.rootRenderFunc = pathProps.rootRenderFunc;
+    this.compiled = true;
+  } else {
+    tc.call(this, ...args);
+    // console.log(`### caching for ${getKey(this)}`);
+    pathMap.set(getKey(this), {
+      blocks: this.blocks,
+      rootRenderFunc: this.rootRenderFunc,
+    });
+  }
+};
+/*
+// END HACKITYHACKHACKHACKHACK
+*/
+
 class EleventyShortcodeError extends EleventyBaseError {}
 
 class Nunjucks extends TemplateEngine {

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -37,7 +37,7 @@ const EleventyBaseError = require("../EleventyBaseError");
   };
 
   let _compile = NunjucksLib.Template.prototype._compile;
-  NunjucksLib.Template.prototype._compile = function (...args) {
+  NunjucksLib.Template.prototype._compile = function _wrap_compile(...args) {
     if (!this.compiled && !this.tmplProps && templateCache.has(getKey(this))) {
       let pathProps = templateCache.get(getKey(this));
       this.blocks = pathProps.blocks;
@@ -54,7 +54,10 @@ const EleventyBaseError = require("../EleventyBaseError");
 
   let extensionIdCounter = 0;
   let addExtension = NunjucksLib.Environment.prototype.addExtension;
-  NunjucksLib.Environment.prototype.addExtension = function (name, ext) {
+  NunjucksLib.Environment.prototype.addExtension = function _wrap_addExtension(
+    name,
+    ext
+  ) {
     ext.__id = extensionIdCounter++;
     return addExtension.call(this, name, ext);
   };
@@ -121,7 +124,6 @@ class Nunjucks extends TemplateEngine {
       );
     }
 
-    // clearCache();
     this.njkEnv.addExtension(name, tagObj);
   }
 
@@ -222,7 +224,6 @@ class Nunjucks extends TemplateEngine {
       };
     }
 
-    // clearCache();
     this.njkEnv.addExtension(shortcodeName, new ShortcodeFunction());
   }
 
@@ -293,7 +294,6 @@ class Nunjucks extends TemplateEngine {
       };
     }
 
-    // clearCache();
     this.njkEnv.addExtension(shortcodeName, new PairedShortcodeFunction());
   }
 

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -12,17 +12,6 @@ const EleventyBaseError = require("../EleventyBaseError");
 (function () {
   let templateCache = new Map();
 
-  let clearAndWrap = (name, obj = NunjucksLib.Environment) => {
-    let orig = obj.prototype[name];
-    obj.prototype[name] = function (...args) {
-      templateCache.clear();
-      return orig.call(this, ...args);
-    };
-  };
-
-  clearAndWrap("addExtension");
-  clearAndWrap("removeExtension");
-
   let getKey = (obj) => {
     return [
       obj.path || obj.tmplStr,
@@ -58,7 +47,9 @@ const EleventyBaseError = require("../EleventyBaseError");
     name,
     ext
   ) {
-    ext.__id = extensionIdCounter++;
+    if (!("__id" in ext)) {
+      ext.__id = extensionIdCounter++;
+    }
     return addExtension.call(this, name, ext);
   };
 })();

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -5,32 +5,76 @@ const EleventyErrorUtil = require("../EleventyErrorUtil");
 const EleventyBaseError = require("../EleventyBaseError");
 
 /*
-// HACKITYHACKHACKHACKHACK
-*/
+ * HACKITYHACKHACKHACKHACK
+ */
+let inc = ((i) => {
+  return () => {
+    return i++;
+  };
+})(0);
 let pathMap = new Map();
-let tc = NunjucksLib.Template.prototype._compile;
-let getKey = (obj) => {
-  return `${obj.path} :: ${obj.tmplStr.length}`;
-};
-NunjucksLib.Template.prototype._compile = function (...args) {
-  if (!this.tmplProps && pathMap.has(getKey(this))) {
-    // console.log(`### cached ${getKey(this)}`);
-    let pathProps = pathMap.get(getKey(this));
-    this.blocks = pathProps.blocks;
-    this.rootRenderFunc = pathProps.rootRenderFunc;
-    this.compiled = true;
-  } else {
-    tc.call(this, ...args);
-    // console.log(`### caching for ${getKey(this)}`);
-    pathMap.set(getKey(this), {
-      blocks: this.blocks,
-      rootRenderFunc: this.rootRenderFunc,
-    });
+
+let clearCache = (reason = "") => {
+  if (pathMap.size > 0) {
+    pathMap.clear();
   }
 };
+
+let clearAndWrap = (name, obj = NunjucksLib.Environment) => {
+  let orig = obj.prototype[name];
+  obj.prototype[name] = function (...args) {
+    clearCache(name);
+    return orig.call(this, ...args);
+  };
+};
+
+clearAndWrap("addExtension");
+clearAndWrap("removeExtension");
+
+(function () {
+  // IFFE to prevent temp var leakage
+  let getKey = (obj) => {
+    let eids = obj.env.extensionsList.reduce((v, c) => {
+      return c.__id ? v + " : " + c.__id : v;
+    }, "");
+    let k =
+      `${obj.path || obj.tmplStr} :: ${obj.tmplStr.length} :: ` +
+      `${obj.env.asyncFilters.length} :: (${eids})`; /* +
+            (
+              (obj.env.extensionsList.length) ? 
+                `${Object.keys(obj.env.extensions).join("|")} :: (${eids})` :
+                ""
+            );
+            */
+    return k;
+  };
+  let tc = NunjucksLib.Template.prototype._compile;
+  NunjucksLib.Template.prototype._compile = function (...args) {
+    // console.log(`NunjucksLib.Template.prototype._compile`);
+    if (!this.compiled && !this.tmplProps && pathMap.has(getKey(this))) {
+      let pathProps = pathMap.get(getKey(this));
+      this.blocks = pathProps.blocks;
+      this.rootRenderFunc = pathProps.rootRenderFunc;
+      this.compiled = true;
+    } else {
+      tc.call(this, ...args);
+      pathMap.set(getKey(this), {
+        blocks: this.blocks,
+        rootRenderFunc: this.rootRenderFunc,
+      });
+    }
+  };
+
+  let ae = NunjucksLib.Environment.prototype.addExtension;
+  NunjucksLib.Environment.prototype.addExtension = function (...args) {
+    let e = args[1];
+    e.__id = inc();
+    return ae.call(this, ...args);
+  };
+})();
 /*
-// END HACKITYHACKHACKHACKHACK
-*/
+ * END HACKITYHACKHACKHACKHACK
+ */
 
 class EleventyShortcodeError extends EleventyBaseError {}
 
@@ -93,6 +137,7 @@ class Nunjucks extends TemplateEngine {
       );
     }
 
+    clearCache("addTag");
     this.njkEnv.addExtension(name, tagObj);
   }
 
@@ -176,7 +221,6 @@ class Nunjucks extends TemplateEngine {
             });
         } else {
           try {
-            // console.log( shortcodeFn.toString() );
             return new NunjucksLib.runtime.SafeString(
               shortcodeFn.call(
                 Nunjucks._normalizeShortcodeContext(context),
@@ -194,6 +238,8 @@ class Nunjucks extends TemplateEngine {
       };
     }
 
+    // Invalidate the caches.
+    clearCache("addShortcode");
     this.njkEnv.addExtension(shortcodeName, new ShortcodeFunction());
   }
 
@@ -264,6 +310,7 @@ class Nunjucks extends TemplateEngine {
       };
     }
 
+    clearCache("addPairedShortcode");
     this.njkEnv.addExtension(shortcodeName, new PairedShortcodeFunction());
   }
 

--- a/src/EventBus.js
+++ b/src/EventBus.js
@@ -1,0 +1,17 @@
+const EventEmitter = require("./Util/AsyncEventEmitter");
+const debug = require("debug")("Eleventy:EventBus");
+
+/**
+ * @module 11ty/eleventy/EventBus
+ */
+
+debug("Setting up global EventBus.");
+/**
+ * Provides a global event bus that modules deep down in the stack can
+ * subscribe to from a global singleton for decoupled pub/sub.
+ * @type * {module:11ty/eleventy/Util/AsyncEventEmitter~AsyncEventEmitter}
+ */
+let bus = new EventEmitter();
+bus.setMaxListeners(100);
+
+module.exports = bus;

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -14,6 +14,7 @@ const config = require("./Config");
 const debug = require("debug")("Eleventy:TemplateContent");
 const debugDev = require("debug")("Dev:Eleventy:TemplateContent");
 const bench = require("./BenchmarkManager").get("Aggregate");
+const eventBus = require("./EventBus");
 
 class TemplateContentFrontMatterError extends EleventyBaseError {}
 class TemplateContentCompileError extends EleventyBaseError {}
@@ -277,5 +278,8 @@ class TemplateContent {
 
 TemplateContent._inputCache = new Map();
 TemplateContent._compileEngineCache = new Map();
+eventBus.on("resourceModified", (path) => {
+  TemplateContent.deleteCached(path);
+});
 
 module.exports = TemplateContent;


### PR DESCRIPTION
*TL;DR:* _this patch speeds up my local 11ty-work-only build steps by ~50%_

I noticed that running 11ty from upstream is much slower than the 0.11.x branch, which surprised me given some of the work I put in earlier this year. I don't have a root cause analysis, but it got annoying so I decided to see if I couldn't speed things up in my local workflow. This patch picks one of the low-hanging fruit I mused at back in May, caching intermediate template compiles after some profiling showed that repeated application of the same templates across many data files was causing NJK compilation to show up as heavy in my local blog project.

The benefits here are NJK specific (sorry, other template engines!) and probably brittle. Feedback on the patch appreciated.

## Before (`11ty/eleventy` HEAD)

```sh
slightlyoff@penguin:~/projects/infrequently$ time (npm run rebuild)

> infrequently.org@ rebuild /home/slightlyoff/projects/infrequently
> unset CACHE_BUST && REBUILD=true npx eleventy

Writing build/feed/feed.xml from ./_posts/feed.njk
...
Writing build/2018/09/the-developer-experience-bait-and-switch/comments.html from ./_posts/2018/09/the-developer-experience-bait-and-switch/comments.md (njk)
Copied 29 files / Wrote 1182 files in 11.76 seconds (9.9ms each, v1.0.0-beta.0)

real    0m13.698s
user    0m15.017s
sys     0m1.503s
```

## After (NJK template caching branch)

```sh
slightlyoff@penguin:~/projects/infrequently$ time (npm run rebuild)

> infrequently.org@ rebuild /home/slightlyoff/projects/infrequently
> unset CACHE_BUST && REBUILD=true npx eleventy

Writing build/feed/feed.xml from ./_posts/feed.njk
...
Writing build/2018/09/the-developer-experience-bait-and-switch/comments.html from ./_posts/2018/09/the-developer-experience-bait-and-switch/comments.md (njk)
Copied 29 files / Wrote 1182 files in 5.13 seconds (4.3ms each, v1.0.0-beta.0)

real    0m7.025s
user    0m7.620s
sys     0m1.228s
```