### PR TITLE
Register dependencies found during pug compilation

### DIFF
--- a/src/Engines/Pug.js
+++ b/src/Engines/Pug.js
@@ -35,7 +35,13 @@ class Pug extends TemplateEngine {
       options.filename = inputPath;
     }
 
-    return this.pugLib.compile(str, options);
+    const compiled = this.pugLib.compile(str, options);
+
+    if (compiled.dependencies) {
+      this.config.uses.addDependency(inputPath, compiled.dependencies);
+    }
+
+    return compiled;
   }
 }
 


### PR DESCRIPTION
My main layout is written in pug, and uses an `include` file. When running `eleventy --serve` I noticed that changes to the included file would trigger rebuilds, but not show the changes. This seems to be similar to #2741.

Here I fix this by using the list of dependencies that the pug `compile` function includes on the function that it returns. With this I am seeing changes to my included file reflected immediately.