### PR TITLE
Configure more extensions as the JavaScript engine

### DIFF
--- a/src/TemplateEngineManager.js
+++ b/src/TemplateEngineManager.js
@@ -24,6 +24,9 @@ class TemplateEngineManager {
         njk: "Nunjucks",
         liquid: "Liquid",
         "11ty.js": "JavaScript",
+        "11ty.jsx": "JavaScript",
+        "11ty.ts": "JavaScript",
+        "11ty.tsx": "JavaScript",
       };
 
       if ("extensionMap" in this.config) {


### PR DESCRIPTION
Allow users to treat JSX, TS, and TSX files as the JavaScript engine.

https://github.com/11ty/eleventy/issues/2248

This is based on the comment from https://github.com/11ty/eleventy/issues/577#issuecomment-1037632961