### PR TITLE
Alias more extensions as 11ty.js

### DIFF
--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -239,6 +239,9 @@ class EleventyExtensionMap {
         liquid: "liquid",
         "11ty.js": "11ty.js",
         "11ty.cjs": "11ty.js",
+        "11ty.jsx": "11ty.js",
+        "11ty.ts": "11ty.js",
+        "11ty.tsx": "11ty.js",
       };
 
       if ("extensionMap" in this.config) {


### PR DESCRIPTION
Allow more extensions to be treated at the `11ty.js` template engine. This builds on the work of #2249 and solves #2248. A user could run Eleventy via `ts-node` or `esbuild-register` and have the appropriate behavior now.