### PR TITLE
feat: pass file path to custom data parser

### DIFF
--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -423,7 +423,7 @@ class TemplateData {
 
     if (ignoreProcessing || engineName === false) {
       try {
-        return parser(rawInput);
+        return parser(rawInput, path);
       } catch (e) {
         throw new TemplateDataParseError(
           `Having trouble parsing data file ${path}`,
@@ -439,7 +439,7 @@ class TemplateData {
       try {
         // pass in rawImports, don’t pass in global data, that’s what we’re parsing
         let raw = await fn(rawImports);
-        return parser(raw);
+        return parser(raw, path);
       } catch (e) {
         throw new TemplateDataParseError(
           `Having trouble parsing data file ${path}`,

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -492,11 +492,12 @@ class TemplateData {
       return this._parseDataFile(path, rawImports, ignoreProcessing, parser);
     } else if (extension === "json") {
       // File to string, parse with JSON (preprocess)
+      const parser = (content) => JSON.parse(content)
       return this._parseDataFile(
         path,
         rawImports,
         ignoreProcessing,
-        JSON.parse
+        parser
       );
     } else {
       throw new TemplateDataParseError(


### PR DESCRIPTION
This change is to pass the currently processed file path to the custom data parser.

Reason to make this change is to be able to process the file along with it's dependencies that are imported with relative paths.
To do that parser needs to know what is the entry file path to be able to resolve relative imports.

Custom template parser provides file path already, but custom data parser provides only text content of the file.