### PR TITLE
#2224 git created option for date

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -13,6 +13,7 @@ const { TemplatePath, isPlainObject } = require("@11ty/eleventy-utils");
 
 const ConsoleLogger = require("./Util/ConsoleLogger");
 const getDateFromGitLastUpdated = require("./Util/DateGitLastUpdated");
+const getDateFromGitFirstAdded = require("./Util/DateGitFirstAdded");
 
 const TemplateData = require("./TemplateData");
 const TemplateContent = require("./TemplateContent");
@@ -948,6 +949,15 @@ class Template extends TemplateContent {
       }
       if (data.date.toLowerCase() === "last modified") {
         return this._getDateInstance("ctimeMs");
+      }
+      if (data.date.toLowerCase() === "git created") {
+        let d = getDateFromGitFirstAdded(this.inputPath);
+        if (d) {
+          return d;
+        }
+
+        // return now if this file is not yet available in `git`
+        return new Date();
       }
       if (data.date.toLowerCase() === "created") {
         return this._getDateInstance("birthtimeMs");

--- a/src/Util/DateGitFirstAdded.js
+++ b/src/Util/DateGitFirstAdded.js
@@ -1,0 +1,24 @@
+const spawn = require("cross-spawn");
+
+function getGitFirstAddedTimeStamp(filePath) {
+  return (
+    parseInt(
+      spawn
+        .sync(
+          "git",
+          // Formats https://www.git-scm.com/docs/git-log#_pretty_formats
+          // %at author date, UNIX timestamp
+          ["log", "--diff-filter=A", "--follow", "-1", "--format=%at", filePath]
+        )
+        .stdout.toString("utf-8")
+    ) * 1000
+  );
+}
+
+// return a Date
+module.exports = function (inputPath) {
+  let timestamp = getGitFirstAddedTimeStamp(inputPath);
+  if (timestamp) {
+    return new Date(timestamp);
+  }
+};

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -2,6 +2,7 @@ const test = require("ava");
 const Eleventy = require("../src/Eleventy");
 const EleventyWatchTargets = require("../src/EleventyWatchTargets");
 const TemplateConfig = require("../src/TemplateConfig");
+const DateGitFirstAdded = require("../src/Util/DateGitFirstAdded.js");
 const DateGitLastUpdated = require("../src/Util/DateGitLastUpdated");
 const normalizeNewLines = require("./Util/normalizeNewLines");
 
@@ -547,4 +548,15 @@ ${JSON.stringify(arr)}`);
   let content = results.map((entry) => entry.content).sort();
   t.is(normalizeNewLines(content[0]), str);
   t.is(normalizeNewLines(content[1]), str);
+});
+
+test("#2224: date 'git created' populates page.date", async (t) => {
+  let elev = new Eleventy("./test/stubs-2224/", "./test/stubs-2224/_site");
+
+  let results = await elev.toJSON();
+  let [result] = results;
+
+  // This doesn’t test the validity of the function, only that it populates page.date.
+  let comparisonDate = DateGitFirstAdded("./test/stubs-2224/index.njk");
+  t.is(result.content.trim(), "" + comparisonDate.getTime());
 });

--- a/test/stubs-2224/index.njk
+++ b/test/stubs-2224/index.njk
@@ -1,0 +1,4 @@
+---
+date: git created
+---
+{{ page.date.getTime() }}


### PR DESCRIPTION
This change allows to use "git created" as a magic string to use the first appearance in git as the date of a template.

This uses gits feature to also track the file across renames.

If a file isn't yet tracked, it uses the current date.

It uses "git created" instead of "git first added", to keep closer to the already existing "created" option.

fixes #2224