### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm install
       - run: npm test
 env:


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
