### PR TITLE
Ignore nested node modules by default

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -118,7 +118,7 @@ class EleventyFiles {
   _setConfig(config) {
     if (!config.ignores) {
       config.ignores = new Set();
-      config.ignores.add("node_modules/**");
+      config.ignores.add("**/node_modules/**");
     }
     this.config = config;
     this.initConfig();

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -67,7 +67,7 @@ class UserConfig {
 
     this.useGitIgnore = true;
     this.ignores = new Set();
-    this.ignores.add("node_modules/**");
+    this.ignores.add("**/node_modules/**");
     this.ignores.add(".git/**");
 
     this.dataDeepMerge = true;

--- a/test/EleventyFilesGitIgnoreEleventyIgnoreTest.js
+++ b/test/EleventyFilesGitIgnoreEleventyIgnoreTest.js
@@ -19,7 +19,7 @@ test("Get ignores (no .eleventyignore no .gitignore)", (t) => {
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalroot/node_modules/**",
+    "./test/stubs/ignorelocalroot/**/node_modules/**",
     "./test/stubs/ignorelocalroot/.git/**",
     "./test/stubs/ignorelocalroot/test.md",
     "./test/stubs/ignore1/_site/**",
@@ -38,7 +38,7 @@ test("Get ignores (no .eleventyignore)", (t) => {
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalrootgitignore/node_modules/**",
+    "./test/stubs/ignorelocalrootgitignore/**/node_modules/**",
     "./test/stubs/ignorelocalrootgitignore/.git/**",
     "./test/stubs/ignorelocalrootgitignore/thisshouldnotexist12345",
     "./test/stubs/ignorelocalrootgitignore/test.md",
@@ -65,7 +65,7 @@ test("Get ignores (no .eleventyignore, using setUseGitIgnore(false))", (t) => {
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalroot/node_modules/**",
+    "./test/stubs/ignorelocalroot/**/node_modules/**",
     "./test/stubs/ignorelocalroot/test.md",
     "./test/stubs/ignore2/_site/**",
   ]);
@@ -83,7 +83,7 @@ test("Get ignores (no .gitignore)", (t) => {
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalroot/node_modules/**",
+    "./test/stubs/ignorelocalroot/**/node_modules/**",
     "./test/stubs/ignorelocalroot/.git/**",
     "./test/stubs/ignorelocalroot/test.md",
     "./test/stubs/ignore3/ignoredFolder/**",
@@ -104,7 +104,7 @@ test("Get ignores (project .eleventyignore and root .gitignore)", (t) => {
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalrootgitignore/node_modules/**",
+    "./test/stubs/ignorelocalrootgitignore/**/node_modules/**",
     "./test/stubs/ignorelocalrootgitignore/.git/**",
     "./test/stubs/ignorelocalrootgitignore/thisshouldnotexist12345",
     "./test/stubs/ignorelocalrootgitignore/test.md",
@@ -133,7 +133,7 @@ test("Get ignores (project .eleventyignore and root .gitignore, using setUseGitI
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalrootgitignore/node_modules/**",
+    "./test/stubs/ignorelocalrootgitignore/**/node_modules/**",
     "./test/stubs/ignorelocalrootgitignore/test.md",
     "./test/stubs/ignore4/ignoredFolder/**",
     "./test/stubs/ignore4/ignoredFolder/ignored.md",
@@ -154,7 +154,7 @@ test("Get ignores (no .eleventyignore  .gitignore exists but empty)", (t) => {
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalroot/node_modules/**",
+    "./test/stubs/ignorelocalroot/**/node_modules/**",
     "./test/stubs/ignorelocalroot/.git/**",
     "./test/stubs/ignorelocalroot/test.md",
     "./test/stubs/ignore5/_site/**",
@@ -173,7 +173,7 @@ test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore is
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignorelocalroot/node_modules/**",
+    "./test/stubs/ignorelocalroot/**/node_modules/**",
     "./test/stubs/ignorelocalroot/.git/**",
     "./test/stubs/ignorelocalroot/test.md",
     "./test/stubs/ignore6/ignoredFolder/**",
@@ -324,7 +324,7 @@ test("De-duplicated ignores", (t) => {
   ]);
 
   t.deepEqual(evf.getIgnores(), [
-    "./test/stubs/ignore-dedupe/node_modules/**",
+    "./test/stubs/ignore-dedupe/**/node_modules/**",
     "./test/stubs/ignore-dedupe/.git/**",
     "./test/stubs/ignore-dedupe/ignoredFolder",
     "./test/stubs/ignore-dedupe/_site/**",


### PR DESCRIPTION
It changes Eleventy default ignore from `node_modules/**` to `**/node_modules/**`.
https://github.com/11ty/eleventy/issues/2436

Docs section that will need to be updated => https://www.11ty.dev/docs/ignores/#node_modules