### PR TITLE
fix liquid template argument parsing and shortcode undefined values

### DIFF
--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -116,13 +116,16 @@ class Liquid extends TemplateEngine {
           line: 1,
           col: 1 }*/
         if (arg.type.indexOf("ignore:") === -1) {
-          argArray.push(await engine.evalValue(arg.value, scope));
+          // Push the promise into an array instead of awaiting it here.
+          // This forces the promises to run in order with the correct scope value for each arg.
+          // Otherwise they run out of order and can lead to undefined values for arguments in layout template shortcodes.
+          argArray.push(engine.evalValue(arg.value, scope));
         }
         arg = lexer.next();
       }
     }
 
-    return argArray;
+    return await Promise.all(argArray);
   }
 
   static _normalizeShortcodeScope(ctx) {


### PR DESCRIPTION
- fixes undefined arguments in shortcodes and potentially other uses
- fixes #2348 and #2154

This fixes a major bug with liquid shortcodes not working in layout templates. They end up randomly getting `undefined` values for arguments after the first argument due to an order of execution issue with a changing `scope` context being sent to [evalValue](https://github.com/11ty/eleventy/compare/master...epelc:master#diff-cd8b0d5daef1e85d609f147e72a641e39dd0091c09dce6b8be1903e8dfd59a25R122).

I changed it from running the promise using await immediately to calling the promise immediately instead so it gets the correct current scope value. I then use `await Promise.all(pendingPromises)` to wait for each promise to resolve.

There is a separate example here which shows the differences in order of execution with calling the promise immediately with await(broken) vs calling it without await and then later awaiting all of the promises(fixed).

# Demo/why it fixes and didn't work before

> See example javascript below

 Notice how the regular version starts the two functions concurrently and their counter is then randomly iterated between the the functions. Consider each function an eleventy input file and the counter to be the scope in the liquid parser. You end up with the undefined arguments bug in this setup because the scope changes out of order compared to where the variables are being processed.

Compare with the fixed version under it in which the first file is completely executed then the next one. Nodejs is single threaded anyways so executing it in order synchronously while still using async/await is fine. We are just fixing the processing order here so that the counter/scope are processed in the corresponding order to their arguments.

```
> console.log('reg',await Promise.all([doConcurrentStuff(ctx),doConcurrentStuff(ctx)]))
Doing concurrent stuff
ctx { counter: 71 }
Doing concurrent stuff
ctx { counter: 72 }
ctx { counter: 73 }
ctx { counter: 74 }
ctx { counter: 75 }
ctx { counter: 76 }
ctx { counter: 77 }
ctx { counter: 78 }
ctx { counter: 79 }
ctx { counter: 80 }
reg [ [ 71, 73, 75, 77, 79 ], [ 72, 74, 76, 78, 80 ] ]
undefined
> console.log('fixed',await Promise.all([doConcurrentStufffixed(ctx),doConcurrentStufffixed(ctx)]))
Doing concurrent stuff with fixed passing of current value of ctx/scope
ctx { counter: 81 }
ctx { counter: 82 }
ctx { counter: 83 }
ctx { counter: 84 }
ctx { counter: 85 }
Doing concurrent stuff with fixed passing of current value of ctx/scope
ctx { counter: 86 }
ctx { counter: 87 }
ctx { counter: 88 }
ctx { counter: 89 }
ctx { counter: 90 }
fixed [ [ 81, 82, 83, 84, 85 ], [ 86, 87, 88, 89, 90 ] ]
undefined
```

<details>
  <summary>Example.js</summary>

```
function calc(scope) {
  return new Promise((resolve) => {
    scope.counter += 1

    console.log('ctx', scope)
    resolve(scope.counter)
  })
}

async function doConcurrentStuff(ctx) {
  console.log('Doing concurrent stuff')
  let out = []
  for (let i = 0; i < 5; i++) {
    // ctx.counter += i
    out.push(await calc(ctx))
  }

  return out
}

async function doConcurrentStufffixed(ctx) {
  console.log(
    'Doing concurrent stuff with fixed passing of current value of ctx/scope'
  )

  let out = []
  for (let i = 0; i < 5; i++) {
    // ctx.counter =i+ctx.counter
    // ctx.counter += i

    out.push(calc(ctx))
  }

  return await Promise.all(out)
}

let ctx = {
  counter: 10,
}

console.log(
  'reg',
  await Promise.all([doConcurrentStuff(ctx), doConcurrentStuff(ctx)])
)
console.log(
  'fixed',
  await Promise.all([doConcurrentStufffixed(ctx), doConcurrentStufffixed(ctx)])
)
```

</details>