### PR TITLE
Fixes serverlessFilePath is not defined (2.0.0-beta.2) #2782

### DIFF
--- a/src/Plugins/ServerlessBundlerPlugin.js
+++ b/src/Plugins/ServerlessBundlerPlugin.js
@@ -168,7 +168,7 @@ class BundlerHelper {
     );
 
     return async function EleventyServerlessMiddleware(req, res, next) {
-      deleteRequireCache(serverlessFilePath);
+      deleteRequireCache(serverlessFilepath);
 
       let serverlessFunction = EleventyRequire(serverlessFilepath);
       let url = new URL(req.url, "http://localhost/"); // any domain will do here, we just want the searchParams


### PR DESCRIPTION
An incorrectly named variable was added [here](https://github.com/11ty/eleventy/commit/786105e6f18feef27e0a2b8da4681725bce9a320#diff-99713a149e70b46dac489a0995bac49ab972cec22b54bc16f9b7ae704a9b62daR171). This fixes the issue