### PR TITLE
Adds code of conduct link to top CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,7 @@
 # Eleventy Community Code of Conduct
 
+View the [Code of Conduct](https://www.11ty.dev/docs/code-of-conduct/) on 11ty.dev
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.


### PR DESCRIPTION
> I would love a follow up PR that adds a link to the top of the code of conduct in 11ty/eleventy to point to the website as the home base for the code of conduct, since technically now it lives in two places. - _[original comment by @zachleat ](https://github.com/11ty/11ty-website/pull/1109#issuecomment-883738110)_

This PR adds a link to the Code of Conduct (https://www.11ty.dev/docs/code-of-conduct/) which will exist when [#1109](https://github.com/11ty/11ty-website/pull/1109) in `11ty/11ty-website` lands.

I added some text "View the [Code of Conduct](foo) on 11ty.dev" but it could just be the `[Code of Conduct](link)`. Let me know and I'm happy to change it :)