### PR TITLE
Fix being unable to namespace when using addPlugin

### DIFF
--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -180,9 +180,14 @@ class TemplateConfig {
     // for Nested addPlugin calls, Issue #1925
     this.userConfig._enablePluginExecution();
 
-    this.userConfig.plugins.forEach(({ plugin, options }) => {
+    let storedActiveNamespace = this.userConfig.activeNamespace;
+
+    this.userConfig.plugins.forEach(({ plugin, options, pluginNamespace }) => {
+      this.userConfig.activeNamespace = pluginNamespace;
       this.userConfig._executePlugin(plugin, options);
     });
+
+    this.userConfig.activeNamespace = storedActiveNamespace;
   }
 
   /**

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -316,7 +316,11 @@ class UserConfig {
     if (this._pluginExecution) {
       this._executePlugin(plugin, options);
     } else {
-      this.plugins.push({ plugin, options });
+      this.plugins.push({
+        plugin,
+        options,
+        pluginNamespace: this.activeNamespace,
+      });
     }
   }
 

--- a/test/TemplateConfigTest.js
+++ b/test/TemplateConfigTest.js
@@ -115,6 +115,7 @@ test("Add universal filter", (t) => {
   t.not(Object.keys(cfg.handlebarsHelpers).indexOf("myFilterName"), -1);
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("myFilterName"), -1);
 });
+
 test("Add namespaced universal filter", (t) => {
   let templateCfg = new TemplateConfig(
     require("../src/defaultConfig.js"),
@@ -146,6 +147,56 @@ test("Add namespaced universal filter using underscore", (t) => {
   );
   templateCfg.userConfig.namespace("testNamespace_", function () {
     templateCfg.userConfig.addFilter("myFilterName", function () {});
+  });
+
+  let cfg = templateCfg.getConfig();
+  t.not(
+    Object.keys(cfg.liquidFilters).indexOf("testNamespace_myFilterName"),
+    -1
+  );
+  t.not(
+    Object.keys(cfg.handlebarsHelpers).indexOf("testNamespace_myFilterName"),
+    -1
+  );
+  t.not(
+    Object.keys(cfg.nunjucksFilters).indexOf("testNamespace_myFilterName"),
+    -1
+  );
+});
+
+test("Add namespaced plugin", (t) => {
+  let templateCfg = new TemplateConfig();
+
+  templateCfg.userConfig.namespace("testNamespace", function () {
+    templateCfg.userConfig.addPlugin(function (eleventyConfig) {
+      eleventyConfig.addFilter("MyFilterName", function () {});
+    });
+  });
+
+  let cfg = templateCfg.getConfig();
+  t.not(
+    Object.keys(cfg.liquidFilters).indexOf("testNamespaceMyFilterName"),
+    -1
+  );
+  t.not(
+    Object.keys(cfg.handlebarsHelpers).indexOf("testNamespaceMyFilterName"),
+    -1
+  );
+  t.not(
+    Object.keys(cfg.nunjucksFilters).indexOf("testNamespaceMyFilterName"),
+    -1
+  );
+});
+
+test("Add namespaced plugin using underscore", (t) => {
+  let templateCfg = new TemplateConfig(
+    require("../src/defaultConfig.js"),
+    "./test/stubs/config.js"
+  );
+  templateCfg.userConfig.namespace("testNamespace_", function () {
+    templateCfg.userConfig.addPlugin(function (config) {
+      config.addFilter("myFilterName", function () {});
+    });
   });
 
   let cfg = templateCfg.getConfig();


### PR DESCRIPTION
Fixes #2007 

I'm not sure if we actually need to restore the previous namespace or if we could just set it to an empty string after looping.