### PR TITLE
Problem with "Eleventy fatal watch error"

### DIFF
--- a/src/EleventyWatch.js
+++ b/src/EleventyWatch.js
@@ -43,6 +43,8 @@ class EleventyWatch {
   getActiveQueue() {
     if (!this.isActive) {
       return [];
+    } else if (this.incremental && this.activeQueue.length === 0) {
+      return [];
     } else if (this.incremental) {
       return [this.activeQueue[0]];
     }


### PR DESCRIPTION
in `_watch()` in ..\@11ty\eleventy\src\Eleventy.js when calling `this.watchManager.getActiveQueue()` (line 802) an non empty array of path segments with `undefined` in the first and only array item might be returned.

This is unexpected and causes the error below.

`clearRequireCacheFor` is called with corrupted array.
`deleteRequireCache` is called with corrupted array.
`TemplatePath.absolutePath(...)` is used and breaks as it is not handling `undefined`;

This is happing when changing files and using autosave with --serve --incremental
flags and seems to be a racing condition problem that can be avoided by checking
`this.activeQueue.length` in `..\@11ty\eleventy\src\EleventyWatch.js`

    } else if (this.incremental && this.activeQueue.length === 0) {
      return [];

Stack Trace:

    [11ty] Eleventy fatal watch error: (more in DEBUG output)
    ConsoleLogger.js:91
    [11ty] The "path" argument must be of type string. Received undefined (via TypeError)
    ConsoleLogger.js:93
    [11ty] 
    [11ty] Original error stack trace: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    [11ty]     at new NodeError (node:internal/errors:387:5)
    [11ty]     at validateString (node:internal/validators:162:11)
    [11ty]     at Object.isAbsolute (node:path:403:5)
    [11ty]     at Function.TemplatePath.absolutePath (..\@11ty\eleventy-utils\src\TemplatePath.js:153:25)
    [11ty]     at deleteRequireCache (..\@11ty\eleventy\src\Util\DeleteRequireCache.js:17:35)
    [11ty]     at EleventyWatchTargets.clearRequireCacheFor (..\@11ty\eleventy\src\EleventyWatchTargets.js:131:7)
    [11ty]     at Eleventy._watch (..\@11ty\eleventy\src\Eleventy.js:807:23)
    [11ty]     at async watchRun (..\@11ty\eleventy\src\Eleventy.js:1047:9)
    [11ty]     at async FSWatcher.<anonymous> (..\@11ty\eleventy\src\Eleventy.js:1065:7)
