### PR TITLE
Add a dictionary for the i18n plugin to translate based on each lang file

### DIFF
--- a/src/Plugins/I18nPlugin.js
+++ b/src/Plugins/I18nPlugin.js
@@ -193,7 +193,7 @@ function getDeep(obj, keys) {
       return false;
     }
     obj = obj[key];
-    if (!obj) {
+    if (typeof obj === "undefined") {
       return false;
     }
   }
@@ -439,12 +439,14 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
       : createLangDictionary(lang, addIns, DeepCopy(options.dictionary));
 
     // Find the nested value of the translation, or the default language one if the value isn't found
-    const translation =
-      getDeep(extendedDictionary, `${key}.${lang}`) ||
-      getDeep(extendedDictionary, `${key}.${options.defaultLanguage}`);
+    // (note that a localized string can be an empty string, which is falsy, so there needs to be a strictly false check in place)
+    let translation = getDeep(fullDictionary, `${key}.${lang}`);
+    if (translation === false) {
+      translation = getDeep(fullDictionary, `${key}.${defaultLang}`);
+    }
 
     // If no translation was found, throw an error
-    if (!translation) {
+    if (translation === false) {
       throw new Error(
         `The dictionary entry for [${key}] was not found in the target language or the default language.`
       );


### PR DESCRIPTION
This extends the I18n plugin by providing a dictionary option.

# Usage

A new filter (defaults to `locale_dict`) takes a string as a key (such as `home` or `rss.cta`) and finds the translation based on the language of the current template.

The dictionary must be provided ahead of time to build a full one that covers all languages, or at least the default language.

Each language's locale file, such as `src/en/en.json` should have a `lang` property and an `i18n` property (nesting is allowed for the latter):
```json
{
  "lang": "en",
  "i18n": {
    "home": "Home",
    "feed": {
      "label": "Feed",
      "cta": "Subscribe to the RSS feed"
    }
  }
}
```

This can then be imported into the `.eleventy.js` file for every language needed for the site, e.g.:
```js
const locales = ['en', 'fr'];
const localeDictionaries = Object.fromEntries(locales.map((locale) => [locale, require(`./src/${locale}/${locale}.json`)]));
```

A utility is exposed in the `LangUtils` to generate the final dictionary based on all the provided dictionaries:
```js
const dictionary = EleventyI18nPlugin.LangUtils.buildDictionary(localeDictionaries);
```
This "compiles" all the dictionaries into a single one, and looks like so, with the language code as the last node in the object "property chain":

```json
{
  "home": {
    "en": "Home",
    "fr": "Acceuil",
  },
  "feed": {
    "label": {
      "en": "Feed",
      "fr": "Flux"
    },
    "cta": {
      "en": "Subscribe to the RSS feed",
      "fr": "S'inscrire au flux RSS",
    }
  }
}
```

Finally, this dictionary can be passed to the plugin configuration object (where the filter name can be overwritten as well):
```js
eleventyConfig.addPlugin(EleventyI18nPlugin, {
	defaultLanguage: locales[0],
	errorMode: 'allow-fallback',
	dictionary: dictionary,
	filters: { dict: 'i18n' },
});
```

We can then call `{{ 'rss.cta' | i18n }}` in a `njk` file for example.

Oh and you can add a `i18n` object in a page's front matter to provide additional or contextual translations that will be available only for that page:
```
---
title: Homepage
i18n:
  greeting: "Welcome"
---
```

The key of `i18n` can be changed with the `dictKey` option. I would recommend users who add entries on a single page nest that data to avoid overrides (unless desired).

## Caveats
I tested this on one site, probably some issues here and there.

## Notes
Very inspired by the existing [11ty-plugin-i18n](https://github.com/adamduncan/eleventy-plugin-i18n) for this feature, which is likely implemented in a smarter way than my plugin.