### PR TITLE
Support rebuild event from dev server

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -952,6 +952,8 @@ Arguments:
     benchmark.before();
     await this._initWatchDependencies();
     benchmark.after();
+
+    eventBus.on("eleventyDevServer.rebuild", async () => await this._watch());
   }
 
   get isEsm() {

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -3,6 +3,7 @@ import EleventyDevServer from "@11ty/eleventy-dev-server";
 import debugUtil from "debug";
 
 import EleventyBaseError from "./EleventyBaseError.js";
+import EventBus from "./EventBus.js";
 import ConsoleLogger from "./Util/ConsoleLogger.js";
 import PathPrefixer from "./Util/PathPrefixer.js";
 import merge from "./Util/Merge.js";
@@ -164,6 +165,10 @@ class EleventyServe {
 
     // Static method `getServer` was already checked in `getServerModule`
     this._server = serverModule.getServer("eleventy-server", this.outputDir, this.options);
+
+    if ("setEventBus" in this._server) {
+      this._server.setEventBus(EventBus);
+    }
 
     this.setAliases(this._aliases);
   }


### PR DESCRIPTION
This feature adds the ability to define a `rebuildUrl` in the config. When eleventy-dev-server is running and a POST request is made to that URL, 11ty rebuilds the site.

Rationale: I'm working on a cool 11ty / Strapi project. In the cloud, when content is updated on Strapi, Strapi can send a webhook to whichever service is hosting 11ty, to rebuild the 11ty site. However this doesn't work for local development, as discussed at https://github.com/11ty/eleventy/issues/604, https://github.com/11ty/eleventy/issues/691 and elsewhere.

There have been suggested workarounds that generally involve the 11ty user writing an(other) HTTP server to accept the request and dumping a file somewhere to trigger a rebuild. But it is clunky and we already have an HTTP server. I reused existing EventBus functionality; really most of my time was spent reading and understanding the code.

I hope this is useful; it's my first 11ty contribution so feel free to let me know how it may be improved. :)

Corresponding dev server PR: (to be filled in)