### PR TITLE
Standardized `this` signature for filters

### DIFF
--- a/src/Engines/Handlebars.js
+++ b/src/Engines/Handlebars.js
@@ -27,22 +27,20 @@ class Handlebars extends TemplateEngine {
     this.handlebarsLib.registerHelper(name, callback);
   }
 
-  wrapHelper(callback) {
-    let jsFuncs = this.config.javascriptFunctions;
+  static wrapHelper(callback) {
     return function () {
       const newThis = {
-        ...jsFuncs,
+        ...this,
         ctx: this,
-        page: this.page,
+        // page: this.page
       };
-      // Handlebars passes an additional argument
       return callback.call(newThis, ...arguments);
     };
   }
 
   addHelpers(helpers) {
     for (let name in helpers) {
-      this.addHelper(name, this.wrapHelper(helpers[name]));
+      this.addHelper(name, Handlebars.wrapHelper(helpers[name]));
     }
   }
 

--- a/src/Engines/Handlebars.js
+++ b/src/Engines/Handlebars.js
@@ -27,9 +27,22 @@ class Handlebars extends TemplateEngine {
     this.handlebarsLib.registerHelper(name, callback);
   }
 
+  wrapHelper(callback) {
+    let jsFuncs = this.config.javascriptFunctions;
+    return function () {
+      const newThis = {
+        ...jsFuncs,
+        ctx: this,
+        page: this.page,
+      };
+      // Handlebars passes an additional argument
+      return callback.call(newThis, ...arguments);
+    };
+  }
+
   addHelpers(helpers) {
     for (let name in helpers) {
-      this.addHelper(name, helpers[name]);
+      this.addHelper(name, this.wrapHelper(helpers[name]));
     }
   }
 

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -105,11 +105,23 @@ class JavaScript extends TemplateEngine {
       if (key === "page") {
         // do nothing
       } else {
-        // note: bind creates a new function
-        fns[key] = configFns[key].bind(inst);
+        // note: wrapping creates a new function
+        fns[key] = this.wrapJavaScriptFunction(inst, configFns[key]);
       }
     }
     return fns;
+  }
+
+  wrapJavaScriptFunction(inst, fn) {
+    let jsFuncs = this.config.javascriptFunctions;
+    return function () {
+      const newThis = {
+        ...jsFuncs,
+        ctx: inst,
+        page: inst.page,
+      };
+      return fn.call(newThis, ...arguments);
+    };
   }
 
   async compile(str, inputPath) {

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -106,17 +106,16 @@ class JavaScript extends TemplateEngine {
         // do nothing
       } else {
         // note: wrapping creates a new function
-        fns[key] = this.wrapJavaScriptFunction(inst, configFns[key]);
+        fns[key] = JavaScript.wrapJavaScriptFunction(inst, configFns[key]);
       }
     }
     return fns;
   }
 
