### PR TITLE
Adds ondemand support for serve mode

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -24,6 +24,7 @@ try {
       "quiet",
       "version",
       "watch",
+      "ondemand",
       "dryrun",
       "help",
       "serve",
@@ -80,6 +81,7 @@ try {
       } else if (argv.help) {
         console.log(elev.getHelp());
       } else if (argv.serve) {
+        elev.setOnDemand(argv.ondemand);
         elev.watch().then(function () {
           elev.serve(argv.port);
         });

--- a/src/Template.js
+++ b/src/Template.js
@@ -653,13 +653,9 @@ class Template extends TemplateContent {
     return content;
   }
 
-  async writeMapEntry(mapEntry) {
-    await Promise.all(
-      mapEntry._pages.map(async (page) => {
-        let content = await this.renderPageEntry(mapEntry, page);
-        return this._write(page.outputPath, content);
-      })
-    );
+  async writePageEntry(mapEntry, page) {
+    let content = await this.renderPageEntry(mapEntry, page);
+    return this._write(page.outputPath, content);
   }
 
   // TODO this but better

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -186,10 +186,12 @@ class TemplateWriter {
   async _writeTemplate(mapEntry) {
     let tmpl = mapEntry.template;
 
-    return tmpl.writeMapEntry(mapEntry).then(() => {
-      this.skippedCount += tmpl.getSkippedCount();
-      this.writeCount += tmpl.getWriteCount();
-    });
+    await Promise.all(
+      mapEntry._pages.map((page) => tmpl.writePageEntry(mapEntry, page))
+    );
+
+    this.skippedCount += tmpl.getSkippedCount();
+    this.writeCount += tmpl.getWriteCount();
   }
 
   async writePassthroughCopy(paths) {


### PR DESCRIPTION
This adds a `--ondemand` flag that, when combined with `--watch`, only builds pages which are requested. (This is basically the idea behind [11ty-fast-dev](https://github.com/samthor/11ty-fast-dev)).

In our testing, this provides ~1.5x speedup on test Eleventy sites during development. If you have costly transforms or filters, it speeds it up even more (this is the case for developer.chrome.com, where we unfortunately do HTML parsing and rewriting as part of this step).

If running your templates (and their filters) or transforms has global side-effects and you reply on that during development, then this probably isn't a good idea.

Cons:
- I'm not entirely sure how well this interacts with incremental build
- You might want this behavior _without_ BrowserSync (in fact, developer.chrome.com probably does, but this feature just makes sense behind `--watch`).