### PR TITLE
chore: Replace deprecated String.prototype.substr() with String.prototype.slice()

### DIFF
--- a/src/ComputedDataTemplateString.js
+++ b/src/ComputedDataTemplateString.js
@@ -38,7 +38,10 @@ class ComputedDataTemplateString {
     let vars = new Set();
     let splits = output.split(this.prefix);
     for (let split of splits) {
-      let varName = split.substr(0, split.indexOf(this.suffix));
+      let varName = split.slice(
+        0,
+        split.indexOf(this.suffix) < 0 ? 0 : split.indexOf(this.suffix)
+      );
       if (varName) {
         vars.add(varName);
       }

--- a/src/EleventyErrorUtil.js
+++ b/src/EleventyErrorUtil.js
@@ -28,7 +28,12 @@ class EleventyErrorUtil {
       return "" + msg;
     }
 
-    return msg.substr(0, msg.indexOf(EleventyErrorUtil.prefix));
+    return msg.slice(
+      0,
+      msg.indexOf(EleventyErrorUtil.prefix) < 0
+        ? 0
+        : msg.indexOf(EleventyErrorUtil.prefix)
+    );
   }
 
   static deconvertErrorToObject(error) {

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -217,7 +217,12 @@ class EleventyExtensionMap {
   removeTemplateExtension(path) {
     for (var extension in this.extensionToKeyMap) {
       if (path === extension || path.endsWith("." + extension)) {
-        return path.substr(0, path.length - 1 - extension.length);
+        return path.slice(
+          0,
+          path.length - 1 - extension.length < 0
+            ? 0
+            : path.length - 1 - extension.length
+        );
       }
     }
     return path;

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -126,10 +126,10 @@ class TemplateContent {
           fm.content =
             fm.excerpt.trim() +
             "\n" +
-            fm.content.substr((excerptString + os.EOL).length);
+            fm.content.slice((excerptString + os.EOL).length);
         } else if (fm.content.startsWith(excerptString)) {
           // no newline after excerpt separator
-          fm.content = fm.excerpt + fm.content.substr(excerptString.length);
+          fm.content = fm.excerpt + fm.content.slice(excerptString.length);
         }
 
         // alias, defaults to page.excerpt

--- a/src/TemplateGlob.js
+++ b/src/TemplateGlob.js
@@ -15,7 +15,7 @@ class TemplateGlob {
   static normalize(path) {
     path = path.trim();
     if (path.charAt(0) === "!") {
-      return "!" + TemplateGlob.normalizePath(path.substr(1));
+      return "!" + TemplateGlob.normalizePath(path.slice(1));
     } else {
       return TemplateGlob.normalizePath(path);
     }

--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -70,7 +70,7 @@ class TemplateMap {
 
   getTagTarget(str) {
     if (str.startsWith("collections.")) {
-      return str.substr("collections.".length);
+      return str.slice("collections.".length);
     }
   }
 
@@ -283,7 +283,7 @@ class TemplateMap {
     for (let depEntry of dependencyMap) {
       if (depEntry.startsWith(tagPrefix)) {
         // is a tag (collection) entry
-        let tagName = depEntry.substr(tagPrefix.length);
+        let tagName = depEntry.slice(tagPrefix.length);
         await this.setCollectionByTagName(tagName);
       } else {
         // is a template entry

--- a/src/TemplatePermalink.js
+++ b/src/TemplatePermalink.js
@@ -75,7 +75,7 @@ class TemplatePermalink {
   }
 
   _addDefaultLinkFilename(link) {
-    return link + (link.substr(-1) === "/" ? "index.html" : "");
+    return link + (link.slice(-1) === "/" ? "index.html" : "");
   }
 
   toOutputPath() {
@@ -134,8 +134,8 @@ class TemplatePermalink {
     let needle = "/index.html";
     if (original === needle) {
       return "/";
-    } else if (original.substr(-1 * needle.length) === needle) {
-      return original.substr(0, original.length - needle.length) + "/";
+    } else if (original.slice(-1 * needle.length) === needle) {
+      return original.slice(0, original.length - needle.length) + "/";
     }
     return original;
   }

--- a/src/Util/Merge.js
+++ b/src/Util/Merge.js
@@ -3,7 +3,7 @@ const OVERRIDE_PREFIX = "override:";
 
 function cleanKey(key, prefix) {
   if (prefix && key.startsWith(prefix)) {
-    return key.substr(prefix.length);
+    return key.slice(prefix.length);
   }
   return key;
 }
@@ -60,7 +60,7 @@ function Merge(target, ...sources) {
   if (isPlainObject(target)) {
     for (let key in target) {
       if (key.indexOf(OVERRIDE_PREFIX) === 0) {
-        target[key.substr(OVERRIDE_PREFIX.length)] = target[key];
+        target[key.slice(OVERRIDE_PREFIX.length)] = target[key];
         delete target[key];
       }
     }

--- a/test/EleventyErrorHandlerTest.js
+++ b/test/EleventyErrorHandlerTest.js
@@ -21,7 +21,7 @@ test("Log a warning, warning", (t) => {
   errorHandler.warn(new Error("Test warning"), "Hello");
 
   let expected = "Hello: (more in DEBUG output)";
-  t.is(output.join("\n").substr(0, expected.length), expected);
+  t.is(output.join("\n").slice(0, expected.length), expected);
 });
 
 test("Log a warning, error", (t) => {
@@ -49,5 +49,5 @@ test("Log a warning, error", (t) => {
 Test error (via Error)
 
 Original error stack trace: Error: Test error`;
-  t.is(output.join("\n").substr(0, expected.length), expected);
+  t.is(output.join("\n").slice(0, expected.length), expected);
 });

--- a/test/TemplateRenderLiquidTest.js
+++ b/test/TemplateRenderLiquidTest.js
@@ -781,9 +781,9 @@ test("Issue 258: Liquid Render Date", async (t) => {
     "<p>{{ myDate }}</p>"
   );
   let dateStr = await fn({ myDate: new Date(Date.UTC(2016, 0, 1, 0, 0, 0)) });
-  t.is(dateStr.substr(0, 3), "<p>");
-  t.is(dateStr.substr(-4), "</p>");
-  t.not(dateStr.substr(2, 1), '"');
+  t.is(dateStr.slice(0, 3), "<p>");
+  t.is(dateStr.slice(-4), "</p>");
+  t.not(dateStr.slice(2, 1), '"');
 });
 
 test("Issue 347: Liquid addTags with space in argument", async (t) => {


### PR DESCRIPTION

String.prototype.substr() method is deprecated and no longer recommended. So replaced with String.prototype.slice() method.