### PR TITLE
Document default config using JSDoc docstrings

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -4,6 +4,52 @@ const slugFilter = require("./Filters/Slug");
 const slugifyFilter = require("./Filters/Slugify");
 const getCollectionItem = require("./Filters/GetCollectionItem");
 
+/**
+ * @module 11ty/eleventy/defaultConfig
+ */
+
+/**
+ * @callback addFilter - Register a global filter.
+ * @param {string} name - Register a template filter by this name.
+ * @param {function} callback - The filter logic.
+ */
+
+/**
+ * @typedef {Object} config
+ * @property {addFilter} addFilter - Register a new global filter.
+ */
+
+/**
+ * @typedef {Object} defaultConfig
+ * @property {Array<String>} templateFormats - An array of accepted template formats.
+ * @property {String} [pathPrefix='/'] - The directory under which all output files should be written to.
+ * @property {String} [markdownTemplateEngine='liquid'] - Template engine to process markdown files with.
+ * @property {String} [htmlTemplateEngine='liquid'] - Template engine to process html files with.
+ * @property {Boolean} [dataTemplateEngine=false] - Changed in v1.0
+ * @property {String} [htmlOutputSuffix='-o']
+ * @property {String} [jsDataFileSuffix='.11tydata'] - File suffix for jsData files.
+ * @property {Object} keys
+ * @property {String} [keys.package='pkg']
+ * @property {String} [keys.layout='layout']
+ * @property {String} [keys.permalink='permalink']
+ * @property {String} [keys.permalinkRoot='permalinkBypassOutputDir']
+ * @property {String} [keys.engineOverride='templateEngineOverride']
+ * @property {String} [keys.computed='eleventyComputed']
+ * @property {Object} dir
+ * @property {String} [dir.input='.']
+ * @property {String} [dir.includes='_includes']
+ * @property {String} [dir.data='_data']
+ * @property {String} [dir.output='_site']
+ * @deprecated handlebarsHelpers
+ * @deprecated nunjucksFilters
+ */
+
+/**
+ * Default configuration object factory.
+ *
+ * @param {config} config - Eleventy configuration object.
+ * @returns {defaultConfig}
+ */
 module.exports = function (config) {
   let templateConfig = this;
 

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -21,25 +21,25 @@ const getCollectionItem = require("./Filters/GetCollectionItem");
 
 /**
  * @typedef {Object} defaultConfig
- * @property {Array<String>} templateFormats - An array of accepted template formats.
- * @property {String} [pathPrefix='/'] - The directory under which all output files should be written to.
- * @property {String} [markdownTemplateEngine='liquid'] - Template engine to process markdown files with.
- * @property {String} [htmlTemplateEngine='liquid'] - Template engine to process html files with.
- * @property {Boolean} [dataTemplateEngine=false] - Changed in v1.0
- * @property {String} [htmlOutputSuffix='-o']
- * @property {String} [jsDataFileSuffix='.11tydata'] - File suffix for jsData files.
+ * @property {Array<string>} templateFormats - An array of accepted template formats.
+ * @property {string} [pathPrefix='/'] - The directory under which all output files should be written to.
+ * @property {string} [markdownTemplateEngine='liquid'] - Template engine to process markdown files with.
+ * @property {string} [htmlTemplateEngine='liquid'] - Template engine to process html files with.
+ * @property {boolean} [dataTemplateEngine=false] - Changed in v1.0
+ * @property {string} [htmlOutputSuffix='-o']
+ * @property {string} [jsDataFileSuffix='.11tydata'] - File suffix for jsData files.
  * @property {Object} keys
- * @property {String} [keys.package='pkg']
- * @property {String} [keys.layout='layout']
- * @property {String} [keys.permalink='permalink']
- * @property {String} [keys.permalinkRoot='permalinkBypassOutputDir']
- * @property {String} [keys.engineOverride='templateEngineOverride']
- * @property {String} [keys.computed='eleventyComputed']
+ * @property {string} [keys.package='pkg']
+ * @property {string} [keys.layout='layout']
+ * @property {string} [keys.permalink='permalink']
+ * @property {string} [keys.permalinkRoot='permalinkBypassOutputDir']
+ * @property {string} [keys.engineOverride='templateEngineOverride']
+ * @property {string} [keys.computed='eleventyComputed']
  * @property {Object} dir
- * @property {String} [dir.input='.']
- * @property {String} [dir.includes='_includes']
- * @property {String} [dir.data='_data']
- * @property {String} [dir.output='_site']
+ * @property {string} [dir.input='.']
+ * @property {string} [dir.includes='_includes']
+ * @property {string} [dir.data='_data']
+ * @property {string} [dir.output='_site']
  * @deprecated handlebarsHelpers
  * @deprecated nunjucksFilters
  */


### PR DESCRIPTION
I'm back after some hiatus to maybe sneak in a documentation or two before the v2.0 release :)

I was a bit confused where my doc command went (:eyes: #1885) but you can install `jsodc` and run
`node_modules/.bin/jsdoc -d ./api-docs -p ./package.json -R README.md src/` (resp. with `npx`) to generate files.

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>