### PR TITLE
Strip date from directory slugs

### DIFF
--- a/src/TemplateFileSlug.js
+++ b/src/TemplateFileSlug.js
@@ -23,7 +23,12 @@ class TemplateFileSlug {
   }
 
   _getRawSlug() {
-    let slug = this.filenameNoExt;
+    const slug = this.filenameNoExt;
+    return this._stripDateFromSlug(slug);
+  }
+
+  /** Removes dates in the format of YYYY-MM-DD from a given slug string candidate. */
+  _stripDateFromSlug(slug) {
     let reg = slug.match(/\d{4}-\d{2}-\d{2}-(.*)/);
     if (reg) {
       return reg[1];
@@ -35,7 +40,11 @@ class TemplateFileSlug {
     let rawSlug = this._getRawSlug();
 
     if (rawSlug === "index") {
-      return this.dirs.length ? this.dirs[this.dirs.length - 1] : "";
+      if (!this.dirs.length) {
+        return "";
+      }
+      const lastDir = this.dirs[this.dirs.length - 1];
+      return this._stripDateFromSlug(lastDir);
     }
 
     return rawSlug;

--- a/test/TemplateFileSlugTest.js
+++ b/test/TemplateFileSlugTest.js
@@ -96,6 +96,12 @@ test("Easy slug with date, index with dir", (t) => {
   t.is(fs.getFullPathWithoutExtension(), "/test/index");
 });
 
+test("Strips date from dir name", (t) => {
+  let fs = getNewSlugInstance("./2021-11-20-my-awesome-post/index.md");
+  t.is(fs.getSlug(), "my-awesome-post");
+  t.is(fs.getFullPathWithoutExtension(), "/2021-11-20-my-awesome-post/index");
+});
+
 /* Pass Input dir */
 test("Easy slug, input dir", (t) => {
   let fs = getNewSlugInstance("./file.html", ".");


### PR DESCRIPTION
Closes #1947 

`2021-11-20-my-awesome-post/index.md` gets a slug of `my-awesome-post` rather than `2021-11-20-my-awesome-post`.