### PR TITLE
#2935 Remove the .d.ts file and rely on JSDocs entirely

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "access": "public"
   },
   "main": "src/Eleventy.js",
-  "types": "src/index.d.ts",
   "bin": {
     "eleventy": "./cmd.js"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,0 @@
-import UserConfig from "./UserConfig";
-
-export { UserConfig };


### PR DESCRIPTION
When we import values in a Typescript project, Typescript automatically infers the types using JSDoc comments if possible: https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#providing-type-hints-in-js-via-jsdoc. The present index.d.ts file is then just a redundancy on top of the Eleventy.js file, and requires additional maintenance to keep it up to date. 

This fixes #2935 