### PR TITLE
Use inclusive language in CLI help text

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -681,7 +681,7 @@ Arguments:
        Start without a build; build when files change. Works best with watch/serve/incremental.
 
      --formats=liquid,md
-       Whitelist only certain template types (default: \`*\`)
+       Allow only certain template types (default: \`*\`)
 
      --quiet
        Don’t print all written files (off by default)


### PR DESCRIPTION
Pretty straightforward change to use inclusive language in the help text. Testable by running `npx eleventy --help` and scrolling down to the `--formats` flag's description.

Thanks for your consideration!