### PR TITLE
Import EleventyShortcodeError into RenderPlugin.js

### DIFF
--- a/src/EleventyShortcodeError.js
+++ b/src/EleventyShortcodeError.js
@@ -1,0 +1,5 @@
+const EleventyBaseError = require("./EleventyBaseError");
+
+class EleventyShortcodeError extends EleventyBaseError {}
+
+module.exports = EleventyShortcodeError;

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -3,10 +3,8 @@ const { TemplatePath } = require("@11ty/eleventy-utils");
 
 const TemplateEngine = require("./TemplateEngine");
 const EleventyErrorUtil = require("../EleventyErrorUtil");
-const EleventyBaseError = require("../EleventyBaseError");
+const EleventyShortcodeError = require("../EleventyShortcodeError");
 const eventBus = require("../EventBus");
-
-class EleventyShortcodeError extends EleventyBaseError {}
 
 class Nunjucks extends TemplateEngine {
   constructor(name, dirs, config) {

--- a/src/Plugins/RenderPlugin.js
+++ b/src/Plugins/RenderPlugin.js
@@ -7,6 +7,7 @@ const { TemplatePath, isPlainObject } = require("@11ty/eleventy-utils");
 const Merge = require("../Util/Merge");
 const { ProxyWrap } = require("../Util/ProxyWrap");
 const TemplateDataInitialGlobalData = require("../TemplateDataInitialGlobalData");
+const EleventyShortcodeError = require("../EleventyShortcodeError");
 const TemplateRender = require("../TemplateRender");
 const TemplateConfig = require("../TemplateConfig");
 const Liquid = require("../Engines/Liquid");


### PR DESCRIPTION
This fixes the following error, which obscures the actual issue causing an error to be thrown.

```
[11ty] Unhandled rejection in promise: (more in DEBUG output)
[11ty] EleventyShortcodeError is not defined (via ReferenceError)
[11ty] 
[11ty] Original error stack trace: ReferenceError: EleventyShortcodeError is not defined
[11ty]     at /path/to/project/node_modules/@11ty/eleventy/src/Plugins/RenderPlugin.js:225:21
[11ty]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```