### PR TITLE
#1312 Improve situation for dependency monitoring

### DIFF
--- a/src/EleventyWatch.js
+++ b/src/EleventyWatch.js
@@ -1,4 +1,5 @@
 const { TemplatePath } = require("@11ty/eleventy-utils");
+const PathNormalizer = require("./Util/PathNormalizer.js");
 
 /* Decides when to watch and in what mode to watch
  * Incremental builds don’t batch changes, they queue.
@@ -87,7 +88,9 @@ class EleventyWatch {
 
   addToPendingQueue(path) {
     if (path) {
-      path = TemplatePath.addLeadingDotSlash(path);
+      path = PathNormalizer.normalizeSeperator(
+        TemplatePath.addLeadingDotSlash(path)
+      );
       this.pendingQueue.push(path);
     }
   }

--- a/src/Util/PathNormalizer.js
+++ b/src/Util/PathNormalizer.js
@@ -1,0 +1,12 @@
+const path = require("path");
+
+class PathNormalizer {
+  static normalizeSeperator(inputPath) {
+    if (!inputPath) {
+      return inputPath;
+    }
+    return inputPath.split(path.sep).join("/");
+  }
+}
+
+module.exports = PathNormalizer;

--- a/src/Util/PathPrefixer.js
+++ b/src/Util/PathPrefixer.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const PathNormalizer = require("./PathNormalizer.js");
 
 class PathPrefixer {
   static normalizePathPrefix(pathPrefix) {
@@ -12,10 +13,7 @@ class PathPrefixer {
   }
 
   static joinUrlParts(...parts) {
-    return path
-      .join(...parts)
-      .split(path.sep)
-      .join("/");
+    return PathNormalizer.normalizeSeperator(path.join(...parts));
   }
 }
 

--- a/test/PathNormalizerTest.js
+++ b/test/PathNormalizerTest.js
@@ -1,0 +1,10 @@
+const test = require("ava");
+const PathNormalizer = require("../src/Util/PathNormalizer");
+
+test("PathNormalize Seperator", (t) => {
+  t.is(PathNormalizer.normalizeSeperator("."), ".");
+  t.is(PathNormalizer.normalizeSeperator("a/b"), "a/b");
+  t.is(PathNormalizer.normalizeSeperator("a\\b"), "a/b");
+  t.is(PathNormalizer.normalizeSeperator("a\\b/c"), "a/b/c");
+  t.is(PathNormalizer.normalizeSeperator(undefined), undefined);
+});


### PR DESCRIPTION
This change adds a "PathNormalizer" with tests which converts all paths to be unix compatible (replace "\" with "/"). That way auto reloading dependencies of the config also works on windows.

Sadly nested dependencies still always lag exactly one update behind, so if you have the following dependency graph:
- .eleventy.js depends on
- middle.js depends on
- nested.js

and you update nested, you see the following:
- do update 1 -> no result
- do update 2 -> see update 1
- do update 3 -> see update 2

During a short lookaround, I was unable to resolve this issue.

This should improve the situation around #1312