### PR TITLE
#2311 First fix for cli output dir

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -198,13 +198,7 @@ class Eleventy {
 
   /** @type {String} */
   get outputDir() {
-    let dir = this.rawOutput || this.config.dir.output;
-    if (dir !== this._savedOutputDir) {
-      this.eleventyServe.setOutputDir(dir);
-    }
-    this._savedOutputDir = dir;
-
-    return dir;
+    return this.rawOutput || this.config.dir.output;
   }
 
   /**
@@ -353,6 +347,13 @@ class Eleventy {
     let formats = this.formatsOverride || this.config.templateFormats;
     this.extensionMap = new EleventyExtensionMap(formats, this.eleventyConfig);
     await this.config.events.emit("eleventy.extensionmap", this.extensionMap);
+
+    // tbd
+    // This is likely async in the future, since updating the output dir of the server
+    // will likely be an async action. Also having this in the getter seems a little unexpected
+    if (this.eleventyServe.outputDir !== this.outputDir) {
+      this.eleventyServe.setOutputDir(this.outputDir);
+    }
 
     this.eleventyFiles = new EleventyFiles(
       this.inputDir,

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -174,7 +174,7 @@ class EleventyServe {
     // Static method `getServer` was already checked in `getServerModule`
     this._server = serverModule.getServer(
       "eleventy-server",
-      this.config.dir.output,
+      this.outputDir,
       this.options
     );
 

--- a/test/EleventyServeTest.js
+++ b/test/EleventyServeTest.js
@@ -1,8 +1,8 @@
 const test = require("ava");
-const EleventyServe = require("../src/EleventyServe");
 const TemplateConfig = require("../src/TemplateConfig");
 
 async function getServerInstance(cfg) {
+  const EleventyServe = require("../src/EleventyServe");
   let es = new EleventyServe();
   if (!cfg) {
     cfg = new TemplateConfig().getConfig();
@@ -52,4 +52,21 @@ test("Get Options (override in config)", async (t) => {
     pathPrefix: "/",
     port: 8080,
   });
+});
+
+test("Sanity test that default output is set correctly", async (t) => {
+  let es = await getServerInstance();
+  es.setOutputDir("_site");
+
+  t.is(es.server.dir, "_site");
+});
+
+// This assert should work once updating the output dir of the server works.
+test.skip("Custom output dir is set correctly", async (t) => {
+  let es = await getServerInstance();
+  es.setOutputDir("x");
+
+  t.is(es.outputDir, "x");
+
+  t.is(es.server.dir, "x");
 });

--- a/test/EleventyServeTest.js
+++ b/test/EleventyServeTest.js
@@ -1,8 +1,8 @@
 const test = require("ava");
+const EleventyServe = require("../src/EleventyServe");
 const TemplateConfig = require("../src/TemplateConfig");
 
 async function getServerInstance(cfg) {
-  const EleventyServe = require("../src/EleventyServe");
   let es = new EleventyServe();
   if (!cfg) {
     cfg = new TemplateConfig().getConfig();


### PR DESCRIPTION
This commit makes the EleventyServe module listen with the correct folder.

WARNING! This is still broken, as it doesn't update when you change the output directory!
Fixing this issue will likely involve a deeper look into which part of the "Server modules" are considered public/stable and how 11ty should interact with servers.

partly fixes #2311