### PR TITLE
Remove parse-filepath dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "mustache": "^4.2.0",
     "normalize-path": "^3.0.0",
     "nunjucks": "^3.2.3",
-    "parse-filepath": "^1.0.2",
     "please-upgrade-node": "^3.2.0",
     "pretty": "^2.0.0",
     "pug": "^3.0.2",

--- a/src/Template.js
+++ b/src/Template.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const parsePath = require("parse-filepath");
 const normalize = require("normalize-path");
 const isPlainObject = require("lodash/isPlainObject");
 const { DateTime } = require("luxon");
@@ -23,11 +22,18 @@ const debugDev = require("debug")("Dev:Eleventy:Template");
 const bench = require("./BenchmarkManager").get("Aggregate");
 
 class Template extends TemplateContent {
-  constructor(path, inputDir, outputDir, templateData, extensionMap, config) {
-    debugDev("new Template(%o)", path);
-    super(path, inputDir, config);
+  constructor(
+    templatePath,
+    inputDir,
+    outputDir,
+    templateData,
+    extensionMap,
+    config
+  ) {
+    debugDev("new Template(%o)", templatePath);
+    super(templatePath, inputDir, config);
 
-    this.parsed = parsePath(path);
+    this.parsed = path.parse(templatePath);
 
     // for pagination
     this.extraOutputSubdirectory = "";

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const fastglob = require("fast-glob");
-const parsePath = require("parse-filepath");
+const path = require("path");
 const lodashset = require("lodash/set");
 const lodashget = require("lodash/get");
 const lodashUniq = require("lodash/uniq");
@@ -241,9 +241,12 @@ class TemplateData {
     return paths;
   }
 
-  getObjectPathForDataFile(path) {
-    let reducedPath = TemplatePath.stripLeadingSubPath(path, this.dataDir);
-    let parsed = parsePath(reducedPath);
+  getObjectPathForDataFile(dataFilePath) {
+    let reducedPath = TemplatePath.stripLeadingSubPath(
+      dataFilePath,
+      this.dataDir
+    );
+    let parsed = path.parse(reducedPath);
     let folders = parsed.dir ? parsed.dir.split("/") : [];
     folders.push(parsed.name);
 
@@ -515,7 +518,7 @@ class TemplateData {
 
   async getLocalDataPaths(templatePath) {
     let paths = [];
-    let parsed = parsePath(templatePath);
+    let parsed = path.parse(templatePath);
     let inputDir = TemplatePath.addLeadingDotSlash(
       TemplatePath.normalize(this.inputDir)
     );

--- a/src/TemplateFileSlug.js
+++ b/src/TemplateFileSlug.js
@@ -1,4 +1,4 @@
-const parsePath = require("parse-filepath");
+const path = require("path");
 const TemplatePath = require("./TemplatePath");
 
 class TemplateFileSlug {
@@ -14,7 +14,7 @@ class TemplateFileSlug {
     this.dirs = dirs;
     this.dirs.pop();
 
-    this.parsed = parsePath(inputPath);
+    this.parsed = path.parse(inputPath);
     this.filenameNoExt = extensionMap.removeTemplateExtension(this.parsed.base);
   }
 

--- a/src/TemplatePath.js
+++ b/src/TemplatePath.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const normalize = require("normalize-path");
-const parsePath = require("parse-filepath");
 const fs = require("fs");
 
 function TemplatePath() {}
@@ -31,23 +30,23 @@ TemplatePath.getDir = function (path) {
  * Returns the directory portion of a path that either points to a file
  * or ends in a glob pattern. If `path` points to a directory,
  * the returned value will have its last path segment stripped
- * due to how [`parsePath`][1] works.
+ * due to how [`path.parse`][1] works.
  *
- * [1]: https://www.npmjs.com/package/parse-filepath
+ * [1]: https://nodejs.org/api/path.html#path_path_parse_path
  *
  * @param {String} path A path
  * @returns {String} the directory portion of a path.
  */
-TemplatePath.getDirFromFilePath = function (path) {
-  return parsePath(path).dir || ".";
+TemplatePath.getDirFromFilePath = function (filePath) {
+  return path.parse(filePath).dir || ".";
 };
 
 /**
  * Returns the last path segment in a path (no leading/trailing slashes).
  *
- * Assumes [`parsePath`][1] was called on `path` before.
+ * Assumes [`path.parse`][1] was called on `path` before.
  *
- * [1]: https://www.npmjs.com/package/parse-filepath
+ * [1]: https://nodejs.org/api/path.html#path_path_parse_path
  *
  * @param {String} path A path
  * @returns {String} the last path segment in a path

--- a/src/TemplatePermalink.js
+++ b/src/TemplatePermalink.js
@@ -1,4 +1,4 @@
-const parsePath = require("parse-filepath");
+const path = require("path");
 const TemplatePath = require("./TemplatePath");
 const normalize = require("normalize-path");
 const isPlainObject = require("lodash/isPlainObject");
@@ -87,7 +87,7 @@ class TemplatePermalink {
     }
 
     let cleanLink = this._addDefaultLinkFilename(this.buildLink);
-    let parsed = parsePath(cleanLink);
+    let parsed = path.parse(cleanLink);
 
     return TemplatePath.join(
       parsed.dir,

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -2,7 +2,7 @@ const test = require("ava");
 const fs = require("fs");
 const rimraf = require("rimraf");
 const fastglob = require("fast-glob");
-const parsePath = require("parse-filepath");
+const path = require("path");
 const EleventyFiles = require("../src/EleventyFiles");
 const EleventyExtensionMap = require("../src/EleventyExtensionMap");
 const TemplateWriter = require("../src/TemplateWriter");
@@ -149,8 +149,14 @@ test("__testGetCollectionsData with custom collection (ascending)", async (t) =>
   let templateMap = await tw._createTemplateMap(paths);
   let collectionsData = await templateMap._testGetCollectionsData();
   t.is(collectionsData.customPostsAsc.length, 2);
-  t.is(parsePath(collectionsData.customPostsAsc[0].inputPath).base, "test1.md");
-  t.is(parsePath(collectionsData.customPostsAsc[1].inputPath).base, "test2.md");
+  t.is(
+    path.parse(collectionsData.customPostsAsc[0].inputPath).base,
+    "test1.md"
+  );
+  t.is(
+    path.parse(collectionsData.customPostsAsc[1].inputPath).base,
+    "test2.md"
+  );
 });
 
 test("__testGetCollectionsData with custom collection (descending)", async (t) => {
@@ -173,8 +179,8 @@ test("__testGetCollectionsData with custom collection (descending)", async (t) =
   let templateMap = await tw._createTemplateMap(paths);
   let collectionsData = await templateMap._testGetCollectionsData();
   t.is(collectionsData.customPosts.length, 2);
-  t.is(parsePath(collectionsData.customPosts[0].inputPath).base, "test2.md");
-  t.is(parsePath(collectionsData.customPosts[1].inputPath).base, "test1.md");
+  t.is(path.parse(collectionsData.customPosts[0].inputPath).base, "test2.md");
+  t.is(path.parse(collectionsData.customPosts[1].inputPath).base, "test1.md");
 });
 
 test("__testGetCollectionsData with custom collection (filter only to markdown input)", async (t) => {
@@ -198,8 +204,8 @@ test("__testGetCollectionsData with custom collection (filter only to markdown i
   let templateMap = await tw._createTemplateMap(paths);
   let collectionsData = await templateMap._testGetCollectionsData();
   t.is(collectionsData.onlyMarkdown.length, 2);
-  t.is(parsePath(collectionsData.onlyMarkdown[0].inputPath).base, "test1.md");
-  t.is(parsePath(collectionsData.onlyMarkdown[1].inputPath).base, "test2.md");
+  t.is(path.parse(collectionsData.onlyMarkdown[0].inputPath).base, "test1.md");
+  t.is(path.parse(collectionsData.onlyMarkdown[1].inputPath).base, "test2.md");
 });
 
 test("Pagination with a Collection", async (t) => {
@@ -472,8 +478,8 @@ test("Custom collection returns array", async (t) => {
   let templateMap = await tw._createTemplateMap(paths);
   let collectionsData = await templateMap._testGetCollectionsData();
   t.is(collectionsData.returnAllInputPaths.length, 2);
-  t.is(parsePath(collectionsData.returnAllInputPaths[0]).base, "test1.md");
-  t.is(parsePath(collectionsData.returnAllInputPaths[1]).base, "test2.md");
+  t.is(path.parse(collectionsData.returnAllInputPaths[0]).base, "test1.md");
+  t.is(path.parse(collectionsData.returnAllInputPaths[1]).base, "test2.md");
 });
 
 test("Custom collection returns a string", async (t) => {


### PR DESCRIPTION
As described in #1903 this commit removes the parse-filepath dependency from 11ty in favor of the native path.parse.

Some files needed renaming of some variables which were named "path" and shadowed the path module. I hope I selected reasonable replacements.

In TemplatePath.js I also changed the documentation links to point to the nodejs api doc instead of the npm package.

According to a local test run it does not change test results.