-  wrapJavaScriptFunction(inst, fn) {
-    let jsFuncs = this.config.javascriptFunctions;
+  static wrapJavaScriptFunction(inst, fn) {
     return function () {
       const newThis = {
-        ...jsFuncs,
+        ...this,
         ctx: inst,
         page: inst.page,
       };

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -96,7 +96,7 @@ class JavaScript extends TemplateEngine {
     return getJavaScriptData(inst, inputPath);
   }
 
-  getJavaScriptFunctions(inst) {
+  getJavaScriptFunctions(inst, data) {
     let fns = {};
     let configFns = this.config.javascriptFunctions;
 
@@ -106,17 +106,21 @@ class JavaScript extends TemplateEngine {
         // do nothing
       } else {
         // note: wrapping creates a new function
-        fns[key] = JavaScript.wrapJavaScriptFunction(inst, configFns[key]);
+        fns[key] = JavaScript.wrapJavaScriptFunction(
+          inst,
+          data,
+          configFns[key]
+        );
       }
     }
     return fns;
   }
 
-  static wrapJavaScriptFunction(inst, fn) {
+  static wrapJavaScriptFunction(inst, data, fn) {
     return function () {
       const newThis = {
         ...this,
-        ctx: inst,
+        ctx: data,
         page: inst.page,
       };
       return fn.call(newThis, ...arguments);
@@ -138,7 +142,7 @@ class JavaScript extends TemplateEngine {
         if (!inst.page || inst.page.url) {
           inst.page = data.page;
         }
-        Object.assign(inst, this.getJavaScriptFunctions(inst));
+        Object.assign(inst, this.getJavaScriptFunctions(inst, data));
 
         return this.normalize(inst.render.call(inst, data));
       }.bind(this);

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -65,20 +65,16 @@ class Liquid extends TemplateEngine {
   }
 
   addFilter(name, filter) {
-    this.liquidLib.registerFilter(name, this.wrapFilter(filter));
+    this.liquidLib.registerFilter(name, Liquid.wrapFilter(filter));
   }
 
-  wrapFilter(filter) {
-    let jsFuncs = this.config.javascriptFunctions;
+  static wrapFilter(filter) {
     return function () {
+      let ctx = this.context.environments;
       const newThis = {
-        ...jsFuncs,
-        ctx: {
-          ...this.context.environments,
-        },
-        page: {
-          ...this.context.environments.page,
-        },
+        ...this,
+        ctx: ctx,
+        page: ctx.page,
       };
       return filter.call(newThis, ...arguments);
     };

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -65,7 +65,23 @@ class Liquid extends TemplateEngine {
   }
 
   addFilter(name, filter) {
-    this.liquidLib.registerFilter(name, filter);
+    this.liquidLib.registerFilter(name, this.wrapFilter(filter));
+  }
+
+  wrapFilter(filter) {
+    let jsFuncs = this.config.javascriptFunctions;
+    return function () {
+      const newThis = {
+        ...jsFuncs,
+        ctx: {
+          ...this.context.environments,
+        },
+        page: {
+          ...this.context.environments.page,
+        },
+      };
+      return filter.call(newThis, ...arguments);
+    };
   }
 
   addTag(name, tagFn) {

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -174,16 +174,15 @@ class Nunjucks extends TemplateEngine {
 
   addFilters(helpers, isAsync) {
     for (let name in helpers) {
-      this.njkEnv.addFilter(name, this.wrapFilter(helpers[name]), isAsync);
+      this.njkEnv.addFilter(name, Nunjucks.wrapFilter(helpers[name]), isAsync);
     }
   }
 
-  wrapFilter(filter) {
-    let jsFuncs = this.config.javascriptFunctions;
+  static wrapFilter(filter) {
     return function () {
       const newThis = {
-        ...jsFuncs,
-        ctx: this.ctx,
+        ...this,
+        // ctx: this.ctx,
         page: this.ctx.page,
       };
       return filter.call(newThis, ...arguments);

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -174,8 +174,20 @@ class Nunjucks extends TemplateEngine {
 
   addFilters(helpers, isAsync) {
     for (let name in helpers) {
-      this.njkEnv.addFilter(name, helpers[name], isAsync);
+      this.njkEnv.addFilter(name, this.wrapFilter(helpers[name]), isAsync);
     }
+  }
+
+  wrapFilter(filter) {
+    let jsFuncs = this.config.javascriptFunctions;
+    return function () {
+      const newThis = {
+        ...jsFuncs,
+        ctx: this.ctx,
+        page: this.ctx.page,
+      };
+      return filter.call(newThis, ...arguments);
+    };
   }
 
   addCustomTags(tags) {


### PR DESCRIPTION
Adds a more consistent `this` signature to Nunjucks and Liquid filters, as well as Handlebars helpers and JavaScript functions. Related to #1522.

The changes aim to make the this signature consistent for all filters added using `eleventyConfig.addFilter(...)` as well as the individual methods for the individual template languages. Example:
```javascript
eleventyConfig.addFilter("pagetitle", function(arg1, arg2) {
    console.log("Called 'pagetitle' from " + this.page.inputPath);
    return this.ctx.title;
})
```

## Details

The format of the this object is given by
```javascript
{
    ctx: {
        title: "...",
        content: "...",  // (only in templates)
        collections: [...],
        ...
    },
    page: {
        inputPath: "...",
        outputPath: "...",
        url: "...",
        ...
    }
}
```
It should still be discussed if this is a "good" format or if a better one could be found. This current version is a mix from the default nunjucks (which provides the ctx field) and nunjucks shortcodes (which provide the page field).

The `ctx` field contains the context (variables) of the templating engine or the [Edit: ~~JavaScript module~~ data cascade (latest commit)] for 11ty.js files.

The actual `this` object may contain more fields. For backwards compatibility the original fields provided by the templating engine are inherited.

## Potential problems

~~The ctx field in 11ty.js files does not contain the data cascade but only the module itself.~~ [Edit: Fixed with latest commit]

Almost all projects should be unaffected. Projects can break when writing to fields of the `this` object.