### PR TITLE
docs: document capitalize utility

### DIFF
--- a/src/Util/Capitalize.js
+++ b/src/Util/Capitalize.js
@@ -1,3 +1,11 @@
+/**
+ * Capitalize a given string.
+ *
+ * @param {string} str - The string to capitalize.
+ * @param {Object} options - Additional options.
+ * @param {boolean} options.lowercaseRestOfWord - The only recognised option. Transform the rest of the input?
+ * @returns {string} The transformed string.
+ */
 module.exports = function (str, options) {
   options = Object.assign(
     {


### PR DESCRIPTION
This function is mainly used as filter. It assumes standard Unicode
case mappings. That is, it can have surprising for certain locales
such as Turkey:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase

I was wondering, whether a lesson could be learned by Lodash,
which defines several helper functions to transform into different
casings. This function here could then defer to the respective
transformation.

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>