### PR TITLE
docs: document AsyncEventEmitter and harmonise function signature

### DIFF
--- a/src/Util/AsyncEventEmitter.js
+++ b/src/Util/AsyncEventEmitter.js
@@ -1,13 +1,22 @@
 const EventEmitter = require("events");
 
+/**
+ * This class emits events asynchronously.
+ * It can be used for time measurements during a build.
+ */
 class AsyncEventEmitter extends EventEmitter {
+  /**
+   * @param {string} type - The event name to emit.
+   * @param {*[]} args - Additional arguments that get passed to listeners.
+   * @returns {Promise<*[]>} - Promise resolves once all listeners were invoked
+   */
   async emit(type, ...args) {
     let listeners = this.listeners(type);
-    if (!listeners.length) {
-      return;
+    if (listeners.length === 0) {
+      return [];
     }
 
-    return await Promise.all(listeners.map((h) => h.apply(this, args)));
+    return Promise.all(listeners.map((listener) => listener.apply(this, args)));
   }
 }
 


### PR DESCRIPTION
Introduced with https://github.com/11ty/eleventy/commit/554d7928308d52c128a88e716600cde8ff740d90

While I was at it, I made some small changes:

* looked after returning a homegeneous return value type
* `0` is falsy, so `!0` is true. I prefer to be more explicit by checking for the length against a number to get the Boolean
* An async function always returns a Promise, so there is no need for an additional `await`. See also https://jakearchibald.com/2017/await-vs-return-vs-return-await/ (last sentence). I can add the ESLint rule if you prefer. (That would be another PR since I can find 9 other instances of this pattern).

I'm happy to undo those changes if you prefer the old way.

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>