### PR TITLE
Fix for nested nunjucks async shortcodes

### DIFF
--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -295,8 +295,8 @@ class Nunjucks extends TemplateEngine {
         let body = args.pop();
         let [context, ...argArray] = args;
 
-        body(function (err, bodyContent) {
-          if (err) {
+        body(function (e, bodyContent) {
+          if (e) {
             resolve(
               new EleventyShortcodeError(
                 `Error with Nunjucks paired shortcode \`${shortcodeName}\`${EleventyErrorUtil.convertErrorToString(

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -287,57 +287,68 @@ class Nunjucks extends TemplateEngine {
         var body = parser.parseUntilBlocks("end" + shortcodeName);
         parser.advanceAfterBlockEnd();
 
-        if (isAsync) {
-          return new nodes.CallExtensionAsync(this, "run", args, [body]);
-        }
-        return new nodes.CallExtension(this, "run", args, [body]);
+        return new nodes.CallExtensionAsync(this, "run", args, [body]);
       };
 
       this.run = function (...args) {
-        let resolve;
-        if (isAsync) {
-          resolve = args.pop();
-        }
+        let resolve = args.pop();
         let body = args.pop();
         let [context, ...argArray] = args;
 
-        if (isAsync) {
-          shortcodeFn
-            .call(
-              Nunjucks._normalizeShortcodeContext(context),
-              body(),
-              ...argArray
-            )
-            .then(function (returnValue) {
-              resolve(null, new NunjucksLib.runtime.SafeString(returnValue));
-            })
-            .catch(function (e) {
+        body(function (err, bodyContent) {
+          if (err) {
+            resolve(
+              new EleventyShortcodeError(
+                `Error with Nunjucks paired shortcode \`${shortcodeName}\`${EleventyErrorUtil.convertErrorToString(
+                  e
+                )}`
+              )
+            );
+          }
+
+          if (isAsync) {
+            shortcodeFn
+              .call(
+                Nunjucks._normalizeShortcodeContext(context),
+                bodyContent,
+                ...argArray
+              )
+              .then(function (returnValue) {
+                resolve(null, new NunjucksLib.runtime.SafeString(returnValue));
+              })
+              .catch(function (e) {
+                resolve(
+                  new EleventyShortcodeError(
+                    `Error with Nunjucks paired shortcode \`${shortcodeName}\`${EleventyErrorUtil.convertErrorToString(
+                      e
+                    )}`
+                  ),
+                  null
+                );
+              });
+          } else {
+            try {
+              resolve(
+                null,
+                new NunjucksLib.runtime.SafeString(
+                  shortcodeFn.call(
+                    Nunjucks._normalizeShortcodeContext(context),
+                    bodyContent,
+                    ...argArray
+                  )
+                )
+              );
+            } catch (e) {
               resolve(
                 new EleventyShortcodeError(
                   `Error with Nunjucks paired shortcode \`${shortcodeName}\`${EleventyErrorUtil.convertErrorToString(
                     e
                   )}`
-                ),
-                null
+                )
               );
-            });
-        } else {
-          try {
-            return new NunjucksLib.runtime.SafeString(
-              shortcodeFn.call(
-                Nunjucks._normalizeShortcodeContext(context),
-                body(),
-                ...argArray
-              )
-            );
-          } catch (e) {
-            throw new EleventyShortcodeError(
-              `Error with Nunjucks paired shortcode \`${shortcodeName}\`${EleventyErrorUtil.convertErrorToString(
-                e
-              )}`
-            );
+            }
           }
-        }
+        });
       };
     }
 

--- a/test/TemplateRenderNunjucksTest.js
+++ b/test/TemplateRenderNunjucksTest.js
@@ -545,6 +545,40 @@ test("Nunjucks Async Paired Shortcode", async (t) => {
   );
 });
 
+test("Nunjucks Nested Async Paired Shortcode", async (t) => {
+  t.plan(3);
+
+  let tr = getNewTemplateRender("njk", "./test/stubs/");
+  tr.engine.addPairedShortcode(
+    "postfixWithZach",
+    function (content, str) {
+      // Data in context
+      t.is(this.page.url, "/hi/");
+
+      return new Promise(function (resolve) {
+        setTimeout(function () {
+          resolve(str + content + "Zach");
+        });
+      });
+    },
+    true
+  );
+
+  t.is(
+    await tr._testRender(
+      "{% postfixWithZach name %}Content{% postfixWithZach name2 %}Content{% endpostfixWithZach %}{% endpostfixWithZach %}",
+      {
+        name: "test",
+        name2: "test2",
+        page: {
+          url: "/hi/",
+        },
+      }
+    ),
+    "testContenttest2ContentZachZach"
+  );
+});
+
 test("Nunjucks Paired Shortcode without args", async (t) => {
   let tr = getNewTemplateRender("njk", "./test/stubs/");
   tr.engine.addPairedShortcode("postfixWithZach", function (content) {


### PR DESCRIPTION
Nested async shortcodes would fail to correctly output content from the inner shortcode as eleventy wasn't waiting for the content to have processed before passing it to the parent.

The `body()` call takes a callback, which gets called when the passed content of a paired shortcode has finished rendering, both on async and sync templates.

Fixes #1053