### PR TITLE
#2424 Fix failing builds for new markdown files using git Last Modified

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -944,7 +944,7 @@ class Template extends TemplateContent {
         }
 
         // return now if this file is not yet available in `git`
-        return Date.now();
+        return new Date();
       }
       if (data.date.toLowerCase() === "last modified") {
         return this._getDateInstance("ctimeMs");


### PR DESCRIPTION
This PR fixes the issue where builds fail when you have at least two tempaltes where at least one is not yet in git and has the date set to "git last modified".

The issue was, that a timestamp as a number was returned in that case instead of a date object.