### PR TITLE
docs: add docstring for EleventyBaseError

### DIFF
--- a/src/EleventyBaseError.js
+++ b/src/EleventyBaseError.js
@@ -1,12 +1,21 @@
+/**
+ * This class serves as basis for all Eleventy-specific errors.
+ */
 class EleventyBaseError extends Error {
+  /**
+   * @param {string} message - The error message to display.
+   * @param {Error} originalError - The original error catched.
+   */
   constructor(message, originalError) {
     super(message);
 
+    /** @type {string} - The error message to display. */
     this.name = this.constructor.name;
 
     Error.captureStackTrace(this, this.constructor);
 
     if (originalError) {
+      /** @type {Error} - The original error catched. */
       this.originalError = originalError;
     }
   }


### PR DESCRIPTION
By extension, this will also document the signature for derived errors.

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>

I'm counting on your word, @zachleat :)
https://github.com/11ty/eleventy/issues/1885#issuecomment-880053251