### PR TITLE
Refactor/switch to async fs operations after init/config load

### DIFF
--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -1,4 +1,6 @@
-const fs = require("fs");
+const fs = require("graceful-fs");
+const util = require("util");
+const fsReadFile = util.promisify(fs.readFile);
 const { TemplatePath } = require("@11ty/eleventy-utils");
 
 const TemplateConfig = require("../TemplateConfig");
@@ -155,8 +157,7 @@ class TemplateEngine {
             partialPathNoExt = TemplatePath.removeExtension(partialPathNoExt, "." + extension);
           });
 
-          return fs.promises
-            .readFile(partialFile, {
+          return fsReadFile(partialFile, {
               encoding: "utf8",
             })
             .then((content) => {

--- a/src/Plugins/RenderPlugin.js
+++ b/src/Plugins/RenderPlugin.js
@@ -1,5 +1,7 @@
-const fs = require("fs");
-const fsp = fs.promises;
+const fs = require("graceful-fs");
+const util = require("util");
+const fsReadFile = util.promisify(fs.readFile);
+const fsExists = util.promisify(fs.exists);
 const { TemplatePath, isPlainObject } = require("@11ty/eleventy-utils");
 
 // TODO add a first-class Markdown component to expose this using Markdown-only syntax (will need to be synchronous for markdown-it)
@@ -49,7 +51,7 @@ async function compileFile(inputPath, { templateConfig, extensionMap, config } =
     throw new Error("Missing file path argument passed to the `renderFile` shortcode.");
   }
 
-  if (!fs.existsSync(TemplatePath.normalizeOperatingSystemFilePath(inputPath))) {
+  if (!await fsExists(TemplatePath.normalizeOperatingSystemFilePath(inputPath))) {
     throw new Error(
       "Could not find render plugin file for the `renderFile` shortcode, looking for: " + inputPath
     );
@@ -74,7 +76,7 @@ async function compileFile(inputPath, { templateConfig, extensionMap, config } =
   }
 
   // TODO we could make this work with full templates (with front matter?)
-  let content = await fsp.readFile(inputPath, "utf8");
+  let content = await fsReadFile(inputPath, "utf8");
   return tr.getCompiledTemplate(content);
 }
 

--- a/src/Template.js
+++ b/src/Template.js
@@ -2,6 +2,7 @@ const fs = require("graceful-fs");
 const util = require("util");
 const writeFile = util.promisify(fs.writeFile);
 const mkdir = util.promisify(fs.mkdir);
+const fsStat = util.promisify(fs.stat);
 
 const os = require("os");
 const path = require("path");
@@ -898,7 +899,7 @@ class Template extends TemplateContent {
       return this._stats;
     }
 
-    this._stats = fs.promises.stat(this.inputPath);
+    this._stats = fsStat(this.inputPath);
 
     return this._stats;
   }

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -67,7 +67,7 @@ class TemplatePassthrough {
     let fullOutputPath = TemplatePath.normalize(TemplatePath.join(outputDir, outputPath));
 
     if (
-      await fsExists(inputPath) &&
+      (await fsExists(inputPath)) &&
       !TemplatePath.isDirectorySync(inputPath) &&
       TemplatePath.isDirectorySync(fullOutputPath)
     ) {
@@ -119,7 +119,7 @@ class TemplatePassthrough {
       if (dir.endsWith(path.sep)) {
         return dir;
       }
-      if (await fsStat(dir).isDirectory()) {
+      if ((await fsStat(dir)).isDirectory()) {
         return `${dir}/`;
       }
     }
@@ -129,7 +129,7 @@ class TemplatePassthrough {
   // maps input paths to output paths
   async getFileMap() {
     // TODO VirtualFileSystem candidate
-    if (!isGlob(this.inputPath) && await fsExists(this.inputPath)) {
+    if (!isGlob(this.inputPath) && (await fsExists(this.inputPath))) {
       // When inputPath is a directory, make sure it has a slash for passthrough copy aliasing
       // https://github.com/11ty/eleventy/issues/2709
       let inputPath = await this.addTrailingSlashIfDirectory(this.inputPath);

--- a/test/TemplatePassthroughTest.js
+++ b/test/TemplatePassthroughTest.js
@@ -23,17 +23,17 @@ const getTemplatePassthrough = (path, outputDir, inputDir) => {
   return p;
 };
 
-test("Constructor", (t) => {
+test("Constructor", async (t) => {
   let pass = getTemplatePassthrough("avatar.png", "_site", ".");
   t.truthy(pass);
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/avatar.png");
+  t.is(await pass.getOutputPath(), "_site/avatar.png");
 });
 
-test("Constructor, input directory in inputPath is stripped", (t) => {
+test("Constructor, input directory in inputPath is stripped", async (t) => {
   let pass = getTemplatePassthrough("src/avatar.png", "_site", "src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/avatar.png");
+  t.is(await pass.getOutputPath(), "_site/avatar.png");
 
   let pass2 = getTemplatePassthrough(
     { inputPath: "src/avatar.png", outputPath: "avatar.png" },
@@ -41,13 +41,13 @@ test("Constructor, input directory in inputPath is stripped", (t) => {
     "src"
   );
   t.is(pass2.outputPath, "avatar.png");
-  t.is(pass2.getOutputPath(), "_site/avatar.png");
+  t.is(await pass2.getOutputPath(), "_site/avatar.png");
 });
 
-test("Constructor, input directory in inputPath is stripped, duplicate directory names", (t) => {
+test("Constructor, input directory in inputPath is stripped, duplicate directory names", async (t) => {
   let pass = getTemplatePassthrough("src/src/avatar.png", "_site", "src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/src/avatar.png");
+  t.is(await pass.getOutputPath(), "_site/src/avatar.png");
 
   let pass2 = getTemplatePassthrough(
     { inputPath: "src/src/avatar.png", outputPath: "src/avatar.png" },
@@ -55,19 +55,19 @@ test("Constructor, input directory in inputPath is stripped, duplicate directory
     "src"
   );
   t.is(pass2.outputPath, "src/avatar.png");
-  t.is(pass2.getOutputPath(), "_site/src/avatar.png");
+  t.is(await pass2.getOutputPath(), "_site/src/avatar.png");
 });
 
-test("Constructor, input directory (object param, directory)", (t) => {
+test("Constructor, input directory (object param, directory)", async (t) => {
   let pass = getTemplatePassthrough({ inputPath: "src/test", outputPath: "test" }, "_site", "src");
   t.is(pass.outputPath, "test");
-  t.is(pass.getOutputPath(), "_site/test");
+  t.is(await pass.getOutputPath(), "_site/test");
 });
 
-test("Constructor, input directory, path missing input directory", (t) => {
+test("Constructor, input directory, path missing input directory", async (t) => {
   let pass = getTemplatePassthrough("avatar.png", "_site", "src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/avatar.png");
+  t.is(await pass.getOutputPath(), "_site/avatar.png");
 
   let pass2 = getTemplatePassthrough(
     { inputPath: "avatar.png", outputPath: "avatar.png" },
@@ -75,7 +75,7 @@ test("Constructor, input directory, path missing input directory", (t) => {
     "src"
   );
   t.is(pass2.outputPath, "avatar.png");
-  t.is(pass2.getOutputPath(), "_site/avatar.png");
+  t.is(await pass2.getOutputPath(), "_site/avatar.png");
 });
 
 test("Constructor Dry Run", (t) => {
@@ -85,80 +85,84 @@ test("Constructor Dry Run", (t) => {
   t.is(pass.isDryRun, true);
 });
 
-test("Origin path isn’t included in output when targeting a directory", (t) => {
+test("Origin path isn’t included in output when targeting a directory", async (t) => {
   let pass = getTemplatePassthrough("img", "_site", "_src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/img");
+  t.is(await pass.getOutputPath(), "_site/img");
 });
 
-test("Origin path isn’t included in output when targeting a directory several levels deep", (t) => {
+test("Origin path isn’t included in output when targeting a directory several levels deep", async (t) => {
   let pass = getTemplatePassthrough("img", "_site", "_src/subdir");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/img");
+  t.is(await pass.getOutputPath(), "_site/img");
 });
 
-test("Target directory’s subdirectory structure is retained", (t) => {
+test("Target directory’s subdirectory structure is retained", async (t) => {
   let pass = getTemplatePassthrough("subdir/img", "_site", "_src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/subdir/img");
+  t.is(await pass.getOutputPath(), "_site/subdir/img");
 
   let pass2 = getTemplatePassthrough(
     { inputPath: "subdir/img", outputPath: "subdir/img" },
     "_site",
     "_src"
   );
-  t.is(pass2.getOutputPath(), "_site/subdir/img");
+  t.is(await pass2.getOutputPath(), "_site/subdir/img");
 });
 
-test("Origin path isn’t included in output when targeting a file", (t) => {
+test("Origin path isn’t included in output when targeting a file", async (t) => {
   let pass = getTemplatePassthrough("avatar.png", "_site", "_src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/avatar.png");
+  t.is(await pass.getOutputPath(), "_site/avatar.png");
 });
 
-test("Origin path isn’t included in output when targeting a file several levels deep", (t) => {
+test("Origin path isn’t included in output when targeting a file several levels deep", async (t) => {
   let pass = getTemplatePassthrough("avatar.png", "_site", "_src/subdir/img");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/avatar.png");
+  t.is(await pass.getOutputPath(), "_site/avatar.png");
 });
 
-test("Full input file path and deep input path", (t) => {
+test("Full input file path and deep input path", async (t) => {
   t.is(
-    getTemplatePassthrough("src/views/avatar.png", "_site", "src/views/").getOutputPath(),
+    await getTemplatePassthrough("src/views/avatar.png", "_site", "src/views/").getOutputPath(),
     "_site/avatar.png"
   );
   t.is(
-    getTemplatePassthrough("src/views/avatar.png", "_site", "src/views").getOutputPath(),
+    await getTemplatePassthrough("src/views/avatar.png", "_site", "src/views").getOutputPath(),
     "_site/avatar.png"
   );
   t.is(
-    getTemplatePassthrough("src/views/avatar.png", "_site/", "src/views").getOutputPath(),
+    await getTemplatePassthrough("src/views/avatar.png", "_site/", "src/views").getOutputPath(),
     "_site/avatar.png"
   );
   t.is(
-    getTemplatePassthrough("src/views/avatar.png", "./_site", "./src/views").getOutputPath(),
+    await getTemplatePassthrough("src/views/avatar.png", "./_site", "./src/views").getOutputPath(),
     "_site/avatar.png"
   );
   t.is(
-    getTemplatePassthrough("./src/views/avatar.png", "./_site/", "./src/views/").getOutputPath(),
+    await getTemplatePassthrough(
+      "./src/views/avatar.png",
+      "./_site/",
+      "./src/views/"
+    ).getOutputPath(),
     "_site/avatar.png"
   );
   t.is(
-    getTemplatePassthrough("./src/views/avatar.png", "_site", "src/views/").getOutputPath(),
+    await getTemplatePassthrough("./src/views/avatar.png", "_site", "src/views/").getOutputPath(),
     "_site/avatar.png"
   );
 });
 
-test(".htaccess", (t) => {
+test(".htaccess", async (t) => {
   let pass = getTemplatePassthrough(".htaccess", "_site", ".");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/.htaccess");
+  t.is(await pass.getOutputPath(), "_site/.htaccess");
 });
 
-test(".htaccess with input dir", (t) => {
+test(".htaccess with input dir", async (t) => {
   let pass = getTemplatePassthrough(".htaccess", "_site", "_src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/.htaccess");
+  t.is(await pass.getOutputPath(), "_site/.htaccess");
 });
 
 test("getFiles where not glob and file does not exist", async (t) => {
@@ -193,15 +197,15 @@ test("getFiles with glob", async (t) => {
   );
 
   t.is(
-    pass.getOutputPath(files.filter((entry) => entry.endsWith("test.css"))[0]),
+    await pass.getOutputPath(files.filter((entry) => entry.endsWith("test.css"))[0]),
     "_site/test/stubs/template-passthrough/static/test.css"
   );
   t.is(
-    pass.getOutputPath(files.filter((entry) => entry.endsWith("test.js"))[0]),
+    await pass.getOutputPath(files.filter((entry) => entry.endsWith("test.js"))[0]),
     "_site/test/stubs/template-passthrough/static/test.js"
   );
   t.is(
-    pass.getOutputPath(files.filter((entry) => entry.endsWith("test-nested.css"))[0]),
+    await pass.getOutputPath(files.filter((entry) => entry.endsWith("test-nested.css"))[0]),
     "_site/test/stubs/template-passthrough/static/nested/test-nested.css"
   );
 });
@@ -211,13 +215,13 @@ test("getFiles with glob 2", async (t) => {
   t.is(pass.outputPath, true);
   const files = await pass.getFiles(inputPath);
   t.deepEqual(files, ["./test/stubs/template-passthrough/static/test.js"]);
-  t.is(pass.getOutputPath(files[0]), "_site/test/stubs/template-passthrough/static/test.js");
+  t.is(await pass.getOutputPath(files[0]), "_site/test/stubs/template-passthrough/static/test.js");
 });
 
 test("Directory where outputPath is true", async (t) => {
   let pass = getTemplatePassthrough({ inputPath: "./static", outputPath: true }, "_site", "_src");
   t.is(pass.outputPath, true);
-  t.is(pass.getOutputPath(), "_site/static");
+  t.is(await pass.getOutputPath(), "_site/static");
 });
 
 test("Nested directory where outputPath is remapped", async (t) => {
@@ -227,7 +231,7 @@ test("Nested directory where outputPath is remapped", async (t) => {
     "_src"
   );
   t.is(pass.outputPath, "./test");
-  t.is(pass.getOutputPath(), "_site/test");
+  t.is(await pass.getOutputPath(), "_site/test");
 });
 
 test("Glob pattern", async (t) => {
@@ -241,7 +245,7 @@ test("Glob pattern", async (t) => {
     "_src"
   );
   t.is(pass.outputPath, "./directory/");
-  t.is(pass.getOutputPath(globResolvedPath), "_site/directory/test.js");
+  t.is(await pass.getOutputPath(globResolvedPath), "_site/directory/test.js");
 });
 
 test("Output paths match with different templatePassthrough methods", async (t) => {
@@ -251,7 +255,7 @@ test("Output paths match with different templatePassthrough methods", async (t) 
     "_src"
   );
   let pass2 = getTemplatePassthrough("avatar.png", "_site/test", ".");
-  t.is(pass1.getOutputPathForGlobFile("avatar.png"), pass2.getOutputPath());
+  t.is(await pass1.getOutputPathForGlobFile("avatar.png"), await pass2.getOutputPath());
 });
 
 // ToDo: Currently can't do :(
@@ -265,7 +269,7 @@ test("Output paths match with different templatePassthrough methods", async (t) 
 //     "_src"
 //   );
 //   t.truthy(pass);
-//   t.is(pass.getOutputPath(), "_site/rename.js");
+//   t.is(await pass.getOutputPath(), "_site/rename.js");
 // });
 
 test("Bug with incremental file copying to a directory output, issue #2278 #1038", async (t) => {
@@ -275,7 +279,7 @@ test("Bug with incremental file copying to a directory output, issue #2278 #1038
     "."
   );
 
-  t.is(pass1.getOutputPath(), "test/stubs/test.css");
+  t.is(await pass1.getOutputPath(), "test/stubs/test.css");
 });
 
 test("Bug with incremental dir copying to a directory output, issue #2278 #1038", async (t) => {
@@ -285,5 +289,5 @@ test("Bug with incremental dir copying to a directory output, issue #2278 #1038"
     "."
   );
 
-  t.is(pass1.getOutputPath(), "test/stubs");
+  t.is(await pass1.getOutputPath(), "test/stubs");
 });


### PR DESCRIPTION
This patch switches almost all usage of the `fs.*Sync` apis and `fs.promises.*` to using `graceful-fs` async promise versions instead. Required changing several methods and functions to be async but I believe they are all internal to the eleventy api(aka not a breaking change).

The only parts of eleventy which still use the sync apis after this are the initial config load ones.

## EMFILE Issues on windows/towards potential fix
There has been a history of EMFILE issues on windows with elventy. We've experience this in our own projects even on latest 2.0.1. These mostly stem from `addPassthroughCopy` but people have also had issues with a large number of template files. In our case we have a large number of image files(10k+).

https://github.com/11ty/eleventy/issues/2604

Although this patch does not fix it. Adding a graceful fs patch at the top of `Eleventy.js` after this patch does make large projects work but very slow on windows. Example: on windows with 16k files build takes 120 seconds instead of 12 under wsl or macOS. Previously the build would error out with EMFILE no matter what. I believe it has something to do with watchers or `recursive-copy` somehow.

## Improvements to eleventy
Anyways regardless of our own EMFILE issues this patch should improve the resiliency of eleventy since graceful-fs handles many other errors. The project already uses graceful-fs in a few places so I wouldn't think you'd oppose. I've also gone ahead and update all of the tests so they use `async/await` where necessary due to `getOutputPath()` changing.

## Performance
On wsl, linux, and macos this doesn't affect performance. On windows it makes large projects which previously failed buildable although slow(something is better than nothing).


Perf numbers on macOS m2 max:
``` 
Various plain eleventy versions:
[11ty] Copied 16549 files / Wrote 1191 files in 12.54 seconds (10.5ms each, v2.0.0-canary.9)
[11ty] Copied 16549 files / Wrote 1191 files in 11.50 seconds (9.7ms each, v2.0.1)

With: graceful-fs async all ops patch
[11ty] Copied 16549 files / Wrote 1191 files in 11.59 seconds (9.7ms each, v2.0.2-alpha.1)
```

Performance is essentially unchanged. Especially if you run multiple times this fluctuates.