### PR TITLE
elev.write: handle missing Eleventy.init

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -828,6 +828,12 @@ Arguments:
     let ret;
     let hasError = false;
 
+    if (!this.writer) {
+      this.errorHandler.fatal(new Error(
+        "Did you call Eleventy.init to create the TemplateWriter instance? Hint: you probably didn’t."
+      ), "Problem writing Eleventy templates");
+    }
+
     try {
       await this.config.events.emit("beforeBuild");
       let promise;


### PR DESCRIPTION
```js
const Eleventy = require("@11ty/eleventy");
let elev = new Eleventy();

// bad: init was not called
elev
  .write()
  .catch(e => console.log(":("))
  .then(r => console.log(":)"))
;

// good
elev.init().then(r => {
  elev
    .write()
    .catch(e => console.log(":("))
    .then(r => console.log(":)"))
  ;
}
```

before this was failing with

```
Problem writing Eleventy templates: (more in DEBUG output)
> Cannot read property 'write' of undefined

`TypeError` was thrown:
    TypeError: Cannot read property 'write' of undefined
        at Eleventy.executeBuild (@11ty/eleventy/src/Eleventy.js:835:31)
```

now it says

```
Problem writing Eleventy templates: (more in DEBUG output)
> Did you call Eleventy.init to create the TemplateWriter instance? Hint: you probably didn’t.

`Error` was thrown:
    Error: Did you call Eleventy.init to create the TemplateWriter instance? Hint: you probably didn’t.
        at Eleventy.executeBuild (eleventy/src/Eleventy.js:832:31)
        at Eleventy.write (eleventy/src/Eleventy.js:795:17)
```
