### PR TITLE
Deduplicate tags when using deepDataMerge

### DIFF
--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -586,6 +586,9 @@ class TemplateData {
       } else if (data.tags === null) {
         data.tags = [];
       }
+
+      // Deduplicate tags
+      data.tags = [...new Set(data.tags)];
     }
 
     return data;

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -1489,6 +1489,26 @@ test("Data Cascade Tag Merge (Deep merge)", async (t) => {
   t.deepEqual(data.tags.sort(), ["tagA", "tagB", "tagC", "tagD"]);
 });
 
+test("Data Cascade Tag Merge (Deep Merge - Deduplication)", async (t) => {
+  let eleventyConfig = new TemplateConfig();
+  // Default changed in 1.0
+  // eleventyConfig.userConfig.setDataDeepMerge(true);
+  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  await dataObj.cacheData();
+
+  let tmpl = getNewTemplate(
+    "./test/stubs/data-cascade/template.njk",
+    "./test/stubs/",
+    "./dist",
+    dataObj,
+    null,
+    eleventyConfig
+  );
+
+  let data = await tmpl.getData();
+  t.deepEqual(data.tags.sort(), ["tagA", "tagB", "tagC", "tagD"]);
+});
+
 test("Data Cascade Tag Merge (Shallow merge)", async (t) => {
   let eleventyConfig = new TemplateConfig();
   // Default changed in 1.0

--- a/test/stubs/data-cascade/template.11tydata.js
+++ b/test/stubs/data-cascade/template.11tydata.js
@@ -1,8 +1,8 @@
 module.exports = {
   parent: {
     child: 2,
-    datafile: true
+    datafile: true,
   },
   datafile: true,
-  tags: ["tagC", "tagD"]
+  tags: ["tagC", "tagD", "tagD"],
 };


### PR DESCRIPTION
Resolves #1810.

As described in #1810, tags can be duplicated through a data deep merge if they appear in more than one place.

I can't think of a reason why anyone needs a tag to appear more than once within the data cascade, so this uses `new Set` to deduplicate the output.

Hopefully this is OK!