### PR TITLE
Fix use local timezone unintentionally when parse date from filename

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -881,7 +881,7 @@ class Template extends TemplateContent {
     } else {
       let filenameRegex = this.inputPath.match(/(\d{4}-\d{2}-\d{2})/);
       if (filenameRegex !== null) {
-        let dateObj = DateTime.fromISO(filenameRegex[1]).toJSDate();
+        let dateObj = DateTime.fromISO(filenameRegex[1], { zone: 'utc' }).toJSDate();
         debug(
           "getMappedDate: using filename regex time for %o of %o: %o",
           this.inputPath,


### PR DESCRIPTION
### Step to reproduce (What is the problem)

Demo: https://knokmki612.github.io/sandbox-11ty/

```sh
$ git clone https://github.com/knokmki612/sandbox-11ty.git
$ cd sandbox-11ty
$ yarn install
$ yarn eleventy
$ cat _site/parse-date-from-front-matter/index.html

<h1>Parse date from front matter</h1>

<p>date: Fri, 30 Apr 2021 00:00:00 GMT</p>
$ cat _site/2021-04-30/index.html

<h1>Parse date from filename</h1>

<p>date: Thu, 29 Apr 2021 15:00:00 GMT</p>
```

Doesn't match the results of date parsing between front-matter and filename.

This caused by unspecified the UTC timezone when parse date from filename.


According to [official document](https://www.11ty.dev/docs/dates/#dates-off-by-one-day), `page.date` must be the midnight of UTC
(in case of above example: `Fri, 30 Apr 2021 00:00:00 GMT`)

### Environment

- My timezone: `Asia/Tokyo (GMT +09:00)`