### PR TITLE
Fix #2350

### DIFF
--- a/src/Engines/Custom.js
+++ b/src/Engines/Custom.js
@@ -170,7 +170,12 @@ class CustomEngine extends TemplateEngine {
       // Bind defaultRenderer to render function
       if ("then" in fn && typeof fn.then === "function") {
         // Promise, wait to bind
-        return fn.then((fn) => fn.bind({ defaultRenderer }));
+        return fn.then((fn) => {
+          if (typeof fn === "function") {
+            return fn.bind({ defaultRenderer });
+          }
+          return fn;
+        });
       } else if ("bind" in fn && typeof fn.bind === "function") {
         return fn.bind({ defaultRenderer });
       }

--- a/test/TemplateTest-CustomExtensions.js
+++ b/test/TemplateTest-CustomExtensions.js
@@ -466,3 +466,31 @@ test("Return undefined in compile to ignore #2267", async (t) => {
   let data = await tmpl.getData();
   t.is(await tmpl.render(data), undefined);
 });
+
+test("Return undefined in compile to ignore (async compile function) #2350", async (t) => {
+  let eleventyConfig = new TemplateConfig();
+  eleventyConfig.userConfig.extensionMap.add({
+    extension: "txt",
+    key: "txt",
+    compileOptions: {
+      cache: false,
+    },
+    getData: false,
+    compile: async function (str, inputPath) {
+      return;
+    },
+  });
+
+  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let tmpl = getNewTemplate(
+    "./test/stubs/custom-extension.txt",
+    "./test/stubs/",
+    "dist",
+    dataObj,
+    null,
+    eleventyConfig
+  );
+
+  let data = await tmpl.getData();
+  t.is(await tmpl.render(data), undefined);
+});


### PR DESCRIPTION
Currently, it fails when a custom template extension has an async compile function and it returns undefined to ignore, because there is no type check before binding defaultRenderer. (#2350)
The fix is simply to add a type check.