### PR TITLE
Remove `indent_size` from `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
 end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = true


### PR DESCRIPTION
As the author of this [Stack Overflow answer](https://stackoverflow.com/questions/35649847/objective-reasons-for-using-spaces-instead-of-tabs-for-indentation/75019495#75019495), I loved seeing the [recent commit which converted the codebase to tabs](https://github.com/11ty/eleventy/commit/358ec48f779fa34e14abef057cc1fa0c1a10aa45) :slightly_smiling_face: Well done :clap:

As explained in the SO answer, the indent size should only be a personal preference set in your code editor. So any dev can have their own preference.

The purpose of having tabs is to let the user chooses the indent size they prefer. Having `indent_size = 2` in the project's `.editorconfig` overrides the user's personal preference, which defeats this purpose.