### PR TITLE
- removed references to `browser-sync` from EleventyServe.js, meant t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@11ty/dependency-tree": "^2.0.0",
     "@iarna/toml": "^2.2.5",
     "@sindresorhus/slugify": "^1.1.2",
-    "browser-sync": "^2.27.7",
     "chokidar": "^3.5.3",
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.3",

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -71,6 +71,7 @@ class Eleventy {
      * @member {Object} - Initialize Eleventy’s configuration, including the user config file
      */
     this.config = this.eleventyConfig.getConfig();
+    this.config.eleventyServe = this.config.eleventyServe || EleventyServe;
 
     /**
      * @member {Object} - Singleton BenchmarkManager instance
@@ -130,7 +131,7 @@ class Eleventy {
     this.formatsOverride = null;
 
     /** @member {Object} - tbd. */
-    this.eleventyServe = new EleventyServe();
+    this.eleventyServe = new this.config.eleventyServe();
     this.eleventyServe.config = this.config;
 
     /** @member {String} - Holds the path to the input directory. */

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -1,9 +1,7 @@
-const fs = require("fs");
 const path = require("path");
 
 const TemplatePath = require("./TemplatePath");
 const EleventyBaseError = require("./EleventyBaseError");
-const debug = require("debug")("EleventyServe");
 
 class EleventyServeConfigError extends EleventyBaseError {}
 class EleventyServe {
@@ -40,160 +38,26 @@ class EleventyServe {
   getRedirectDir(dirName) {
     return TemplatePath.join(this.outputDir, dirName);
   }
-  getRedirectDirOverride() {
-    // has a pathPrefix, add a /index.html template to redirect to /pathPrefix/
-    if (this.getPathPrefix() !== "/") {
-      return "_eleventy_redirect";
-    }
-  }
 
   getRedirectFilename(dirName) {
     return TemplatePath.join(this.getRedirectDir(dirName), "index.html");
   }
 
   getOptions(port) {
-    let pathPrefix = this.getPathPrefix();
-
-    // TODO customize this in Configuration API?
-    let serverConfig = {
-      baseDir: this.outputDir,
-    };
-
-    let redirectDirName = this.getRedirectDirOverride();
-    // has a pathPrefix, add a /index.html template to redirect to /pathPrefix/
-    if (redirectDirName) {
-      serverConfig.baseDir = this.getRedirectDir(redirectDirName);
-      serverConfig.routes = {};
-      serverConfig.routes[pathPrefix] = this.outputDir;
-
-      // if has a savedPathPrefix, use the /savedPathPrefix/index.html template to redirect to /pathPrefix/
-      if (this.savedPathPrefix) {
-        serverConfig.routes[this.savedPathPrefix] = TemplatePath.join(
-          this.outputDir,
-          this.savedPathPrefix
-        );
-      }
-    }
-
-    return Object.assign(
-      {
-        server: serverConfig,
-        port: port || 8080,
-        ignore: ["node_modules"],
-        watch: false,
-        open: false,
-        notify: false,
-        ui: false, // Default changed in 1.0
-        ghostMode: false, // Default changed in 1.0
-        index: "index.html",
-      },
-      this.config.browserSyncConfig
-    );
-  }
-
-  cleanupRedirect(dirName) {
-    if (dirName && dirName !== "/") {
-      let savedPathFilename = this.getRedirectFilename(dirName);
-
-      setTimeout(function () {
-        if (!fs.existsSync(savedPathFilename)) {
-          debug(`Cleanup redirect: Could not find ${savedPathFilename}`);
-          return;
-        }
-
-        let savedPathContent = fs.readFileSync(savedPathFilename, "utf8");
-        if (
-          savedPathContent.indexOf("Browsersync pathPrefix Redirect") === -1
-        ) {
-          debug(
-            `Cleanup redirect: Found ${savedPathFilename} but it wasn’t an eleventy redirect.`
-          );
-          return;
-        }
-
-        fs.unlink(savedPathFilename, (err) => {
-          if (!err) {
-            debug(`Cleanup redirect: Deleted ${savedPathFilename}`);
-          }
-        });
-      }, 2000);
-    }
-  }
-
-  serveRedirect(dirName) {
-    fs.mkdirSync(this.getRedirectDir(dirName), {
-      recursive: true,
-    });
-    fs.writeFileSync(
-      this.getRedirectFilename(dirName),
-      `<!doctype html>
-  <meta http-equiv="refresh" content="0; url=${this.config.pathPrefix}">
-  <title>Browsersync pathPrefix Redirect</title>
-  <a href="${this.config.pathPrefix}">Go to ${this.config.pathPrefix}</a>`
-    );
+    // get server options
   }
 
   serve(port) {
-    // Only load on serve—this is pretty expensive
-    // We use a string module name and try/catch here to hide this from the zisi and esbuild serverless bundlers
-    let server;
-    // eslint-disable-next-line no-useless-catch
-    try {
-      let moduleName = "browser-sync";
-      server = require(moduleName);
-    } catch (e) {
-      throw e;
-    }
-
-    this.server = server.create("eleventy-server");
-
-    let pathPrefix = this.getPathPrefix();
-
-    if (this.savedPathPrefix && pathPrefix !== this.savedPathPrefix) {
-      let redirectFilename = this.getRedirectFilename(this.savedPathPrefix);
-      if (!fs.existsSync(redirectFilename)) {
-        debug(
-          `Redirecting BrowserSync from ${this.savedPathPrefix} to ${pathPrefix}`
-        );
-        this.serveRedirect(this.savedPathPrefix);
-      } else {
-        debug(
-          `Config updated with a new pathPrefix. Tried to set up a transparent redirect but found a template already existing at ${redirectFilename}. You’ll have to navigate manually.`
-        );
-      }
-    }
-
-    let redirectDirName = this.getRedirectDirOverride();
-    // has a pathPrefix, add a /index.html template to redirect to /pathPrefix/
-    if (redirectDirName) {
-      this.serveRedirect(redirectDirName);
-    }
-
-    this.cleanupRedirect(this.savedPathPrefix);
-
-    let options = this.getOptions(port);
-    this.server.init(options);
-
-    // this needs to happen after `.getOptions`
-    this.savedPathPrefix = pathPrefix;
+    // create server
   }
 
   close() {
-    if (this.server) {
-      this.server.exit();
-    }
+    // close server
   }
 
   /* filesToReload is optional */
   reload(filesToReload) {
-    if (this.server) {
-      if (this.getPathPrefix() !== this.savedPathPrefix) {
-        this.server.exit();
-        this.serve();
-      } else {
-        this.server.reload(filesToReload);
-      }
-    }
+    // reload files
   }
 }
 

--- a/test/EleventyServeTest.js
+++ b/test/EleventyServeTest.js
@@ -19,6 +19,8 @@ test("Directories", (t) => {
   t.is(es.getRedirectFilename("test"), "_site/test/index.html");
 });
 
+// TODO: these should be moved to the external eleventy-browser-sync "EleventyServe" plugin
+/*
 test("Get Options", (t) => {
   let es = new EleventyServe();
   let cfg = new TemplateConfig().getConfig();
@@ -90,3 +92,4 @@ test("Get Options (override in config)", (t) => {
     ghostMode: false,
   });
 });
+*/


### PR DESCRIPTION
- removed references to `browser-sync` from `EleventyServe.js`, meant to be used now as a base class with no effective implementation
- removed `browser-sync` from dependencies
- added `config.eleventyServe` configuration option to specify the server class implementation to be used for serving site files
