### PR TITLE
#2386 show custom engine label

### DIFF
--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -163,12 +163,8 @@ class TemplateRender {
   getReadableEnginesListDifferingFromFileExtension() {
     let keyFromFilename = this.extensionMap.getKey(this.engineNameOrPath);
     if (this.engine instanceof CustomEngine) {
-      if (this.engine.entry && keyFromFilename !== this.engine.entry.name) {
-        if (this.engine.entry.name) {
-          return `custom/${this.engine.entry.name}`;
-        } else {
-          return "custom";
-        }
+      if (this.engine.entry && this.engine.entry.name && keyFromFilename !== this.engine.entry.name) {
+        return this.engine.entry.name;
       } else {
         return undefined;
       }

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -3,6 +3,7 @@ const { TemplatePath } = require("@11ty/eleventy-utils");
 const TemplateConfig = require("./TemplateConfig");
 const EleventyBaseError = require("./EleventyBaseError");
 const EleventyExtensionMap = require("./EleventyExtensionMap");
+const CustomEngine = require("./Engines/Custom.js");
 // const debug = require("debug")("Eleventy:TemplateRender");
 
 class TemplateRenderConfigError extends EleventyBaseError {}
@@ -160,6 +161,19 @@ class TemplateRender {
   }
 
   getReadableEnginesListDifferingFromFileExtension() {
+    let keyFromFilename = this.extensionMap.getKey(this.engineNameOrPath);
+    if (this.engine instanceof CustomEngine) {
+      if (this.engine.entry && keyFromFilename !== this.engine.entry.name) {
+        if (this.engine.entry.name) {
+          return `custom/${this.engine.entry.name}`;
+        } else {
+          return "custom";
+        }
+      } else {
+        return undefined;
+      }
+    }
+
     if (
       this.engineName === "md" &&
       this.useMarkdown &&
@@ -172,7 +186,6 @@ class TemplateRender {
     }
 
     // templateEngineOverride in play and template language differs from file extension
-    let keyFromFilename = this.extensionMap.getKey(this.engineNameOrPath);
     if (keyFromFilename !== this.engineName) {
       return this.engineName;
     }


### PR DESCRIPTION
This change adresses the issue in #2386.
It changes the output for custom engines as follows:

Before:
```
[11ty] Writing _site/index2/index.html from ./index2.md (liquid)
[11ty] Writing _site/test/index.html from ./test.md (liquid)
[11ty] Writing _site/description/index.html from ./description.njk
[11ty] Writing _site/cloud/index.html from ./cloud.clowd
```

After:
```
[11ty] Writing _site/cloud/index.html from ./cloud.clowd (custom)
[11ty] Writing _site/description/index.html from ./description.njk
[11ty] Writing _site/index2/index.html from ./index2.md (custom/customName)
[11ty] Writing _site/test/index.html from ./test.md (custom/customName)
```

To configure the "customName", you can now add a key called `name` to the `addExtension` options object.

I set this PR to draft for now, to maybe update the naming of the added "name" attribute.