### PR TITLE
Pagination: bind `this` to `before` callback

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -126,7 +126,7 @@ class Pagination {
       typeof this.data.pagination.before === "function"
     ) {
       // we don’t need to make a copy of this because we already .filter() above
-      result = this.data.pagination.before(result);
+      result = this.data.pagination.before.bind(this)(result);
     }
 
     if (this.data.pagination.reverse === true) {

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -654,6 +654,20 @@ test("Pagination `before` Callback with a Filter", async (t) => {
   t.deepEqual(templates[0].data.myalias, "item2");
 });
 
+test("Pagination `before` Callback with a Filter using `this` data", async (t) => {
+  let tmpl = getNewTemplate(
+    "./test/stubs/paged/paged-before-filter-this.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let templates = await tmpl.getTemplates(data);
+  t.is(templates.length, 2);
+  t.deepEqual(templates[0].data.pagination.items, ["foo"]);
+  t.deepEqual(templates[1].data.pagination.items, ["woo"]);
+});
+
 test("Pagination `before` Callback with `reverse: true` (test order of operations)", async (t) => {
   let tmpl = getNewTemplate(
     "./test/stubs/paged/paged-before-and-reverse.njk",

--- a/test/stubs/paged/paged-before-filter-this.njk
+++ b/test/stubs/paged/paged-before-filter-this.njk
@@ -1,0 +1,14 @@
+---js
+{
+  fooData: "moo",
+  pagination: {
+    data: "items",
+    size: 1,
+    before: function(data) {
+      return data.filter(item => item !== this.data.fooData);
+    }
+  },
+  items: ["foo", "moo", "woo"]
+}
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>


### PR DESCRIPTION
Provides access to all page data, via `this` in the `before` callback function for pagination. Useful, for example, for filtering pagination items based on the permalink of the current page.