### PR TITLE
Allow specifying absolute URL as pathPrefix value

### DIFF
--- a/src/Filters/Url.js
+++ b/src/Filters/Url.js
@@ -21,6 +21,24 @@ module.exports = function (url, pathPrefix) {
   }
 
   let normUrl = TemplatePath.normalizeUrlPath(url);
+
+  if (pathPrefix.startsWith("https://") || pathPrefix.startsWith("http://")) {
+    // if pathPrefix is an absolute URL, normalize a trailing slash and resolve
+    // with url. Standard path normalization can't be used here as it doesn't
+    // comprehend URLs
+    let isUrlLeadingSlash = normUrl.startsWith("/");
+    let isPathPrefixTrailingSlash = pathPrefix.endsWith("/");
+    if (isUrlLeadingSlash && isPathPrefixTrailingSlash) {
+      // remove leading slash from url to join with trailing slash of pathPrefix
+      return `${pathPrefix}${normUrl.slice(1)}`;
+    }
+    if (!isUrlLeadingSlash && !isPathPrefixTrailingSlash) {
+      // add joining slash to normalize
+      return `${pathPrefix}/${normUrl}`;
+    }
+    return `${pathPrefix}${normUrl}`;
+  }
+
   let normRootDir = TemplatePath.normalizeUrlPath("/", pathPrefix);
   let normFull = TemplatePath.normalizeUrlPath("/", pathPrefix, url);
   let isRootDirTrailingSlash =

--- a/test/UrlTest.js
+++ b/test/UrlTest.js
@@ -261,3 +261,54 @@ test("Test url filter with custom pathPrefix (no slash)", (t) => {
   t.is(url("./test/", "testdir"), "test/");
   t.is(url("../test/", "testdir"), "../test/");
 });
+
+test("Test url filter with custom pathPrefix (absolute url)", (t) => {
+  t.is(url("test", "https://example.com"), "https://example.com/test");
+  t.is(url("/test", "https://example.com"), "https://example.com/test");
+  t.is(url("//test", "https://example.com"), "https://example.com/test");
+
+  // plain http
+  t.is(url("test", "http://example.com"), "http://example.com/test");
+  t.is(url("/test", "http://example.com"), "http://example.com/test");
+  t.is(url("//test", "http://example.com"), "http://example.com/test");
+});
+
+test("Test url filter with custom pathPrefix (absolute url with trailing slash)", (t) => {
+  t.is(url("test", "https://example.com/"), "https://example.com/test");
+  t.is(url("/test", "https://example.com/"), "https://example.com/test");
+  t.is(url("//test", "https://example.com/"), "https://example.com/test");
+
+  // plain http
+  t.is(url("test", "http://example.com/"), "http://example.com/test");
+  t.is(url("/test", "http://example.com/"), "http://example.com/test");
+  t.is(url("//test", "http://example.com/"), "http://example.com/test");
+});
+
+test("Test url filter with custom pathPrefix (absolute url with path)", (t) => {
+  t.is(
+    url("test", "https://example.com/prefix"),
+    "https://example.com/prefix/test"
+  );
+  t.is(
+    url("/test", "https://example.com/prefix"),
+    "https://example.com/prefix/test"
+  );
+  t.is(
+    url("//test", "https://example.com/prefix"),
+    "https://example.com/prefix/test"
+  );
+
+  // plain http
+  t.is(
+    url("test", "http://example.com/prefix"),
+    "http://example.com/prefix/test"
+  );
+  t.is(
+    url("/test", "http://example.com/prefix"),
+    "http://example.com/prefix/test"
+  );
+  t.is(
+    url("//test", "http://example.com/prefix"),
+    "http://example.com/prefix/test"
+  );
+});


### PR DESCRIPTION
This change would allow users to specify a full URL as their `pathPrefix` value and resolve all `url` filtered paths from this URL.

Presently, specifying a full URL as `pathPrefix` prepends a leading slash to the URL, resulting in asset paths like `/https://my-url.com/script/script.js` instead of the intended qualified path.

Unanswered question: how should relative paths, especially `..`, interact with a URL `pathPrefix`? This PR does not address this yet. One option would be to attempt to resolve correctly (for example, if `pathPrefix` was `https://example.com/test` and the URL was `../foo`, the resolved value is `https://example/foo`). Another is to just disallow the combination.