### PR TITLE
Indicate whether a collection is reversed in the pagination data

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -192,6 +192,7 @@ class Pagination {
           data: this.data.pagination.data,
           size: this.data.pagination.size,
           alias: this.alias,
+          reversed: this.data.pagination.reverse === true,
 
           pages: this.size === 1 ? items.map((entry) => entry[0]) : items,
 


### PR DESCRIPTION
The pagination data replaces the frontmatter data of a page. As a consequence the template has no way to determine whether a collection has been reversed or not. I would like to use that information to conditional add the `reversed` attribute to an ordered list:

```nunjucks
<ol class="c-collection"{% if pagination.reversed %} reversed{% endif %}>
  {% for item in pagination.items %}
    {# ... #}
  {% endfor %}
</ol>
```