### PR TITLE
feat: declare "types" in package.json to make consuming types easier

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "access": "public"
   },
   "main": "src/Eleventy.js",
+  "types": "src/index.d.ts",
   "bin": {
     "eleventy": "./cmd.js"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,3 @@
+import UserConfig from "./UserConfig";
+
+export { UserConfig };


### PR DESCRIPTION
Hi 👋  - long time listener, first time caller!

I like to type my javascript files using JSDoc comments.  Thanks to an [excellent contribution](https://github.com/11ty/eleventy/pull/720) this is possible for the `.eleventy.js` config file 🎉 .  However, it can be more discoverable/easier with a small tweak 😄 ... that's where this here PR comes.

As discussed in #2033 the the way for 11ty consumers to get types is to reach into the 11ty package internals and find the type you want.  That's less than ideal for consumers and a bit fragile (if the file ever moves with a refactor or whatnot).

So this PR does 2 things:
1️⃣  - Makes an index.d.ts declaration file that can export types
2️⃣  - updates the package.json "types" property with the path to that type declaration file

So now a consuming project can import directly from the eleventy package without reaching into it to a specific file path:

```js
/** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
module.exports = function (eleventyConfig) { ... }
```

This PR just starts with adding the `UserConfig` to get it up and running, but additional types can be exported from `index.d.ts` over time.


> As a personal preference thing, I like to use typedef's to pull in all my dependency types at the top of the file, like so 👇 

```js
/**
 * @typedef { import("@11ty/eleventy").UserConfig } UserConfig
 */

/** @param {UserConfig} eleventyConfig */
module.exports = function (eleventyConfig) {
```