### PR TITLE
Make Markdown library .set() method optional

### DIFF
--- a/src/Engines/Markdown.js
+++ b/src/Engines/Markdown.js
@@ -18,7 +18,7 @@ class Markdown extends TemplateEngine {
 
     // Overrides a highlighter set in `markdownOptions`
     // This is separate so devs can pass in a new mdLib and still use the official eleventy plugin for markdown highlighting
-    if (this.config.markdownHighlighter) {
+    if (this.config.markdownHighlighter && typeof this.mdLib.set === "function") {
       this.mdLib.set({
         highlight: this.config.markdownHighlighter,
       });


### PR DESCRIPTION
This is a tiny improvement in ergonomics for replacing the underlying Markdown library. 

Due to some issues with `eleventyConfig.addExtension('md')`, namely that it opts you out of pre-processing (#2777) and that it causes issues with permalinks (#2780), `eleventyConfig.setLibrary('md')` remains the best way to replace the library.

At the moment, the library is tacitly assumed to be `markdown-it`, due to usage of library-specific methods (`set()`, `render()`, `disable()`), but there's no other reason why another library wouldn't work, as long as it provides a `render(str, data)` method. 

This PR makes the `set()` method optional in the replacement library.