### PR TITLE
add: include and exclude filters for pagination

### DIFF
--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -116,6 +116,28 @@ class Pagination {
   }
 
   isFiltered(value) {
+    const hasInclude = "include" in this.data.pagination;
+    const hasExclude = "exclude" in this.data.pagination;
+    if (hasInclude && hasExclude) {
+      throw new Error("Pagination cannot have both `include` and `exclude` filters.");
+    }
+    if (hasInclude) {
+      let included = this.data.pagination.include;
+      if (Array.isArray(included)) {
+        return included.indexOf(value) === -1;
+      }
+      return included !== value;
+    }
+    if (hasExclude) {
+      let excluded = this.data.pagination.exclude;
+      if (Array.isArray(excluded)) {
+        return excluded.indexOf(value) !== -1;
+      }
+      return excluded === value;
+    }
+
+    // Let's keep this code for backwards compatibility to V2.
+    // TODO remove in 3.0
     if ("filter" in this.data.pagination) {
       let filtered = this.data.pagination.filter;
       if (Array.isArray(filtered)) {
@@ -179,7 +201,11 @@ class Pagination {
       result = result.reverse();
     }
 
-    if (this.data.pagination.filter) {
+    if (
+      this.data.pagination.filter ||
+      this.data.pagination.include ||
+      this.data.pagination.exclude
+    ) {
       result = result.filter((value) => !this.isFiltered(value));
     }
 

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -452,6 +452,49 @@ test("Page over an object (use values)", async (t) => {
   );
 });
 
+test("Page over an object (excluded, array)", async (t) => {
+  let tmpl = getNewTemplate(
+    "./test/stubs/paged/pagedobjectexcludearray.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let pages = await tmpl.getTemplates(data);
+
+  t.is(
+    (await pages[0].template.render(pages[0].data)).trim(),
+    "<ol><li>item1</li><li>item2</li><li>item3</li><li>item5</li></ol>"
+  );
+
+  t.is(
+    (await pages[1].template.render(pages[1].data)).trim(),
+    "<ol><li>item6</li><li>item7</li><li>item8</li><li>item9</li></ol>"
+  );
+});
+
+test("Page over an object (excluded, string)", async (t) => {
+  let tmpl = getNewTemplate(
+    "./test/stubs/paged/pagedobjectexcludestring.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let pages = await tmpl.getTemplates(data);
+  t.is(pages.length, 2);
+
+  t.is(
+    (await pages[0].template.render(pages[0].data)).trim(),
+    "<ol><li>item1</li><li>item2</li><li>item3</li><li>item5</li></ol>"
+  );
+
+  t.is(
+    (await pages[1].template.render(pages[1].data)).trim(),
+    "<ol><li>item6</li><li>item7</li><li>item8</li><li>item9</li></ol>"
+  );
+});
+
 test("Page over an object (filtered, array)", async (t) => {
   let tmpl = getNewTemplate(
     "./test/stubs/paged/pagedobjectfilterarray.njk",
@@ -493,6 +536,47 @@ test("Page over an object (filtered, string)", async (t) => {
     (await pages[1].template.render(pages[1].data)).trim(),
     "<ol><li>item6</li><li>item7</li><li>item8</li><li>item9</li></ol>"
   );
+});
+
+test("Page over an object (included, array)", async (t) => {
+  let tmpl = getNewTemplate(
+    "./test/stubs/paged/pagedobjectincludearray.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let pages = await tmpl.getTemplates(data);
+
+  t.is(
+    (await pages[0].template.render(pages[0].data)).trim(),
+    "<ol><li>item3</li><li>item4</li></ol>"
+  );
+});
+
+test("Page over an object (included, string)", async (t) => {
+  let tmpl = getNewTemplate(
+    "./test/stubs/paged/pagedobjectincludestring.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  let pages = await tmpl.getTemplates(data);
+  t.is(pages.length, 1);
+
+  t.is((await pages[0].template.render(pages[0].data)).trim(), "<ol><li>item4</li></ol>");
+});
+
+test("Page with exclude and include", async (t) => {
+  let tmpl = getNewTemplate(
+    "./test/stubs/paged/pagedobjectincludeexclude.njk",
+    "./test/stubs/",
+    "./dist"
+  );
+
+  let data = await tmpl.getData();
+  await t.throwsAsync(tmpl.getTemplates(data));
 });
 
 test("Pagination with deep data merge #147", async (t) => {

--- a/test/stubs/paged/pagedobjectexcludearray.njk
+++ b/test/stubs/paged/pagedobjectexcludearray.njk
@@ -1,0 +1,18 @@
+---
+pagination:
+  data: testdata
+  size: 4
+  exclude:
+    - item4
+testdata:
+  item1: itemvalue1
+  item2: itemvalue2
+  item3: itemvalue3
+  item4: itemvalue4
+  item5: itemvalue5
+  item6: itemvalue6
+  item7: itemvalue7
+  item8: itemvalue8
+  item9: itemvalue9
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>

--- a/test/stubs/paged/pagedobjectexcludestring.njk
+++ b/test/stubs/paged/pagedobjectexcludestring.njk
@@ -1,0 +1,17 @@
+---
+pagination:
+  data: testdata
+  size: 4
+  exclude: item4
+testdata:
+  item1: itemvalue1
+  item2: itemvalue2
+  item3: itemvalue3
+  item4: itemvalue4
+  item5: itemvalue5
+  item6: itemvalue6
+  item7: itemvalue7
+  item8: itemvalue8
+  item9: itemvalue9
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>

--- a/test/stubs/paged/pagedobjectincludearray.njk
+++ b/test/stubs/paged/pagedobjectincludearray.njk
@@ -1,0 +1,19 @@
+---
+pagination:
+  data: testdata
+  size: 4
+  include:
+    - item3
+    - item4
+testdata:
+  item1: itemvalue1
+  item2: itemvalue2
+  item3: itemvalue3
+  item4: itemvalue4
+  item5: itemvalue5
+  item6: itemvalue6
+  item7: itemvalue7
+  item8: itemvalue8
+  item9: itemvalue9
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>

--- a/test/stubs/paged/pagedobjectincludeexclude.njk
+++ b/test/stubs/paged/pagedobjectincludeexclude.njk
@@ -1,0 +1,18 @@
+---
+pagination:
+  data: testdata
+  size: 4
+  include: item4
+  exclude: item5
+testdata:
+  item1: itemvalue1
+  item2: itemvalue2
+  item3: itemvalue3
+  item4: itemvalue4
+  item5: itemvalue5
+  item6: itemvalue6
+  item7: itemvalue7
+  item8: itemvalue8
+  item9: itemvalue9
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>

--- a/test/stubs/paged/pagedobjectincludestring.njk
+++ b/test/stubs/paged/pagedobjectincludestring.njk
@@ -1,0 +1,17 @@
+---
+pagination:
+  data: testdata
+  size: 4
+  include: item4
+testdata:
+  item1: itemvalue1
+  item2: itemvalue2
+  item3: itemvalue3
+  item4: itemvalue4
+  item5: itemvalue5
+  item6: itemvalue6
+  item7: itemvalue7
+  item8: itemvalue8
+  item9: itemvalue9
+---
+<ol>{% for item in pagination.items %}<li>{{ item }}</li>{% endfor %}</ol>


### PR DESCRIPTION
This Commit adds the `include` and `exclude` attributes to the pagination plugin. This allows for more semantic filtering in a backwards compatible manner.

This commit also adds the required tests based on the existing filter tests.

TODO: Remove old `filter` for v3.0

fixes: #2522 with option 1 from [this comment](https://github.com/11ty/eleventy/issues/2522#issuecomment-1807181893)