### PR TITLE
TemplateConfig.js: make err.message optional

### DIFF
--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -210,7 +210,7 @@ class TemplateConfig {
         // TODO the error message here is bad and I feel bad (needs more accurate info)
         throw new EleventyConfigError(
           `Error in your Eleventy config file '${path}'.` +
-            (err.message?.includes("Cannot find module")
+            (err.message && err.message.includes("Cannot find module")
               ? chalk.blueBright(" You may need to run `npm install`.")
               : ""),
           err

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -210,7 +210,7 @@ class TemplateConfig {
         // TODO the error message here is bad and I feel bad (needs more accurate info)
         throw new EleventyConfigError(
           `Error in your Eleventy config file '${path}'.` +
-            (err.message.includes("Cannot find module")
+            (err.message?.includes("Cannot find module")
               ? chalk.blueBright(" You may need to run `npm install`.")
               : ""),
           err


### PR DESCRIPTION
support `throw 'whatever';` in `.eleventy.js`

otherwise

```
    TypeError: Cannot read property 'includes' of undefined
        at TemplateConfig.mergeConfig (TemplateConfig.js)
```
in
```js
err.message.includes("Cannot find module")
```

