### PR TITLE
#1297 Make tags work correctly inside eleventyComputed

### DIFF
--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -128,7 +128,7 @@ class TemplateMap {
         // collections.all
         graph.addDependency(tagPrefix + "all", entry.inputPath);
 
-        if (entry.data.tags) {
+        if (entry.data.tags && !entry.data.eleventyComputed?.tags) {
           for (let tag of entry.data.tags) {
             let tagWithPrefix = tagPrefix + tag;
             if (!graph.hasNode(tagWithPrefix)) {
@@ -189,6 +189,19 @@ class TemplateMap {
               // Dependency from tag to inputPath
               graph.addDependency(tagWithPrefix, entry.inputPath);
             }
+          }
+        }
+      }
+
+      if (
+        !entry.data.eleventyExcludeFromCollections &&
+        entry.data.eleventyComputed?.tags &&
+        entry.data.tags
+      ) {
+        for (let tag of entry.data.tags) {
+          let tagWithPrefix = tagPrefix + tag;
+          if (!graph.hasNode(tagWithPrefix)) {
+            graph.addNode(tagWithPrefix);
           }
         }
       }

--- a/test/TemplateMapTest-ComputedData.js
+++ b/test/TemplateMapTest-ComputedData.js
@@ -215,3 +215,41 @@ test("Computed data can filter collections (and other array methods)", async (t)
   t.not(map[0].data.dogCollection, map[0].data.collections.dog);
   t.deepEqual(map[0].data.dogCollection, map[0].data.collections.dog);
 });
+
+test("Computed data is included in collection generation. Issue #1297", async (t) => {
+  let eleventyConfig = new TemplateConfig();
+  let tm = new TemplateMap(eleventyConfig);
+
+  let dataObj = new TemplateData(
+    "./test/stubs-1297/",
+    eleventyConfig
+  );
+
+  let tmpl = getNewTemplate(
+    "./test/stubs-1297/stub.md",
+    "./test/stubs-1297/",
+    "./dist",
+    dataObj,
+    null,
+    eleventyConfig
+  );
+
+  await tm.add(tmpl);
+
+  await tm.cache();
+
+  let map = tm.getMap();
+
+  t.is(map.length, 1);
+
+  t.deepEqual(map[0].data.tags, ['cv', 'stub']);
+
+  t.truthy(map[0].data.collections.all);
+  t.is(map[0].data.collections.all.length, 1);
+  t.truthy(map[0].data.collections.cv);
+  t.is(map[0].data.collections.cv.length, 1);
+  t.truthy(map[0].data.collections.stub);
+  t.is(map[0].data.collections.stub.length, 1);
+
+  t.falsy(map[0].data.collections.toBeErased);
+});

--- a/test/stubs-1297/stub.md
+++ b/test/stubs-1297/stub.md
@@ -1,0 +1,6 @@
+---
+title: stub
+tags: toBeErased
+eleventyComputed:
+  tags: ['cv', '{{title}}']
+---


### PR DESCRIPTION
While making a page myself I came across the same issue as described here: #1297 so I tried to fix it.

My solution works for the test cases I tried and doesn't break anything else according to the tests, but I would like someone else more experienced in the codebase to take a look at it and see if it's a good way to fix this issue.

I would like to see this fixed, but I understand if I turns out to be unfeasible or something not in the current scope.

---

Some more info about my solution:
- If there is no `tags` property in `eleventyComputed`, continue with the normal flow
- If there is a `tags` property in `eleventyComputed`, skip adding tags to graph in `getMappedDependencies` and instead do it in `getDelayedMappedDependencies` when the data from `eleventyComputed` has already been merged to entry data.
- I also added a test case

