### PR TITLE
Support rendering empty data in pagination

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -191,7 +191,13 @@ class Pagination {
       throw new Error("Missing `setData` call for Pagination object.");
     }
 
-    return lodashChunk(this.target, this.size);
+    const chunks = lodashChunk(this.target, this.size);
+
+    if (this.data.pagination && this.data.pagination.renderEmpty) {
+      return chunks.length ? chunks : [[]];
+    } else {
+      return chunks;
+    }
   }
 
   // TODO this name is not good


### PR DESCRIPTION
This is aiming to provide an update that resolves #731 and resolves #1185.

This patch adds the pagination option `renderEmpty`:
```yaml
pagination:
  # if data is empty, renders single page with empty chunk
  renderEmpty: true
```

This pull request probably needs a test written for it. I'm not sure what the process is like here.

Documentation is provided with 11ty/11ty-website#1327.