### PR TITLE
Add passthrough logging filter #2198

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -14,8 +14,8 @@ module.exports = function (config) {
     let pathPrefix = pathPrefixOverride || templateConfig.getPathPrefix();
     return urlFilter.call(this, url, pathPrefix);
   });
-  config.addFilter("log", (input, ...data) => {
-    console.log(input, ...data);
+  config.addFilter("log", (input, ...messages) => {
+    console.log(input, ...messages);
     return input;
   });
 

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -14,7 +14,10 @@ module.exports = function (config) {
     let pathPrefix = pathPrefixOverride || templateConfig.getPathPrefix();
     return urlFilter.call(this, url, pathPrefix);
   });
-  config.addFilter("log", console.log);
+  config.addFilter("log", (input, ...data) => {
+    console.log(input, ...data);
+    return input;
+  });
 
   config.addFilter("serverlessUrl", serverlessUrlFilter);
 


### PR DESCRIPTION
This change makes the `log` filter "passthrough" compatible, so you can put it in the middle of a filter chain.

That way you can use it like `{{ "Some Text" | log("Some logging") | upper }}`.

This fixes #2198.