### PR TITLE
add: make log filter async friendly by adding logAsync

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -73,6 +73,11 @@ export default function (config) {
 		return input;
 	});
 
+	config.addFilter("logAsync", async (input, ...messages) => {
+		console.log(await input, ...(await Promise.all(messages)));
+		return input;
+	});
+
 	config.addFilter("getCollectionItemIndex", function (collection, pageOverride) {
 		return getCollectionItemIndex.call(this, collection, pageOverride);
 	});


### PR DESCRIPTION
Right now the `log` filter logs the passed in values directly. This isn't always helpful when working with async values e.g. in webc components. This change adds the `logAsync` filter to also take promises as any value and awaits them, so you always get some useful output.

It could be possible to just eagerly return the value in the sync filter and then use a `.then` call to log the values, but that would leave room for unexpected data mutation, so I didn't implement it that way for now.

resolves #3133 