### PR TITLE
addPassthroughCopy: expose copyOptions, allow to follow symlinks

### DIFF
--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -21,6 +21,8 @@ class TemplatePassthrough {
     this.outputPath = path.outputPath;
     this.outputDir = outputDir;
 
+    this.copyOptions = path.copyOptions; // custom options for recursive-copy
+
     this.isDryRun = false;
   }
 
@@ -124,12 +126,19 @@ class TemplatePassthrough {
       });
     }
 
-    const copyOptions = {
-      overwrite: true,
-      dot: true,
-      junk: false,
+    // default options for recursive-copy
+    // see https://www.npmjs.com/package/recursive-copy#arguments
+    const copyOptionsDefault = {
+      overwrite: true, // overwrite output. fails when input is directory (mkdir) and output is file
+      dot: true, // copy dotfiles
+      junk: false, // copy cache files like Thumbs.db
       results: false,
+      expand: false, // follow symlinks
+      debug: false,
     };
+
+    const copyOptions = Object.assign(copyOptionsDefault, this.copyOptions);
+
     let promises = [];
 
     debug("Copying %o", this.inputPath);

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -54,21 +54,22 @@ class TemplatePassthroughManager {
     this.incrementalFile = path;
   }
 
-  _normalizePaths(path, outputPath) {
+  _normalizePaths(path, outputPath, copyOptions = {}) {
     return {
       inputPath: TemplatePath.addLeadingDotSlash(path),
       outputPath: outputPath
         ? TemplatePath.stripLeadingDotSlash(outputPath)
         : true,
+      copyOptions,
     };
   }
 
   getConfigPaths() {
-    let paths = [];
-    let target = this.config.passthroughCopies || {};
-    debug("`addPassthroughCopy` config API paths: %o", target);
-    for (let path in target) {
-      paths.push(this._normalizePaths(path, target[path]));
+    const paths = [];
+    const pathsRaw = this.config.passthroughCopies || {};
+    debug("`addPassthroughCopy` config API paths: %o", pathsRaw);
+    for (const [inputPath, { outputPath, copyOptions }] of Object.entries(pathsRaw)) {
+      paths.push(this._normalizePaths(inputPath, outputPath, copyOptions));
     }
     debug("`addPassthroughCopy` config API normalized paths: %o", paths);
     return paths;
@@ -175,22 +176,26 @@ class TemplatePassthroughManager {
       return [this._normalizePaths(this.incrementalFile)];
     }
 
-    let normalizedPaths = [];
-
-    let pathsFromConfigurationFile = this.getConfigPaths();
-    for (let path of pathsFromConfigurationFile) {
-      debug("TemplatePassthrough copying from config: %o", path);
-      normalizedPaths.push(path);
+    const normalizedPaths = this.getConfigPaths();
+    if (debug.enabled) {
+      for (const path of normalizedPaths) {
+        debug("TemplatePassthrough copying from config: %o", path);
+      }
     }
 
     if (paths && paths.length) {
-      let passthroughPaths = this.getNonTemplatePaths(paths);
-      for (let path of passthroughPaths) {
-        let normalizedPath = this._normalizePaths(path);
-        debug(
-          `TemplatePassthrough copying from non-matching file extension: ${normalizedPath.inputPath}`
-        );
+      const passthroughPaths = this.getNonTemplatePaths(paths);
+      for (const path of passthroughPaths) {
+        const normalizedPath = this._normalizePaths(path);
         normalizedPaths.push(normalizedPath);
+      }
+      if (debug.enabled) {
+        for (const path of passthroughPaths) {
+          const normalizedPath = this._normalizePaths(path);
+          debug(
+            `TemplatePassthrough copying from non-matching file extension: ${normalizedPath.inputPath}`
+          );
+        }
       }
     }
 
@@ -203,10 +208,8 @@ class TemplatePassthroughManager {
   async copyAll(paths) {
     debug("TemplatePassthrough copy started.");
     let normalizedPaths = this.getAllNormalizedPaths(paths);
-    let passthroughs = [];
-    for (let path of normalizedPaths) {
-      passthroughs.push(this.getTemplatePassthroughForPath(path));
-    }
+
+    const passthroughs = normalizedPaths.map(path => this.getTemplatePassthroughForPath(path));
 
     return Promise.all(
       passthroughs.map((pass) => this.copyPassthrough(pass))

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -335,14 +335,20 @@ class UserConfig {
    *
    * @param {string|object} fileOrDir The path to the file or directory that should
    * be copied. OR an object where the key is the input glob and the property is the output directory
+   * @param {object} copyOptions options for recursive-copy.
+   * see https://www.npmjs.com/package/recursive-copy#arguments
+   * default options are defined in TemplatePassthrough copyOptionsDefault
    * @returns {any} a reference to the `EleventyConfig` object.
    * @memberof EleventyConfig
    */
-  addPassthroughCopy(fileOrDir) {
+  addPassthroughCopy(fileOrDir, copyOptions = {}) {
     if (typeof fileOrDir === "string") {
-      this.passthroughCopies[fileOrDir] = true;
+      const inputPath = fileOrDir;
+      this.passthroughCopies[inputPath] = { outputPath: true, copyOptions };
     } else {
-      Object.assign(this.passthroughCopies, fileOrDir);
+      for (const [inputPath, outputPath] of Object.entries(fileOrDir)) {
+        this.passthroughCopies[inputPath] = { outputPath, copyOptions };
+      }
     }
 
     return this;

--- a/test/TemplatePassthroughManagerTest.js
+++ b/test/TemplatePassthroughManagerTest.js
@@ -8,18 +8,20 @@ const EleventyExtensionMap = require("../src/EleventyExtensionMap");
 test("Get paths from Config", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    img: true,
+    img: { outputPath: true },
   };
   let mgr = new TemplatePassthroughManager(eleventyConfig);
 
-  t.deepEqual(mgr.getConfigPaths(), [{ inputPath: "./img", outputPath: true }]);
+  t.deepEqual(mgr.getConfigPaths(), [
+    { inputPath: "./img", outputPath: true, copyOptions: {} }
+  ]);
 });
 
 test("isPassthroughCopyFile", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    img: true,
-    fonts: true,
+    img: { outputPath: true },
+    fonts: { outputPath: true },
   };
   let mgr = new TemplatePassthroughManager(eleventyConfig);
 
@@ -38,9 +40,9 @@ test("isPassthroughCopyFile", async (t) => {
 test("Get glob paths from config", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    "test/stubs/img": true,
-    "test/stubs/img/**": "./",
-    "test/stubs/img/*.js": "./",
+    "test/stubs/img": { outputPath: true },
+    "test/stubs/img/**": { outputPath: "./" },
+    "test/stubs/img/*.js": { outputPath: "./" },
   };
   let mgr = new TemplatePassthroughManager(eleventyConfig);
 
@@ -90,11 +92,11 @@ test("Get file paths (one image path)", async (t) => {
 test("Naughty paths outside of project dir", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    "../static": true,
-    "../*": "./",
-    "./test/stubs/template-passthrough2/static/*.css": "./",
-    "./test/stubs/template-passthrough2/static/*.js": "../../",
-    "./test/stubs/template-passthrough2/img.jpg": "../../",
+    "../static": { outputPath: true },
+    "../*": { outputPath: "./" },
+    "./test/stubs/template-passthrough2/static/*.css": { outputPath: "./" },
+    "./test/stubs/template-passthrough2/static/*.js": { outputPath: "../../" },
+    "./test/stubs/template-passthrough2/img.jpg": { outputPath: "../../" },
   };
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
@@ -128,28 +130,28 @@ test("Naughty paths outside of project dir", async (t) => {
 test("getAllNormalizedPaths", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    img: true,
+    img: { outputPath: true },
   };
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
   t.deepEqual(mgr.getAllNormalizedPaths(), [
-    { inputPath: "./img", outputPath: true },
+    { inputPath: "./img", outputPath: true, copyOptions: {} },
   ]);
 });
 
 test("getAllNormalizedPaths with globs", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    img: true,
-    "img/**": "./",
-    "img/*.js": "./",
+    img: { outputPath: true },
+    "img/**": { outputPath: "./" },
+    "img/*.js": { outputPath: "./" },
   };
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
   t.deepEqual(mgr.getAllNormalizedPaths(), [
-    { inputPath: "./img", outputPath: true },
-    { inputPath: "./img/**", outputPath: "" },
-    { inputPath: "./img/*.js", outputPath: "" },
+    { inputPath: "./img", outputPath: true, copyOptions: {} },
+    { inputPath: "./img/**", outputPath: "", copyOptions: {} },
+    { inputPath: "./img/*.js", outputPath: "", copyOptions: {} },
   ]);
 });
 
@@ -157,7 +159,7 @@ test("Look for uniqueness on template passthrough paths #1677", async (t) => {
   let formats = [];
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    "./test/stubs/template-passthrough-duplicates/**/*.png": "./",
+    "./test/stubs/template-passthrough-duplicates/**/*.png": { outputPath: "./", copyOptions: {} },
   };
 
   let files = new EleventyFiles(

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -700,10 +700,10 @@ test.skip("JavaScript with alias", async (t) => {
 test("Passthrough file output", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
-    "./test/stubs/template-passthrough/static": true,
-    "./test/stubs/template-passthrough/static/": "./",
-    "./test/stubs/template-passthrough/static/**/*": "./all/",
-    "./test/stubs/template-passthrough/static/**/*.js": "./js/",
+    "./test/stubs/template-passthrough/static": { outputPath: true, copyOptions: {} },
+    "./test/stubs/template-passthrough/static/": { outputPath: "./", copyOptions: {} },
+    "./test/stubs/template-passthrough/static/**/*": { outputPath: "./all/", copyOptions: {} },
+    "./test/stubs/template-passthrough/static/**/*.js": { outputPath: "./js/", copyOptions: {} },
   };
   let tw = new TemplateWriter(
     "./test/stubs/template-passthrough/",

--- a/test/UserConfigTest.js
+++ b/test/UserConfigTest.js
@@ -95,7 +95,7 @@ test("Set manual Pass-through File Copy (single call)", (t) => {
   let userCfg = new UserConfig();
   userCfg.addPassthroughCopy("img");
 
-  t.is(userCfg.passthroughCopies["img"], true);
+  t.deepEqual(userCfg.passthroughCopies["img"], { outputPath: true, copyOptions: {} });
 });
 
 test("Set manual Pass-through File Copy (chained calls)", (t) => {
@@ -106,10 +106,10 @@ test("Set manual Pass-through File Copy (chained calls)", (t) => {
     .addPassthroughCopy({ "./src/static": "static" })
     .addPassthroughCopy({ "./src/empty": "./" });
 
-  t.is(userCfg.passthroughCopies["css"], true);
-  t.is(userCfg.passthroughCopies["js"], true);
-  t.is(userCfg.passthroughCopies["./src/static"], "static");
-  t.is(userCfg.passthroughCopies["./src/empty"], "./");
+  t.deepEqual(userCfg.passthroughCopies["css"], { outputPath: true, copyOptions: {} });
+  t.deepEqual(userCfg.passthroughCopies["js"], { outputPath: true, copyOptions: {} });
+  t.deepEqual(userCfg.passthroughCopies["./src/static"], { outputPath: "static", copyOptions: {} });
+  t.deepEqual(userCfg.passthroughCopies["./src/empty"], { outputPath: "./", copyOptions: {} });
 });
 
 test("Set manual Pass-through File Copy (glob patterns)", (t) => {
@@ -124,8 +124,8 @@ test("Set manual Pass-through File Copy (glob patterns)", (t) => {
   t.is(userCfg.passthroughCopies["js/**"], undefined);
 
   // exists
-  t.is(userCfg.passthroughCopies["./src/static/**/*"], "renamed");
-  t.is(userCfg.passthroughCopies["./src/markdown/*.md"], "");
+  t.deepEqual(userCfg.passthroughCopies["./src/static/**/*"], { outputPath: "renamed", copyOptions: {} });
+  t.deepEqual(userCfg.passthroughCopies["./src/markdown/*.md"], { outputPath: "", copyOptions: {} });
 });
 
 test("Set Template Formats (string)", (t) => {


### PR DESCRIPTION
fix issue #530 

allow to pass options directly to [recursive-copy](https://www.npmjs.com/package/recursive-copy#arguments)

for example, to follow symlinks, set `{ expand: true }`

```js
eleventyConfig.addPassthroughCopy("node_modules/@fontsource/noto-sans", { expand: true });

eleventyConfig.addPassthroughCopy({
  "node_modules/@fontsource/noto-sans": "css/noto-sans",
  "node_modules/@fontsource/noto-mono": "css/noto-mono",
}, { expand: true });
```

todo: add docs to https://www.11ty.dev/docs/copy/