### PR TITLE
--watch --passthroughall doesn’t re-run on changes to non-Eleventy files #439

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -105,6 +105,10 @@ class EleventyFiles {
     for (let path of this.extensionMap.getPassthroughCopyGlobs(this.inputDir)) {
       paths.add(path);
     }
+    // passthroughAll catch
+    if (this.passthroughAll) {
+      paths.add(TemplateGlob.normalizePath(this.input, "/**"));
+    }
     return Array.from(paths);
   }
 

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -477,6 +477,20 @@ test("Glob Watcher Files with passthroughAll", async (t) => {
   t.is((await evf.getFileGlobs())[0], "./test/stubs/**");
 });
 
+test("#439 Glob Watcher Files with passthroughAll sets correct watch globs", async (t) => {
+  let eleventyConfig = new TemplateConfig();
+  let evf = new EleventyFiles(
+    "test/stubs",
+    "test/stubs/_site",
+    [],
+    eleventyConfig
+  );
+  evf.setPassthroughAll(true);
+  evf.init();
+
+  t.deepEqual(evf.passthroughGlobs, ["./test/stubs/**"]);
+});
+
 test("Test that negations are ignored (for now) PR#709, will change when #693 is implemented", async (t) => {
   t.deepEqual(
     EleventyFiles.normalizeIgnoreContent(


### PR DESCRIPTION
This Commit adds the correct glob to the passthroughGlobs when passthroughAll is enabled.

Fixes #439