### PR TITLE
Fix addWatchTarget ignored when used in a custom config file

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -93,7 +93,6 @@ class Eleventy {
 
     /** @member {Object} - tbd. */
     this.watchTargets = new EleventyWatchTargets();
-    this.watchTargets.addAndMakeGlob(this.config.additionalWatchTargets);
     this.watchTargets.watchJavaScriptDependencies = this.config.watchJavaScriptDependencies;
   }
 
@@ -560,6 +559,8 @@ Arguments:
   async initWatch() {
     this.watchManager = new EleventyWatch();
     this.watchManager.incremental = this.isIncremental;
+
+    this.watchTargets.addAndMakeGlob(this.config.additionalWatchTargets);
 
     this.watchTargets.add(this.eleventyFiles.getGlobWatcherFiles());
 


### PR DESCRIPTION
This Pull Request fixes #1448