### PR TITLE
Run addCollection callbacks in parallel

### DIFF
--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -275,6 +275,11 @@ class UserConfig {
     return this.collections;
   }
 
+  /**
+   * Add a new user defined collection.
+   * @param {string} name Name of the collection
+   * @param {(collectionsApi: TemplateCollection) => unknown[] | Promise<unknown[]>} callback
+   */
   addCollection(name, callback) {
     name = this.getNamespacedName(name);
 


### PR DESCRIPTION
Optimizing away serial promises. I don't think the callbacks depend on the order, so they can all be run at the same time.