### PR TITLE
fix: EleventyServe.js: update debug namespace

### DIFF
--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -6,7 +6,7 @@ const PathPrefixer = require("./Util/PathPrefixer");
 const merge = require("./Util/Merge");
 const checkPassthroughCopyBehavior = require("./Util/PassthroughCopyBehaviorCheck");
 
-const debug = require("debug")("EleventyServe");
+const debug = require("debug")("Eleventy:EleventyServe");
 
 class EleventyServeConfigError extends EleventyBaseError {}
 


### PR DESCRIPTION
All the other Eleventy modules have the `Eleventy:` prefix for their `debug()` namespace (including modules that have “Eleventy” in their name).

I think this was the only one doing it different.  It might make a difference for anyone filtering their debug messages with `Eleventy:*`.