### PR TITLE
#2591 Fix for path prefix in canary build

### DIFF
--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -192,8 +192,10 @@ class TemplateConfig {
    * @param {String} pathPrefix - The new path prefix.
    */
   setPathPrefix(pathPrefix) {
-    debug("Setting pathPrefix to %o", pathPrefix);
-    this.overrides.pathPrefix = pathPrefix;
+    if(pathPrefix && pathPrefix !== '/'){
+      debug("Setting pathPrefix to %o", pathPrefix);
+      this.overrides.pathPrefix = pathPrefix;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes issue #2591 where `canary` builds are disregarding path prefixes set in .eleventy.js config file. 