### PR TITLE
[#1938]: Add --port argument and description to CLI --help output

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -539,6 +539,9 @@ Arguments:
      --serve
        Run web server on --port (default 8080) and watch them too
 
+     --port
+       Run the --serve web server on this port (default 8080)
+
      --watch
        Wait for files to change and automatically rewrite (no web server)
 


### PR DESCRIPTION
## Summary
The `eleventy --help` CLI output does not include the `--port` argument and description.

## Testing
1. Run `node ./cmd.js --help`
2. Confirm the output includes the new `--port` argument and description

## Ticket
Closes #1938

## Screenshot
![Screenshot of CLI --help output](https://user-images.githubusercontent.com/7530507/137948175-036cf52d-d191-4a2e-9d8c-5b3d2ad6e956.png)
