### PR TITLE
Implement proof-of-concept for @

### DIFF
--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -239,6 +239,9 @@ class TemplateConfig {
     // Unique
     merged.templateFormats = lodashUniq(merged.templateFormats);
 
+	// Append config path location
+    merged.configPath = path;
+
     debug("Current configuration: %o", merged);
 
     return merged;

--- a/src/TemplateLayoutPathResolver.js
+++ b/src/TemplateLayoutPathResolver.js
@@ -1,7 +1,8 @@
 const fs = require("fs-extra");
 const config = require("./Config");
+const EleventyExtensionMap = require("./EleventyExtensionMap");
 const TemplatePath = require("./TemplatePath");
-// const debug = require("debug")("Eleventy:TemplateLayoutPathResolver");
+const debug = require("debug")("Eleventy:TemplateLayoutPathResolver");
 
 class TemplateLayoutPathResolver {
   constructor(path, inputDir, extensionMap) {
@@ -44,7 +45,6 @@ class TemplateLayoutPathResolver {
     // we might be able to move this into the constructor?
     this.aliases = Object.assign({}, this.config.layoutAliases, this.aliases);
     // debug("Current layout aliases: %o", this.aliases);
-
     if (this.path in this.aliases) {
       // debug(
       //   "Substituting layout: %o maps to %o",
@@ -53,6 +53,7 @@ class TemplateLayoutPathResolver {
       // );
       this.path = this.aliases[this.path];
     }
+
 
     this.pathAlreadyHasExtension = this.dir + "/" + this.path;
     if (
@@ -124,7 +125,16 @@ class TemplateLayoutPathResolver {
       layoutsDir = "_includes";
     }
 
-    return TemplatePath.join(this.inputDir, layoutsDir);
+    // Check to see if we start with an @
+    let baseDir = this.inputDir;
+    if(layoutsDir.startsWith('@')) {
+      // Make path relative to .eleventy.js
+      baseDir = TemplatePath.dirname(this.config.configPath);
+      // remove the @
+      layoutsDir = layoutsDir.substring(1);
+    }
+
+    return TemplatePath.join(baseDir, layoutsDir);
   }
 }
 

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -5,6 +5,12 @@ const fs = require("fs");
 
 function TemplatePath() {}
 
+// expose "dirname" path function
+// (gets the directory from a file name)
+TemplatePath.dirname = function(thePath) {
+  return path.dirname(thePath);
+};
+
 /**
  * @returns {String} the absolute path to Eleventy’s project directory.
  */


### PR DESCRIPTION
A very rough concept for implementing an `@` like prefix to paths, to make them relative to the `.eleventyconfig.js` file instead of the input.

Helps for when the layouts, includes and data folders are not children of the input dir

e.g.

```
module.exports = function (config) {
	return {
		dir: {
			input: '@/app/content',
			data: '@/app/data',
			includes: '@/app/includes',
			layouts: '@/app/layouts',
		}
	};
};
```

More details can be found in [this repo](https://github.com/mikestreety/11ty-quandary).

Would help with instances [like this, too](https://gitlab.com/streety-sites/behind-the-source/-/blob/master/.eleventy.js)