### PR TITLE
Remove fs-extra dependency (#1891)

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "dependency-graph": "^0.11.0",
     "ejs": "^3.1.6",
     "fast-glob": "^3.2.7",
-    "fs-extra": "^10.0.0",
     "gray-matter": "^4.0.3",
     "hamljs": "^0.6.2",
     "handlebars": "^4.7.7",

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -1,5 +1,5 @@
 const fastglob = require("fast-glob");
-const fs = require("fs-extra");
+const fs = require("fs");
 const TemplatePath = require("../TemplatePath");
 const TemplateConfig = require("../TemplateConfig");
 const EleventyExtensionMap = require("../EleventyExtensionMap");

--- a/src/Template.js
+++ b/src/Template.js
@@ -1,4 +1,5 @@
-const fs = require("fs-extra");
+const fs = require("fs");
+const path = require("path");
 const parsePath = require("parse-filepath");
 const normalize = require("normalize-path");
 const isPlainObject = require("lodash/isPlainObject");
@@ -751,11 +752,11 @@ class Template extends TemplateContent {
     } else {
       let templateBenchmark = bench.get("Template Write");
       templateBenchmark.before();
-      return fs.outputFile(outputPath, finalContent).then(() => {
-        templateBenchmark.after();
-        this.writeCount++;
-        debug(`${outputPath} ${lang.finished}.`);
-      });
+      await fs.promises.mkdir(path.parse(outputPath).dir, { recursive: true });
+      await fs.promises.writeFile(outputPath, finalContent);
+      templateBenchmark.after();
+      this.writeCount++;
+      debug(`${outputPath} ${lang.finished}.`);
     }
   }
 
@@ -868,15 +869,7 @@ class Template extends TemplateContent {
       return this._stats;
     }
 
-    this._stats = new Promise((resolve, reject) => {
-      fs.stat(this.inputPath, (err, stats) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(stats);
-        }
-      });
-    });
+    this._stats = fs.promises.stat(this.inputPath);
 
     return this._stats;
   }

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra");
+const fs = require("fs");
 const chalk = require("chalk");
 const lodashUniq = require("lodash/uniq");
 const lodashMerge = require("lodash/merge");

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -1,5 +1,5 @@
 const os = require("os");
-const fs = require("fs-extra");
+const fs = require("fs");
 const normalize = require("normalize-path");
 const matter = require("gray-matter");
 const lodashSet = require("lodash/set");
@@ -161,7 +161,7 @@ class TemplateContent {
       content = TemplateContent.getCached(this.inputPath);
     }
     if (!content) {
-      content = await fs.readFile(this.inputPath, "utf-8");
+      content = await fs.promises.readFile(this.inputPath, "utf-8");
 
       if (this.config.useTemplateCache) {
         TemplateContent.cache(this.inputPath, content);

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra");
+const fs = require("fs");
 const fastglob = require("fast-glob");
 const parsePath = require("parse-filepath");
 const lodashset = require("lodash/set");
@@ -29,7 +29,7 @@ class FSExistsCache {
   exists(path) {
     let exists = this._cache.get(path);
     if (!this.has(path)) {
-      exists = fs.pathExistsSync(path);
+      exists = fs.existsSync(path);
       this._cache.set(path, exists);
     }
     return exists;
@@ -140,7 +140,7 @@ class TemplateData {
 
   async _checkInputDir() {
     if (this.inputDirNeedsCheck) {
-      let globalPathStat = await fs.stat(this.inputDir);
+      let globalPathStat = await fs.promises.stat(this.inputDir);
 
       if (!globalPathStat.isDirectory()) {
         throw new Error("Could not find data path directory: " + this.inputDir);
@@ -392,7 +392,7 @@ class TemplateData {
   async _loadFileContents(path) {
     let rawInput;
     try {
-      rawInput = await fs.readFile(path, "utf-8");
+      rawInput = await fs.promises.readFile(path, "utf-8");
     } catch (e) {
       // if file does not exist, return nothing
     }

--- a/src/TemplateLayoutPathResolver.js
+++ b/src/TemplateLayoutPathResolver.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra");
+const fs = require("fs");
 const TemplatePath = require("./TemplatePath");
 // const debug = require("debug")("Eleventy:TemplateLayoutPathResolver");
 


### PR DESCRIPTION
@zachleat proposed in #1891 removing fs-extra since the build in FS module now provides a promise based option and supports recursive options.

This Commit only uses the ```require("fs")``` instead of ```require("fs").promises``` or ```require("fs/promises")```, since the last one is not support in Node Version <14 and the sync API is used.

Except for Template.js no file logic needed to be changed to remove fs-extra.

According to my run of "npm test" test results are not changed by this commit.

This commit only replaces fs-extra with fs and does not touch existing logic when it's not needed. Maybe some optimizations like in 5ca1aa755dfb0fac76a86aba360c0cd7a78e780d are possible.