### PR TITLE
Remove FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-open_collective: 11ty


### PR DESCRIPTION
No need for this since the [organization-level FUNDING.yml](https://github.com/11ty/.github/blob/main/.github/FUNDING.yml) exists and is identical to this one.

![Screenshot of a notice above this repository's FUNDING.yml file saying that it is overriding the organization level FUNDING.yml file](https://github.com/11ty/eleventy/assets/47499684/34da2664-ce19-4e91-9adb-da7ff13385cc)
