### PR TITLE
Move stylistic eslint rules to prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,18 +1,14 @@
 {
 	"env": {
-			"es2021": true,
-			"node": true
+		"es2021": true,
+		"node": true
 	},
-	"extends": "eslint:recommended",
+	"extends": ["eslint:recommended", "prettier"],
 	"parserOptions": {
-			"ecmaVersion": "latest",
-			"sourceType": "module"
+		"ecmaVersion": "latest",
+		"sourceType": "module"
 	},
 	"rules": {
-		"indent": ["error", "tab"],
-		"linebreak-style": ["error", "unix"],
-		"quotes": ["error", "double"],
-		"semi": ["error", "always"],
 		"no-async-promise-executor": "warn",
 		"no-prototype-builtins": "warn"
 	}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,8 @@
 {
+	"useTabs": true,
+	"singleQuote": false,
+	"semi": true,
+	"endOfLine": "lf",
 	"arrowParens": "always",
 	"printWidth": 100
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"ava": "^5.3.1",
 		"c8": "^8.0.1",
 		"eslint": "^8.53.0",
+		"eslint-config-prettier": "^9.0.0",
 		"husky": "^8.0.3",
 		"js-yaml": "^4.1.0",
 		"jsdoc": "^4.0.2",


### PR DESCRIPTION
Ideally we shouldn't be using stylistic rules with Eslint since we already have Prettier, and you've already encountered some conflicts (https://github.com/11ty/eleventy/commit/424a4bf85edfed2fbc1727c7cdff610f2521a231, https://github.com/11ty/eleventy/commit/88fe5efcb1b53de63ed9b51074985c2e8da1f82a). This PR moves stylistic rules to Prettier and adds the `eslint-config-prettier` package to disable conflicts.