### PR TITLE
#1036 Add skip parameter to pagination plugin

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -81,6 +81,12 @@ class Pagination {
 
     this.size = data.pagination.size;
     this.alias = data.pagination.alias;
+    this.skip = data.pagination.skip || 0;
+    if (typeof this.skip !== "number") {
+      throw new Error(
+        `Missing pagination skip in front matter data${this.inputPathForErrorMessages}`
+      );
+    }
     // TODO do we need the full data set for serverless?
     this.fullDataSet = this._get(this.data, this._getDataKey());
 
@@ -106,8 +112,8 @@ class Pagination {
         ];
       }
     } else {
-      // this returns an array
-      this.target = this._resolveItems();
+      // this returns an array and skips no elements by default
+      this.target = this._resolveItems().slice(this.skip);
 
       // Serverless Shortcut when key is not found in data set (probably running local build and expected a :path param in data)
       // Only collections are relevant for templates that don’t have a permalink.build, they don’t have a templateContent and aren’t written to disk

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -883,3 +883,41 @@ test("Pagination and eleventyComputed permalink, issue #1555 and #1865", async (
   t.is(templates[1].data.page.url, "/venues/second/");
   t.is(templates[2].data.page.url, "/venues/third/");
 });
+
+test("Pagination with skip parameter, issue #1036", async (t) => {
+  let eleventyConfig = new TemplateConfig();
+  let tmpl = getNewTemplate(
+    "./test/stubs/pagination-skip.md",
+    "./test/stubs/",
+    "./dist",
+    null,
+    null,
+    eleventyConfig
+  );
+
+  let data = await tmpl.getData();
+  let paging = new Pagination(tmpl, data, tmpl.config);
+  paging.setTemplate(tmpl);
+
+  t.truthy(data.pagination);
+  t.is(paging.getPageCount(), 2);
+  t.is(data.pagination.size, 2);
+  t.deepEqual(paging.target, ["second", "third", "fourth", "fifth"]);
+});
+
+test("Pagination with skip parameter required to be number, issue #1036", async (t) => {
+  let eleventyConfig = new TemplateConfig();
+  let tmpl = getNewTemplate(
+    "./test/stubs/pagination-skip-string.md",
+    "./test/stubs/",
+    "./dist",
+    null,
+    null,
+    eleventyConfig
+  );
+
+  let data = await tmpl.getData();
+  t.throws(() => {
+    new Pagination(tmpl, data, tmpl.config);
+  });
+});

--- a/test/stubs/pagination-skip-string.md
+++ b/test/stubs/pagination-skip-string.md
@@ -1,0 +1,13 @@
+---
+venues:
+  - first
+  - second
+  - third
+  - fourth
+  - fifth
+pagination:
+  data: venues
+  size: 2
+  skip: one
+  addAllPagesToCollections: true
+---

--- a/test/stubs/pagination-skip.md
+++ b/test/stubs/pagination-skip.md
@@ -1,0 +1,13 @@
+---
+venues:
+  - first
+  - second
+  - third
+  - fourth
+  - fifth
+pagination:
+  data: venues
+  size: 2
+  skip: 1
+  addAllPagesToCollections: true
+---


### PR DESCRIPTION
This PR adds an option to skip the first n items of a pagination.
This allows usecases as described in #1036, where one might want to show the first n items on onether page and then paginate over the rest.