### PR TITLE
Update browser-sync to 2.27.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@11ty/dependency-tree": "^2.0.0",
     "@iarna/toml": "^2.2.5",
     "@sindresorhus/slugify": "^1.1.2",
-    "browser-sync": "^2.27.5",
+    "browser-sync": "^2.27.6",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "debug": "^4.3.2",


### PR DESCRIPTION
The version of _ua-parser-js_ used by browser-sync `v2.27.5` contains a crypto-miner malware.

BrowserSync/browser-sync#1914

Please consider release the **security fix** to `v0.12.x` branch since this is a [critical severity vulnerability](https://github.com/advisories/GHSA-pjwm-rvh2-c87w).