### PR TITLE
feat: index datafiles with constant basename

### DIFF
--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -485,7 +485,7 @@ class TemplateData {
     // data suffix
     paths.push(base + dataSuffix + ".js");
     paths.push(base + dataSuffix + ".cjs");
-    paths.push(base + dataSuffix + ".json");
+    paths.push(base + dataSuffix + ".json"); // default: .11tydata.json
 
     // inject user extensions
     this._pushExtensionsToPaths(paths, base + dataSuffix, extensions);
@@ -514,6 +514,7 @@ class TemplateData {
 
       let filePathNoExt = parsed.dir + "/" + fileNameNoExt;
       let dataSuffix = this.config.jsDataFileSuffix;
+      // default dataSuffix: .11tydata, is appended in _addBaseToPaths
       debug("Using %o to find data files.", dataSuffix);
 
       this._addBaseToPaths(paths, filePathNoExt, userExtensions);
@@ -530,6 +531,10 @@ class TemplateData {
         }
         if (!inputDir || (dir.indexOf(inputDir) === 0 && dir !== inputDir)) {
           this._addBaseToPaths(paths, dirPathNoExt, userExtensions);
+          if (this.config.jsDataFileBase) {
+            let jsDataFile = dir + "/" + this.config.jsDataFileBase;
+            this._addBaseToPaths(paths, jsDataFile, userExtensions);
+          }
         }
       }
 
@@ -541,6 +546,12 @@ class TemplateData {
         );
         if (lastInputDir !== "./") {
           this._addBaseToPaths(paths, lastInputDir, userExtensions);
+        }
+        // also in root input dir, search for index.11tydata.json et al
+        if (this.config.jsDataFileBase) {
+          let jsDataFile = (TemplatePath.getDirFromFilePath(lastInputDir) +
+            "/" + this.config.jsDataFileBase);
+          this._addBaseToPaths(paths, jsDataFile, userExtensions);
         }
       }
     }

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -42,6 +42,8 @@ module.exports = function (config) {
     dataTemplateEngine: false, // change in 1.0
     htmlOutputSuffix: "-o",
     jsDataFileSuffix: ".11tydata",
+    jsDataFileBase: null,
+    // set to 'index': in every folder use datafiles 'index.11tydata.json' et al
     keys: {
       package: "pkg",
       layout: "layout",


### PR DESCRIPTION
support global / constant basename like `index` for [Directory Data File](https://www.11ty.dev/docs/data-template-dir/)
so when renaming directories, we dont have to rename the directory data files too

`.eleventy.js`
```js
module.exports = function(eleventyConfig) {
  return {
    jsDataFileBase: 'index',
  };
};
```

`some/path/index.11tydata.json`
```json
{
  "tags": "someTag"
} 
```

`some/path/someFile.md`
```md
# hello
```

now `some/path/someFile.md` (and other files in `some/path/`) is tagged with `someTag`

todo: add docs and tests