### PR TITLE
Throw an error if a circular layout chain is detected

### DIFF
--- a/test/TemplateLayoutTest.js
+++ b/test/TemplateLayoutTest.js
@@ -55,6 +55,28 @@ test("Get Layout Chain", async (t) => {
   ]);
 });
 
+test("Throw an error if a layout references itself as the layout", async (t) => {
+  await t.throwsAsync(async () => {
+    const tl = getTemplateLayoutInstance(
+      "layouts/layout-cycle-self.njk",
+      "./test/stubs"
+    );
+    const layoutChain = await tl._testGetLayoutChain();
+    return layoutChain;
+  });
+});
+
+test("Throw an error if a circular layout chain is detected", async (t) => {
+  await t.throwsAsync(async () => {
+    const tl = getTemplateLayoutInstance(
+      "layouts/layout-cycle-a.njk",
+      "./test/stubs"
+    );
+    const layoutChain = await tl._testGetLayoutChain();
+    return layoutChain;
+  });
+});
+
 test("Get Front Matter Data", async (t) => {
   let tl = getTemplateLayoutInstance(
     "layouts/layout-inherit-a.njk",

--- a/test/stubs/_includes/layouts/layout-cycle-a.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-a.njk
@@ -1,5 +1,3 @@
 ---
-inherits: a
 layout: layouts/layout-cycle-b.njk
 ---
-{{content}} {{inherits}}

--- a/test/stubs/_includes/layouts/layout-cycle-a.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-a.njk
@@ -1,0 +1,5 @@
+---
+inherits: a
+layout: layouts/layout-cycle-b.njk
+---
+{{content}} {{inherits}}

--- a/test/stubs/_includes/layouts/layout-cycle-b.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-b.njk
@@ -1,0 +1,6 @@
+---
+inherits: b
+secondinherits: b
+layout: layouts/layout-cycle-c.njk
+---
+{{ content | safe }} {{secondinherits}}

--- a/test/stubs/_includes/layouts/layout-cycle-b.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-b.njk
@@ -1,6 +1,3 @@
 ---
-inherits: b
-secondinherits: b
 layout: layouts/layout-cycle-c.njk
 ---
-{{ content | safe }} {{secondinherits}}

--- a/test/stubs/_includes/layouts/layout-cycle-c.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-c.njk
@@ -1,0 +1,7 @@
+---
+inherits: c
+secondinherits: c
+thirdinherits: c
+layout: layouts/layout-cycle-a.njk
+---
+{{ content | safe }} {{inherits}} {{thirdinherits}}

--- a/test/stubs/_includes/layouts/layout-cycle-c.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-c.njk
@@ -1,7 +1,3 @@
 ---
-inherits: c
-secondinherits: c
-thirdinherits: c
 layout: layouts/layout-cycle-a.njk
 ---
-{{ content | safe }} {{inherits}} {{thirdinherits}}

--- a/test/stubs/_includes/layouts/layout-cycle-self.njk
+++ b/test/stubs/_includes/layouts/layout-cycle-self.njk
@@ -1,0 +1,3 @@
+---
+layout: layouts/layout-cycle-self.njk
+---


### PR DESCRIPTION
Fixes #2064 to terminate the 11ty server if circular layout chains are detected