### PR TITLE
refactor: Prefer `const` where appropriate

### DIFF
--- a/src/Benchmark.js
+++ b/src/Benchmark.js
@@ -34,7 +34,7 @@ class Benchmark {
 			throw new Error("You called Benchmark after() without a before().");
 		}
 
-		let before = this.beforeTimers.pop();
+		const before = this.beforeTimers.pop();
 		if (!this.beforeTimers.length) {
 			this.timeSpent += this.getNewTimestamp() - before;
 		}

--- a/src/BenchmarkGroup.js
+++ b/src/BenchmarkGroup.js
@@ -28,11 +28,11 @@ class BenchmarkGroup {
 
 	// TODO use addAsync everywhere instead
 	add(type, callback) {
-		let benchmark = (this.benchmarks[type] = new Benchmark());
+		const benchmark = (this.benchmarks[type] = new Benchmark());
 
 		return function (...args) {
 			benchmark.before();
-			let ret = callback.call(this, ...args);
+			const ret = callback.call(this, ...args);
 			benchmark.after();
 			return ret;
 		};
@@ -52,7 +52,7 @@ class BenchmarkGroup {
 	// }
 
 	setMinimumThresholdMs(minimumThresholdMs) {
-		let val = parseInt(minimumThresholdMs, 10);
+		const val = parseInt(minimumThresholdMs, 10);
 		if (isNaN(val)) {
 			throw new Error("`setMinimumThresholdMs` expects a number argument.");
 		}
@@ -60,7 +60,7 @@ class BenchmarkGroup {
 	}
 
 	setMinimumThresholdPercent(minimumThresholdPercent) {
-		let val = parseInt(minimumThresholdPercent, 10);
+		const val = parseInt(minimumThresholdPercent, 10);
 		if (isNaN(val)) {
 			throw new Error("`setMinimumThresholdPercent` expects a number argument.");
 		}
@@ -83,24 +83,24 @@ class BenchmarkGroup {
 			return num;
 		}
 
-		let prefix = new Array(length + 1).join(" ");
+		const prefix = new Array(length + 1).join(" ");
 		return (prefix + num).substr(-1 * length);
 	}
 
 	finish(label, totalTimeSpent) {
 		for (var type in this.benchmarks) {
-			let bench = this.benchmarks[type];
-			let isAbsoluteMinimumComparison = this.minimumThresholdMs > 0;
-			let totalForBenchmark = bench.getTotal();
-			let percent = Math.round((totalForBenchmark * 100) / totalTimeSpent);
-			let callCount = bench.getTimesCalled();
+			const bench = this.benchmarks[type];
+			const isAbsoluteMinimumComparison = this.minimumThresholdMs > 0;
+			const totalForBenchmark = bench.getTotal();
+			const percent = Math.round((totalForBenchmark * 100) / totalTimeSpent);
+			const callCount = bench.getTimesCalled();
 
-			let output = {
+			const output = {
 				ms: this.padNumber(totalForBenchmark.toFixed(0), 6),
 				percent: this.padNumber(percent, 3),
 				calls: this.padNumber(callCount, 5),
 			};
-			let str = `Benchmark ${output.ms}ms ${output.percent}% ${output.calls}× (${label}) ${type}`;
+			const str = `Benchmark ${output.ms}ms ${output.percent}% ${output.calls}× (${label}) ${type}`;
 
 			if (
 				(isAbsoluteMinimumComparison && totalForBenchmark >= this.minimumThresholdMs) ||

--- a/src/BenchmarkManager.js
+++ b/src/BenchmarkManager.js
@@ -63,7 +63,7 @@ class BenchmarkManager {
 	}
 
 	finish() {
-		let totalTimeSpentBenchmarking = this.getNewTimestamp() - this.start;
+		const totalTimeSpentBenchmarking = this.getNewTimestamp() - this.start;
 		for (var j in this.benchmarkGroups) {
 			this.benchmarkGroups[j].finish(j, totalTimeSpentBenchmarking);
 		}

--- a/src/ComputedData.js
+++ b/src/ComputedData.js
@@ -49,11 +49,11 @@ class ComputedData {
 	}
 
 	async resolveVarOrder(data) {
-		let proxyByTemplateString = new ComputedDataTemplateString(this.computedKeys);
-		let proxyByProxy = new ComputedDataProxy(this.computedKeys);
+		const proxyByTemplateString = new ComputedDataTemplateString(this.computedKeys);
+		const proxyByProxy = new ComputedDataProxy(this.computedKeys);
 
-		for (let key of this.computedKeys) {
-			let computed = lodashGet(this.computed, key);
+		for (const key of this.computedKeys) {
+			const computed = lodashGet(this.computed, key);
 
 			if (typeof computed !== "function") {
 				// add nodes for non functions (primitives like booleans, etc)
@@ -62,20 +62,20 @@ class ComputedData {
 			} else {
 				this.queue.uses(key, this.declaredDependencies[key]);
 
-				let symbolParseFn = lodashGet(this.symbolParseFunctions, key);
+				const symbolParseFn = lodashGet(this.symbolParseFunctions, key);
 				let varsUsed = [];
 				if (symbolParseFn) {
 					// use the parseForSymbols function in the TemplateEngine
 					varsUsed = symbolParseFn();
 				} else if (symbolParseFn !== false) {
 					// skip resolution is this is false (just use declaredDependencies)
-					let isTemplateString = !!this.templateStringKeyLookup[key];
-					let proxy = isTemplateString ? proxyByTemplateString : proxyByProxy;
+					const isTemplateString = !!this.templateStringKeyLookup[key];
+					const proxy = isTemplateString ? proxyByTemplateString : proxyByProxy;
 					varsUsed = await proxy.findVarsUsed(computed, data);
 				}
 
 				debug("%o accesses %o variables", key, varsUsed);
-				let filteredVarsUsed = varsUsed.filter((varUsed) => {
+				const filteredVarsUsed = varsUsed.filter((varUsed) => {
 					return (
 						(varUsed !== key && this.computedKeys.has(varUsed)) ||
 						varUsed.startsWith("collections.")
@@ -88,11 +88,11 @@ class ComputedData {
 
 	async _setupDataEntry(data, order) {
 		debug("Computed data order of execution: %o", order);
-		for (let key of order) {
-			let computed = lodashGet(this.computed, key);
+		for (const key of order) {
+			const computed = lodashGet(this.computed, key);
 
 			if (typeof computed === "function") {
-				let ret = await computed(data);
+				const ret = await computed(data);
 				lodashSet(data, key, ret);
 			} else if (computed !== undefined) {
 				lodashSet(data, key, computed);

--- a/src/ComputedDataProxy.js
+++ b/src/ComputedDataProxy.js
@@ -23,16 +23,16 @@ class ComputedDataProxy {
 
 		// TODO should make another effort to get rid of this,
 		// See the ProxyWrap util for more proxy handlers that will likely fix this
-		let undefinedValue = "__11TY_UNDEFINED__";
+		const undefinedValue = "__11TY_UNDEFINED__";
 		if (this.computedKeys) {
-			for (let key of this.computedKeys) {
+			for (const key of this.computedKeys) {
 				if (lodashGet(data, key, undefinedValue) === undefinedValue) {
 					lodashSet(data, key, "");
 				}
 			}
 		}
 
-		let proxyData = this._getProxyData(data, keyRef);
+		const proxyData = this._getProxyData(data, keyRef);
 		return proxyData;
 	}
 
@@ -45,7 +45,7 @@ class ComputedDataProxy {
 						return obj[key];
 					}
 
-					let newKey = `${parentKey ? `${parentKey}.` : ""}${key}`;
+					const newKey = `${parentKey ? `${parentKey}.` : ""}${key}`;
 
 					// Issue #1137
 					// Special case for Collections, always return an Array for collection keys
@@ -66,7 +66,7 @@ class ComputedDataProxy {
 						);
 					}
 
-					let newData = this._getProxyData(dataObj[key], keyRef, newKey);
+					const newData = this._getProxyData(dataObj[key], keyRef, newKey);
 					if (!this.isArrayOrPlainObject(newData)) {
 						keyRef.add(newKey);
 					}
@@ -91,8 +91,8 @@ class ComputedDataProxy {
 					return;
 				}
 
-				let newKey = `${parentKey}[${key}]`;
-				let newData = this._getProxyData(dataArr[key], keyRef, newKey);
+				const newKey = `${parentKey}[${key}]`;
+				const newData = this._getProxyData(dataArr[key], keyRef, newKey);
 				if (!this.isArrayOrPlainObject(newData)) {
 					keyRef.add(newKey);
 				}
@@ -113,10 +113,10 @@ class ComputedDataProxy {
 	}
 
 	async findVarsUsed(fn, data = {}) {
-		let keyRef = new Set();
+		const keyRef = new Set();
 
 		// careful, logging proxyData will mess with test results!
-		let proxyData = this.getProxyData(data, keyRef);
+		const proxyData = this.getProxyData(data, keyRef);
 
 		// squelch console logs for this fake proxy data pass 😅
 		// let savedLog = console.log;

--- a/src/ComputedDataQueue.js
+++ b/src/ComputedDataQueue.js
@@ -42,7 +42,7 @@ class ComputedDataQueue {
 			graph.addNode(name);
 		}
 
-		for (let varUsed of varsUsed) {
+		for (const varUsed of varsUsed) {
 			if (!graph.hasNode(varUsed)) {
 				graph.addNode(varUsed);
 			}
@@ -55,7 +55,7 @@ class ComputedDataQueue {
 	}
 
 	markComputed(varsComputed = []) {
-		for (let varComputed of varsComputed) {
+		for (const varComputed of varsComputed) {
 			this.graph.removeNode(varComputed);
 		}
 	}

--- a/src/ComputedDataTemplateString.js
+++ b/src/ComputedDataTemplateString.js
@@ -24,12 +24,12 @@ class ComputedDataTemplateString {
 	}
 
 	getProxyData() {
-		let proxyData = {};
+		const proxyData = {};
 
 		// use these special strings as a workaround to check the rendered output
 		// can’t use proxies here as some template languages trigger proxy for all
 		// keys in data
-		for (let key of this.computedKeys) {
+		for (const key of this.computedKeys) {
 			// TODO don’t allow to set eleventyComputed.page? other disallowed computed things?
 			lodashSet(proxyData, key, this.prefix + key + this.suffix);
 		}
@@ -38,10 +38,13 @@ class ComputedDataTemplateString {
 	}
 
 	findVarsInOutput(output = "") {
-		let vars = new Set();
-		let splits = output.split(this.prefix);
-		for (let split of splits) {
-			let varName = split.slice(0, split.indexOf(this.suffix) < 0 ? 0 : split.indexOf(this.suffix));
+		const vars = new Set();
+		const splits = output.split(this.prefix);
+		for (const split of splits) {
+			const varName = split.slice(
+				0,
+				split.indexOf(this.suffix) < 0 ? 0 : split.indexOf(this.suffix),
+			);
 			if (varName) {
 				vars.add(varName);
 			}
@@ -50,7 +53,7 @@ class ComputedDataTemplateString {
 	}
 
 	async findVarsUsed(fn) {
-		let proxyData = this.getProxyData();
+		const proxyData = this.getProxyData();
 		let output;
 		// Mitigation for #1061, errors with filters in the first pass shouldn’t fail the whole thing.
 		try {

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -325,13 +325,13 @@ class Eleventy {
 			);
 		}
 
-		let ret = [];
+		const ret = [];
 
-		let writeCount = this.writer.getWriteCount();
-		let skippedCount = this.writer.getSkippedCount();
-		let copyCount = this.writer.getCopyCount();
+		const writeCount = this.writer.getWriteCount();
+		const skippedCount = this.writer.getSkippedCount();
+		const copyCount = this.writer.getCopyCount();
 
-		let slashRet = [];
+		const slashRet = [];
 
 		if (copyCount) {
 			slashRet.push(`Copied ${copyCount} ${simplePlural(copyCount, "file", "files")}`);
@@ -347,8 +347,8 @@ class Eleventy {
 			ret.push(slashRet.join(" / "));
 		}
 
-		let versionStr = `v${pkg.version}`;
-		let time = ((this.getNewTimestamp() - this.start) / 1000).toFixed(2);
+		const versionStr = `v${pkg.version}`;
+		const time = ((this.getNewTimestamp() - this.start) / 1000).toFixed(2);
 		ret.push(`in ${time} ${simplePlural(time, "second", "seconds")}`);
 
 		if (writeCount >= 10) {
@@ -371,14 +371,14 @@ class Eleventy {
 
 		// Restore from cache
 		if (this._privateCaches.has(key)) {
-			let c = this._privateCaches.get(key);
-			for (let cacheKey in c) {
+			const c = this._privateCaches.get(key);
+			for (const cacheKey in c) {
 				inst[cacheKey] = c[cacheKey];
 			}
 		} else {
 			// Set cache
-			let c = {};
-			for (let cacheKey of inst.caches || []) {
+			const c = {};
+			for (const cacheKey of inst.caches || []) {
 				c[cacheKey] = inst[cacheKey];
 			}
 			this._privateCaches.set(key, c);
@@ -407,7 +407,7 @@ class Eleventy {
 
 		this.config.inputDir = this.inputDir;
 
-		let formats = this.formatsOverride || this.config.templateFormats;
+		const formats = this.formatsOverride || this.config.templateFormats;
 		this.extensionMap = new EleventyExtensionMap(formats, this.eleventyConfig);
 		await this.config.events.emit("eleventy.extensionmap", this.extensionMap);
 
@@ -446,7 +446,7 @@ class Eleventy {
 		}
 
 		// Note these directories are all project root relative
-		let dirs = {
+		const dirs = {
 			input: this.inputDir,
 			data: this.templateData.getDataDir(),
 			includes: this.eleventyFiles.getIncludesDir(),
@@ -496,17 +496,17 @@ Verbose Output: ${this.verboseMode}`);
 
 	// These are all set as initial global data under eleventy.env.* (see TemplateData->environmentVariables)
 	getEnvironmentVariableValues() {
-		let values = {
+		const values = {
 			source: this.source,
 			runMode: this.runMode,
 		};
-		let configPath = this.eleventyConfig.getLocalProjectConfigFile();
+		const configPath = this.eleventyConfig.getLocalProjectConfigFile();
 		if (configPath) {
-			let absolutePathToConfig = TemplatePath.absolutePath(configPath);
+			const absolutePathToConfig = TemplatePath.absolutePath(configPath);
 			values.config = absolutePathToConfig;
 
 			// TODO(zachleat): if config is not in root (e.g. using --config=)
-			let root = TemplatePath.getDirFromFilePath(absolutePathToConfig);
+			const root = TemplatePath.getDirFromFilePath(absolutePathToConfig);
 			values.root = root;
 		}
 
@@ -762,7 +762,7 @@ Arguments:
 			);
 		}
 
-		let relevantLayouts = this.eleventyConfig.usesGraph.getLayoutsUsedBy(changedFilePath);
+		const relevantLayouts = this.eleventyConfig.usesGraph.getLayoutsUsedBy(changedFilePath);
 
 		// Note: this is a sync event!
 		eventBus.emit("eleventy.resourceModified", changedFilePath, usedByDependants, {
@@ -774,8 +774,8 @@ Arguments:
 	}
 
 	shouldTriggerConfigReset(changedFiles) {
-		let configFilePaths = new Set(this.eleventyConfig.getLocalProjectConfigFiles());
-		for (let filePath of changedFiles) {
+		const configFilePaths = new Set(this.eleventyConfig.getLocalProjectConfigFiles());
+		for (const filePath of changedFiles) {
 			if (configFilePaths.has(filePath)) {
 				return true;
 			}
@@ -783,9 +783,9 @@ Arguments:
 
 		for (const configFilePath of configFilePaths) {
 			// Any dependencies of the config file changed
-			let configFileDependencies = new Set(this.watchTargets.getDependenciesOf(configFilePath));
+			const configFileDependencies = new Set(this.watchTargets.getDependenciesOf(configFilePath));
 
-			for (let filePath of changedFiles) {
+			for (const filePath of changedFiles) {
 				if (configFileDependencies.has(filePath)) {
 					return true;
 				}
@@ -821,7 +821,7 @@ Arguments:
 
 		this.watchManager.setBuildRunning();
 
-		let queue = this.watchManager.getActiveQueue();
+		const queue = this.watchManager.getActiveQueue();
 
 		await this.config.events.emit("beforeWatch", queue);
 		await this.config.events.emit("eleventy.beforeWatch", queue);
@@ -837,12 +837,12 @@ Arguments:
 		await this.restart();
 		await this.init({ viaConfigReset: isResetConfig });
 
-		let incrementalFile = this.watchManager.getIncrementalFile();
+		const incrementalFile = this.watchManager.getIncrementalFile();
 		if (incrementalFile) {
 			this.writer.setIncrementalFile(incrementalFile);
 		}
 
-		let writeResults = await this.write();
+		const writeResults = await this.write();
 		// let passthroughCopyResults;
 		let templateResults;
 		if (!writeResults.error) {
@@ -861,7 +861,7 @@ Arguments:
 		// Is a CSS input file and is not in the includes folder
 		// TODO check output path file extension of this template (not input path)
 		// TODO add additional API for this, maybe a config callback?
-		let onlyCssChanges = this.watchManager.hasAllQueueFiles((path) => {
+		const onlyCssChanges = this.watchManager.hasAllQueueFiles((path) => {
 			return (
 				path.endsWith(".css") &&
 				// TODO how to make this work with relative includes?
@@ -874,7 +874,7 @@ Arguments:
 				error: writeResults.error,
 			});
 		} else {
-			let normalizedPathPrefix = PathPrefixer.normalizePathPrefix(this.config.pathPrefix);
+			const normalizedPathPrefix = PathPrefixer.normalizePathPrefix(this.config.pathPrefix);
 			await this.eleventyServe.reload({
 				files: this.watchManager.getActiveQueue(),
 				subtype: onlyCssChanges ? "css" : undefined,
@@ -892,7 +892,7 @@ Arguments:
 
 		this.watchManager.setBuildFinished();
 
-		let queueSize = this.watchManager.getPendingQueueSize();
+		const queueSize = this.watchManager.getPendingQueueSize();
 		if (queueSize > 0) {
 			this.logger.log(
 				`You saved while Eleventy was running, let’s run again. (${queueSize} change${
@@ -934,7 +934,7 @@ Arguments:
 		// Template and Directory Data Files
 		this.watchTargets.add(await this.eleventyFiles.getGlobWatcherTemplateDataFiles());
 
-		let benchmark = this.watcherBench.get(
+		const benchmark = this.watcherBench.get(
 			"Watching JavaScript Dependencies (disable with `eleventyConfig.setWatchJavaScriptDependencies(false)`)",
 		);
 		benchmark.before();
@@ -946,7 +946,7 @@ Arguments:
 		if (this._isEsm === undefined) {
 			try {
 				// fetch from project’s package.json
-				let projectPackageJson = getWorkingProjectPackageJson();
+				const projectPackageJson = getWorkingProjectPackageJson();
 				this._isEsm = projectPackageJson?.type === "module";
 			} catch (e) {
 				debug("Could not find a project package.json for project’s ES Modules check: %O", e);
@@ -969,7 +969,7 @@ Arguments:
 			return;
 		}
 
-		let dataDir = TemplatePath.stripLeadingDotSlash(this.templateData.getDataDir());
+		const dataDir = TemplatePath.stripLeadingDotSlash(this.templateData.getDataDir());
 		function filterOutGlobalDataFiles(path) {
 			return !dataDir || !TemplatePath.stripLeadingDotSlash(path).startsWith(dataDir);
 		}
@@ -978,7 +978,7 @@ Arguments:
 		this.watchTargets.setProjectUsingEsm(this.isEsm);
 
 		// Template files .11ty.js
-		let templateFiles = await this.eleventyFiles.getWatchPathCache();
+		const templateFiles = await this.eleventyFiles.getWatchPathCache();
 		await this.watchTargets.addDependencies(templateFiles);
 
 		// Config file dependencies
@@ -988,7 +988,7 @@ Arguments:
 		);
 
 		// Deps from Global Data (that aren’t in the global data directory, everything is watched there)
-		let globalDataDeps = this.templateData.getWatchPathCache();
+		const globalDataDeps = this.templateData.getWatchPathCache();
 		await this.watchTargets.addDependencies(globalDataDeps, filterOutGlobalDataFiles);
 
 		await this.watchTargets.addDependencies(
@@ -1008,10 +1008,10 @@ Arguments:
 	}
 
 	getChokidarConfig() {
-		let ignores = this.eleventyFiles.getGlobWatcherIgnores();
+		const ignores = this.eleventyFiles.getGlobWatcherIgnores();
 		debug("Ignoring watcher changes to: %o", ignores);
 
-		let configOptions = this.config.chokidarConfig;
+		const configOptions = this.config.chokidarConfig;
 
 		// can’t override these yet
 		// TODO maybe if array, merge the array?
@@ -1044,8 +1044,8 @@ Arguments:
 		let chokidar;
 		// eslint-disable-next-line no-useless-catch
 		try {
-			let moduleName = "chokidar";
-			let chokidarImport = await import(moduleName);
+			const moduleName = "chokidar";
+			const chokidarImport = await import(moduleName);
 			chokidar = chokidarImport.default;
 		} catch (e) {
 			throw e;
@@ -1053,22 +1053,22 @@ Arguments:
 
 		// Note that watching indirectly depends on this for fetching dependencies from JS files
 		// See: TemplateWriter:pathCache and EleventyWatchTargets
-		let result = await this.write();
+		const result = await this.write();
 		if (result.error) {
 			// initial build failed—quit watch early
 			return Promise.reject(result.error);
 		}
 
-		let initWatchBench = this.watcherBench.get("Start up --watch");
+		const initWatchBench = this.watcherBench.get("Start up --watch");
 		initWatchBench.before();
 
 		await this.initWatch();
 
 		// TODO improve unwatching if JS dependencies are removed (or files are deleted)
-		let rawFiles = await this.getWatchedFiles();
+		const rawFiles = await this.getWatchedFiles();
 		debug("Watching for changes to: %o", rawFiles);
 
-		let watcher = chokidar.watch(rawFiles, this.getChokidarConfig());
+		const watcher = chokidar.watch(rawFiles, this.getChokidarConfig());
 
 		initWatchBench.after();
 
@@ -1079,10 +1079,10 @@ Arguments:
 		this.watcher = watcher;
 
 		let watchDelay;
-		let watchRun = async (path) => {
+		const watchRun = async (path) => {
 			path = TemplatePath.normalize(path);
 			try {
-				let isResetConfig = this._shouldResetConfig([path]);
+				const isResetConfig = this._shouldResetConfig([path]);
 				this._addFileToWatchQueue(path, isResetConfig);
 
 				clearTimeout(watchDelay);
@@ -1207,7 +1207,7 @@ Arguments:
 		let hasError = false;
 
 		try {
-			let eventsArg = {
+			const eventsArg = {
 				inputDir: this.config.inputDir,
 				dir: this.config.dir,
 				runMode: this.runMode,
@@ -1234,7 +1234,7 @@ Arguments:
 			ret = await promise;
 
 			// Passing the processed output to the eleventy.after event is new in 2.0
-			let [, /*passthroughCopyResults*/ ...templateResults] = ret;
+			const [, /*passthroughCopyResults*/ ...templateResults] = ret;
 
 			if (to === "fs") {
 				// New in 3.0: flatten return object for return.

--- a/src/EleventyErrorUtil.js
+++ b/src/EleventyErrorUtil.js
@@ -39,12 +39,12 @@ class EleventyErrorUtil {
 			return error;
 		}
 
-		let msg = error.message;
-		let objectString = msg.substring(
+		const msg = error.message;
+		const objectString = msg.substring(
 			msg.indexOf(EleventyErrorUtil.prefix) + EleventyErrorUtil.prefix.length,
 			msg.lastIndexOf(EleventyErrorUtil.suffix),
 		);
-		let obj = JSON.parse(objectString);
+		const obj = JSON.parse(objectString);
 		obj.name = error.name;
 		return obj;
 	}

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -59,7 +59,7 @@ class EleventyExtensionMap {
 			return [];
 		}
 
-		let files = [];
+		const files = [];
 		this.validTemplateLanguageKeys.forEach(
 			function (key) {
 				this.getExtensionsFromKey(key).forEach(function (extension) {
@@ -75,7 +75,7 @@ class EleventyExtensionMap {
 	// on paths found from the file system glob search.
 	// TODO: Method name might just need to be renamed to something more accurate.
 	isFullTemplateFilePath(path) {
-		for (let extension of this.validTemplateLanguageKeys) {
+		for (const extension of this.validTemplateLanguageKeys) {
 			if (path.endsWith(`.${extension}`)) {
 				return true;
 			}
@@ -88,7 +88,7 @@ class EleventyExtensionMap {
 			return;
 		}
 
-		for (let entry of this.config.extensionMap) {
+		for (const entry of this.config.extensionMap) {
 			if (entry.extension === extension) {
 				return entry;
 			}
@@ -96,8 +96,8 @@ class EleventyExtensionMap {
 	}
 
 	getValidExtensionsForPath(path) {
-		let extensions = new Set();
-		for (let extension in this.extensionToKeyMap) {
+		const extensions = new Set();
+		for (const extension in this.extensionToKeyMap) {
 			if (path.endsWith(`.${extension}`)) {
 				extensions.add(extension);
 			}
@@ -105,7 +105,7 @@ class EleventyExtensionMap {
 
 		// if multiple extensions are valid, sort from longest to shortest
 		// e.g. .11ty.js and .js
-		let sorted = Array.from(extensions)
+		const sorted = Array.from(extensions)
 			.filter((extension) => this.validTemplateLanguageKeys.includes(extension))
 			.sort((a, b) => b.length - a.length);
 
@@ -113,16 +113,16 @@ class EleventyExtensionMap {
 	}
 
 	async shouldSpiderJavaScriptDependencies(path) {
-		let extensions = this.getValidExtensionsForPath(path);
-		for (let extension of extensions) {
+		const extensions = this.getValidExtensionsForPath(path);
+		for (const extension of extensions) {
 			if (extension in this._spiderJsDepsCache) {
 				return this._spiderJsDepsCache[extension];
 			}
 
-			let cls = await this.engineManager.getEngineClassByExtension(extension);
+			const cls = await this.engineManager.getEngineClassByExtension(extension);
 			if (cls) {
-				let entry = this.getCustomExtensionEntry(extension);
-				let shouldSpider = cls.shouldSpiderJavaScriptDependencies(entry);
+				const entry = this.getCustomExtensionEntry(extension);
+				const shouldSpider = cls.shouldSpiderJavaScriptDependencies(entry);
 				this._spiderJsDepsCache[extension] = shouldSpider;
 				return shouldSpider;
 			}
@@ -144,11 +144,11 @@ class EleventyExtensionMap {
 	}
 
 	_getGlobs(formatKeys, inputDir) {
-		let dir = TemplatePath.convertToRecursiveGlobSync(inputDir);
-		let extensions = [];
-		for (let key of formatKeys) {
+		const dir = TemplatePath.convertToRecursiveGlobSync(inputDir);
+		const extensions = [];
+		for (const key of formatKeys) {
 			if (this.hasExtension(key)) {
-				for (let extension of this.getExtensionsFromKey(key)) {
+				for (const extension of this.getExtensionsFromKey(key)) {
 					extensions.push(extension);
 				}
 			} else {
@@ -156,7 +156,7 @@ class EleventyExtensionMap {
 			}
 		}
 
-		let globs = [];
+		const globs = [];
 		if (extensions.length === 1) {
 			globs.push(`${dir}/*.${extensions[0]}`);
 		} else if (extensions.length > 1) {
@@ -176,7 +176,7 @@ class EleventyExtensionMap {
 	}
 
 	getExtensionsFromKey(key) {
-		let extensions = [];
+		const extensions = [];
 		for (var extension in this.extensionToKeyMap) {
 			if (this.extensionToKeyMap[extension] === key) {
 				extensions.push(extension);
@@ -187,9 +187,9 @@ class EleventyExtensionMap {
 
 	// Only `addExtension` configuration API extensions
 	getExtensionEntriesFromKey(key) {
-		let entries = [];
+		const entries = [];
 		if ("extensionMap" in this.config) {
-			for (let entry of this.config.extensionMap) {
+			for (const entry of this.config.extensionMap) {
 				if (entry.key === key) {
 					entries.push(entry);
 				}
@@ -206,7 +206,7 @@ class EleventyExtensionMap {
 		pathOrKey = (pathOrKey || "").toLowerCase();
 
 		for (var extension in this.extensionToKeyMap) {
-			let key = this.extensionToKeyMap[extension];
+			const key = this.extensionToKeyMap[extension];
 			if (pathOrKey === extension) {
 				return key;
 			} else if (pathOrKey.endsWith("." + extension)) {
@@ -242,7 +242,7 @@ class EleventyExtensionMap {
 			};
 
 			if ("extensionMap" in this.config) {
-				for (let entry of this.config.extensionMap) {
+				for (const entry of this.config.extensionMap) {
 					this._extensionToKeyMap[entry.extension] = entry.key;
 				}
 			}

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -92,13 +92,13 @@ class EleventyFiles {
 	}
 
 	get passthroughGlobs() {
-		let paths = new Set();
+		const paths = new Set();
 		// stuff added in addPassthroughCopy()
-		for (let path of this.passthroughManager.getConfigPathGlobs()) {
+		for (const path of this.passthroughManager.getConfigPathGlobs()) {
 			paths.add(path);
 		}
 		// non-template language extensions
-		for (let path of this.extensionMap.getPassthroughCopyGlobs(this.inputDir)) {
+		for (const path of this.extensionMap.getPassthroughCopyGlobs(this.inputDir)) {
 			paths.add(path);
 		}
 		return Array.from(paths);
@@ -144,7 +144,7 @@ class EleventyFiles {
 	}
 
 	initPassthroughManager() {
-		let mgr = new TemplatePassthroughManager(this.eleventyConfig);
+		const mgr = new TemplatePassthroughManager(this.eleventyConfig);
 		mgr.setInputDir(this.inputDir);
 		mgr.setOutputDir(this.outputDir);
 		mgr.setRunMode(this.runMode);
@@ -174,7 +174,7 @@ class EleventyFiles {
 	}
 
 	getDataDir() {
-		let data = this.templateData;
+		const data = this.templateData;
 
 		return data.getDataDir();
 	}
@@ -193,15 +193,15 @@ class EleventyFiles {
 	}
 
 	getIgnoreGlobs() {
-		let uniqueIgnores = new Set();
-		for (let ignore of this.fileIgnores) {
+		const uniqueIgnores = new Set();
+		for (const ignore of this.fileIgnores) {
 			uniqueIgnores.add(ignore);
 		}
-		for (let ignore of this.extraIgnores) {
+		for (const ignore of this.extraIgnores) {
 			uniqueIgnores.add(ignore);
 		}
 		// Placing the config ignores last here is important to the tests
-		for (let ignore of this.config.ignores) {
+		for (const ignore of this.config.ignores) {
 			uniqueIgnores.add(TemplateGlob.normalizePath(this.localPathRoot || ".", ignore));
 		}
 		return Array.from(uniqueIgnores);
@@ -216,10 +216,10 @@ class EleventyFiles {
 		for (let ignorePath of ignoreFiles) {
 			ignorePath = TemplatePath.normalize(ignorePath);
 
-			let dir = TemplatePath.getDirFromFilePath(ignorePath);
+			const dir = TemplatePath.getDirFromFilePath(ignorePath);
 
 			if (fs.existsSync(ignorePath) && fs.statSync(ignorePath).size > 0) {
-				let ignoreContent = fs.readFileSync(ignorePath, "utf8");
+				const ignoreContent = fs.readFileSync(ignorePath, "utf8");
 
 				ignores = ignores.concat(EleventyFiles.normalizeIgnoreContent(dir, ignoreContent));
 			}
@@ -257,7 +257,7 @@ class EleventyFiles {
 
 					try {
 						// Note these folders must exist to get /** suffix
-						let stat = fs.statSync(path);
+						const stat = fs.statSync(path);
 						if (stat.isDirectory()) {
 							return path + "/**";
 						}
@@ -276,9 +276,9 @@ class EleventyFiles {
 	}
 
 	getIgnores() {
-		let files = new Set();
+		const files = new Set();
 
-		for (let ignore of EleventyFiles.getFileIgnores(this.getIgnoreFiles())) {
+		for (const ignore of EleventyFiles.getFileIgnores(this.getIgnoreFiles())) {
 			files.add(ignore);
 		}
 
@@ -296,15 +296,15 @@ class EleventyFiles {
 	}
 
 	getIgnoreFiles() {
-		let ignoreFiles = [];
-		let rootDirectory = this.localPathRoot || ".";
+		const ignoreFiles = [];
+		const rootDirectory = this.localPathRoot || ".";
 
 		if (this.config.useGitIgnore) {
 			ignoreFiles.push(TemplatePath.join(rootDirectory, ".gitignore"));
 		}
 
 		if (this.eleventyIgnoreContent === false) {
-			let absoluteInputDir = TemplatePath.absolutePath(this.inputDir);
+			const absoluteInputDir = TemplatePath.absolutePath(this.inputDir);
 			ignoreFiles.push(TemplatePath.join(rootDirectory, ".eleventyignore"));
 			if (rootDirectory !== absoluteInputDir) {
 				ignoreFiles.push(TemplatePath.join(this.inputDir, ".eleventyignore"));
@@ -336,9 +336,9 @@ class EleventyFiles {
 			throw new Error("Watching requires `.getFiles()` to be called first in EleventyFiles");
 		}
 
-		let ret = [];
+		const ret = [];
 		// Filter out the passthrough copy paths.
-		for (let path of this.pathCache) {
+		for (const path of this.pathCache) {
 			if (
 				this.extensionMap.isFullTemplateFilePath(path) &&
 				(await this.extensionMap.shouldSpiderJavaScriptDependencies(path))
@@ -350,7 +350,7 @@ class EleventyFiles {
 	}
 
 	_globSearch() {
-		let globs = this.getFileGlobs();
+		const globs = this.getFileGlobs();
 
 		// returns a promise
 		debug("Searching for: %o", globs);
@@ -360,10 +360,10 @@ class EleventyFiles {
 	}
 
 	async getFiles() {
-		let bench = this.aggregateBench.get("Searching the file system (templates)");
+		const bench = this.aggregateBench.get("Searching the file system (templates)");
 		bench.before();
-		let globResults = await this._globSearch();
-		let paths = TemplatePath.addLeadingDotSlashArray(globResults);
+		const globResults = await this._globSearch();
+		const paths = TemplatePath.addLeadingDotSlashArray(globResults);
 		bench.after();
 
 		// Note 2.0.0-canary.19 removed a `filter` option for custom template syntax here that was unpublished and unused.
@@ -378,7 +378,7 @@ class EleventyFiles {
 			return false;
 		}
 
-		for (let path of paths) {
+		for (const path of paths) {
 			if (path === filePath) {
 				return true;
 			}
@@ -390,7 +390,7 @@ class EleventyFiles {
 	/* For `eleventy --watch` */
 	getGlobWatcherFiles() {
 		// TODO improvement: tie the includes and data to specific file extensions (currently using `**`)
-		let directoryGlobs = this._getIncludesAndDataDirs();
+		const directoryGlobs = this._getIncludesAndDataDirs();
 
 		if (checkPassthroughCopyBehavior(this.config, this.runMode)) {
 			return this.validTemplateGlobs.concat(directoryGlobs);
@@ -407,17 +407,17 @@ class EleventyFiles {
 
 	/* For `eleventy --watch` */
 	async getGlobWatcherTemplateDataFiles() {
-		let templateData = this.templateData;
+		const templateData = this.templateData;
 		return await templateData.getTemplateDataFileGlob();
 	}
 
 	/* For `eleventy --watch` */
 	// TODO this isn’t great but reduces complexity avoiding using TemplateData:getLocalDataPaths for each template in the cache
 	async getWatcherTemplateJavaScriptDataFiles() {
-		let globs = await this.templateData.getTemplateJavaScriptDataFileGlob();
-		let bench = this.aggregateBench.get("Searching the file system (watching)");
+		const globs = await this.templateData.getTemplateJavaScriptDataFileGlob();
+		const bench = this.aggregateBench.get("Searching the file system (watching)");
 		bench.before();
-		let results = TemplatePath.addLeadingDotSlashArray(
+		const results = TemplatePath.addLeadingDotSlashArray(
 			await this.fileSystemSearch.search("js-dependencies", globs, {
 				ignore: ["**/node_modules/**"],
 			}),
@@ -429,11 +429,11 @@ class EleventyFiles {
 	/* Ignored by `eleventy --watch` */
 	getGlobWatcherIgnores() {
 		// convert to format without ! since they are passed in as a separate argument to glob watcher
-		let entries = new Set(
+		const entries = new Set(
 			this.fileIgnores.map((ignore) => TemplatePath.stripLeadingDotSlash(ignore)),
 		);
 
-		for (let ignore of this.config.watchIgnores) {
+		for (const ignore of this.config.watchIgnores) {
 			entries.add(TemplateGlob.normalizePath(this.localPathRoot || ".", ignore));
 		}
 
@@ -456,7 +456,7 @@ class EleventyFiles {
 		}
 
 		if (this.config.dir.data && this.config.dir.data !== ".") {
-			let dataDir = this.getDataDir();
+			const dataDir = this.getDataDir();
 			files = files.concat(TemplateGlob.map(dataDir + "/**"));
 		}
 

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -85,15 +85,15 @@ class EleventyServe {
 			}
 
 			// Look for peer dep in local project
-			let projectNodeModulesPath = TemplatePath.absolutePath("./node_modules/");
-			let serverPath = TemplatePath.absolutePath(projectNodeModulesPath, name);
+			const projectNodeModulesPath = TemplatePath.absolutePath("./node_modules/");
+			const serverPath = TemplatePath.absolutePath(projectNodeModulesPath, name);
 
 			// No references outside of the project node_modules are allowed
 			if (!serverPath.startsWith(projectNodeModulesPath)) {
 				throw new Error("Invalid node_modules name for Eleventy server instance, received:" + name);
 			}
 
-			let module = await EleventyImport(serverPath);
+			const module = await EleventyImport(serverPath);
 
 			if (!("getServer" in module)) {
 				throw new Error(
@@ -101,7 +101,7 @@ class EleventyServe {
 				);
 			}
 
-			let serverPackageJson = getModulePackageJson(serverPath);
+			const serverPackageJson = getModulePackageJson(serverPath);
 			if (serverPackageJson["11ty"]?.compatibility) {
 				try {
 					this.eleventyConfig.userConfig.versionCheck(serverPackageJson["11ty"].compatibility);
@@ -160,7 +160,7 @@ class EleventyServe {
 			return;
 		}
 
-		let serverModule = await this.getServerModule(this.options.module);
+		const serverModule = await this.getServerModule(this.options.module);
 
 		// Static method `getServer` was already checked in `getServerModule`
 		this._server = serverModule.getServer("eleventy-server", this.outputDir, this.options);
@@ -174,7 +174,7 @@ class EleventyServe {
 	}
 
 	getSetupCallback() {
-		let setupCallback = this.config.serverOptions.setup;
+		const setupCallback = this.config.serverOptions.setup;
 		if (setupCallback && typeof setupCallback === "function") {
 			return setupCallback;
 		}
@@ -183,9 +183,9 @@ class EleventyServe {
 	async init() {
 		if (!this._initPromise) {
 			this._initPromise = new Promise(async (resolve) => {
-				let setupCallback = this.getSetupCallback();
+				const setupCallback = this.getSetupCallback();
 				if (setupCallback) {
-					let opts = await setupCallback();
+					const opts = await setupCallback();
 					this._initOptionsFetched = true;
 
 					if (opts) {

--- a/src/EleventyWatch.js
+++ b/src/EleventyWatch.js
@@ -122,7 +122,7 @@ class EleventyWatch {
 			return this.pendingQueue.length ? [this.pendingQueue.shift()] : [];
 		}
 
-		let ret = this.pendingQueue.slice();
+		const ret = this.pendingQueue.slice();
 		this.pendingQueue = [];
 		return ret;
 	}

--- a/src/EleventyWatchTargets.js
+++ b/src/EleventyWatchTargets.js
@@ -43,7 +43,7 @@ class EleventyWatchTargets {
 		if (!this.graph.hasNode(parent)) {
 			this.graph.addNode(parent);
 		}
-		for (let dep of deps) {
+		for (const dep of deps) {
 			if (!this.graph.hasNode(dep)) {
 				this.graph.addNode(dep);
 			}
@@ -70,8 +70,8 @@ class EleventyWatchTargets {
 	}
 
 	addRaw(targets, isDependency) {
-		for (let target of targets) {
-			let path = TemplatePath.addLeadingDotSlash(target);
+		for (const target of targets) {
+			const path = TemplatePath.addLeadingDotSlash(target);
 			if (!this.isWatched(path)) {
 				this.newTargets.add(path);
 			}
@@ -121,7 +121,7 @@ class EleventyWatchTargets {
 			deps = deps.filter(filterCallback);
 		}
 
-		for (let target of targets) {
+		for (const target of targets) {
 			this.addToDependencyGraph(target, deps);
 		}
 		this.addRaw(deps, true);
@@ -132,18 +132,18 @@ class EleventyWatchTargets {
 	}
 
 	clearImportCacheFor(filePathArray) {
-		let paths = new Set();
+		const paths = new Set();
 		for (const filePath of filePathArray) {
 			paths.add(filePath);
 
 			// Delete from require cache so that updates to the module are re-required
-			let importsTheChangedFile = this.getDependantsOf(filePath);
-			for (let dep of importsTheChangedFile) {
+			const importsTheChangedFile = this.getDependantsOf(filePath);
+			for (const dep of importsTheChangedFile) {
 				paths.add(dep);
 			}
 
-			let isImportedInTheChangedFile = this.getDependenciesOf(filePath);
-			for (let dep of isImportedInTheChangedFile) {
+			const isImportedInTheChangedFile = this.getDependenciesOf(filePath);
+			for (const dep of isImportedInTheChangedFile) {
 				paths.add(dep);
 			}
 		}

--- a/src/Engines/Custom.js
+++ b/src/Engines/Custom.js
@@ -27,7 +27,7 @@ class CustomEngine extends TemplateEngine {
 	getExtensionMapEntry() {
 		if ("extensionMap" in this.config) {
 			// Iterates over only the user config `addExtension` entries
-			for (let entry of this.config.extensionMap) {
+			for (const entry of this.config.extensionMap) {
 				if (entry.key.toLowerCase() === this.name.toLowerCase()) {
 					return entry;
 				}
@@ -99,11 +99,11 @@ class CustomEngine extends TemplateEngine {
 		await this._runningInit();
 
 		if (typeof this.entry.getData === "function") {
-			let dataBench = this.benchmarks.aggregate.get(
+			const dataBench = this.benchmarks.aggregate.get(
 				`Engine (${this.name}) Get Data From File (Function)`,
 			);
 			dataBench.before();
-			let data = this.entry.getData(inputPath);
+			const data = this.entry.getData(inputPath);
 			dataBench.after();
 			return data;
 		}
@@ -121,15 +121,15 @@ class CustomEngine extends TemplateEngine {
 		if (this.entry.getData === true) {
 			keys.add("data");
 		} else if (Array.isArray(this.entry.getData)) {
-			for (let key of this.entry.getData) {
+			for (const key of this.entry.getData) {
 				keys.add(key);
 			}
 		}
 
-		let dataBench = this.benchmarks.aggregate.get(`Engine (${this.name}) Get Data From File`);
+		const dataBench = this.benchmarks.aggregate.get(`Engine (${this.name}) Get Data From File`);
 		dataBench.before();
 
-		let inst = await this.entry.getInstanceFromInputPath(inputPath);
+		const inst = await this.entry.getInstanceFromInputPath(inputPath);
 		// override keys set at the plugin level in the individual template
 		if (inst.eleventyDataKey) {
 			keys = new Set(inst.eleventyDataKey);
@@ -141,8 +141,8 @@ class CustomEngine extends TemplateEngine {
 			mixins = Object.assign({}, this.config.javascriptFunctions);
 		}
 
-		let promises = [];
-		for (let key of keys) {
+		const promises = [];
+		for (const key of keys) {
 			promises.push(
 				getJavaScriptData(inst, inputPath, key, {
 					mixins,
@@ -151,9 +151,9 @@ class CustomEngine extends TemplateEngine {
 			);
 		}
 
-		let results = await Promise.all(promises);
-		let data = {};
-		for (let result of results) {
+		const results = await Promise.all(promises);
+		const data = {};
+		for (const result of results) {
 			Object.assign(data, result);
 		}
 		dataBench.after();
@@ -177,7 +177,7 @@ class CustomEngine extends TemplateEngine {
 		}
 
 		// TODO generalize this (look at JavaScript.js)
-		let fn = this.entry.compile.bind({
+		const fn = this.entry.compile.bind({
 			config: this.config,
 			addDependencies: (from, toArray = []) => {
 				this.config.uses.addDependency(from, toArray);
@@ -222,7 +222,7 @@ class CustomEngine extends TemplateEngine {
 	getCompileCacheKey(str, inputPath) {
 		// Return this separately so we know whether or not to use the cached version
 		// but still return a key to cache this new render for next time
-		let useCache = !this.isFileRelevantTo(inputPath, lastModifiedFile, false);
+		const useCache = !this.isFileRelevantTo(inputPath, lastModifiedFile, false);
 
 		if (this.entry.compileOptions && "getCacheKey" in this.entry.compileOptions) {
 			if (typeof this.entry.compileOptions.getCacheKey !== "function") {
@@ -237,7 +237,7 @@ class CustomEngine extends TemplateEngine {
 			};
 		}
 
-		let { key } = super.getCompileCacheKey(str, inputPath);
+		const { key } = super.getCompileCacheKey(str, inputPath);
 		return {
 			useCache,
 			key,
@@ -246,7 +246,7 @@ class CustomEngine extends TemplateEngine {
 
 	permalinkNeedsCompilation(/*str*/) {
 		if (this.entry.compileOptions && "permalink" in this.entry.compileOptions) {
-			let p = this.entry.compileOptions.permalink;
+			const p = this.entry.compileOptions.permalink;
 			if (p === "raw") {
 				return false;
 			}

--- a/src/Engines/Html.js
+++ b/src/Engines/Html.js
@@ -8,15 +8,15 @@ class Html extends TemplateEngine {
 
 	async compile(str, inputPath, preTemplateEngine) {
 		if (preTemplateEngine) {
-			let engine = await this.engineManager.getEngine(
+			const engine = await this.engineManager.getEngine(
 				preTemplateEngine,
 				this.dirs,
 				this.extensionMap,
 			);
-			let fnReady = engine.compile(str, inputPath);
+			const fnReady = engine.compile(str, inputPath);
 
 			return async function (data) {
-				let fn = await fnReady;
+				const fn = await fnReady;
 
 				return fn(data);
 			};

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -20,8 +20,8 @@ class JavaScript extends TemplateEngine {
 
 		EventBusUtil.soloOn("eleventy.resourceModified", (inputPath, usedByDependants = []) => {
 			// Remove from cached instances when modified
-			let instancesToDelete = [TemplatePath.addLeadingDotSlash(inputPath), ...usedByDependants];
-			for (let inputPath of instancesToDelete) {
+			const instancesToDelete = [TemplatePath.addLeadingDotSlash(inputPath), ...usedByDependants];
+			for (const inputPath of instancesToDelete) {
 				if (inputPath in this.instances) {
 					delete this.instances[inputPath];
 				}
@@ -41,7 +41,7 @@ class JavaScript extends TemplateEngine {
 	// Function, Class
 	// Object
 	_getInstance(mod) {
-		let noop = function () {
+		const noop = function () {
 			return "";
 		};
 
@@ -71,10 +71,10 @@ class JavaScript extends TemplateEngine {
 			return this.instances[inputPath];
 		}
 
-		let isEsm = this.eleventyConfig.getIsProjectUsingEsm();
+		const isEsm = this.eleventyConfig.getIsProjectUsingEsm();
 		const mod = await EleventyImport(inputPath, isEsm ? "esm" : "cjs");
 
-		let inst = this._getInstance(mod);
+		const inst = this._getInstance(mod);
 		if (inst) {
 			this.instances[inputPath] = inst;
 		} else {
@@ -95,15 +95,15 @@ class JavaScript extends TemplateEngine {
 	}
 
 	async getExtraDataFromFile(inputPath) {
-		let inst = await this.getInstanceFromInputPath(inputPath);
+		const inst = await this.getInstanceFromInputPath(inputPath);
 		return getJavaScriptData(inst, inputPath);
 	}
 
 	getJavaScriptFunctions(inst) {
-		let fns = {};
-		let configFns = this.config.javascriptFunctions;
+		const fns = {};
+		const configFns = this.config.javascriptFunctions;
 
-		for (let key in configFns) {
+		for (const key in configFns) {
 			// prefer pre-existing `page` javascriptFunction, if one exists
 			if (key === "page") {
 				// do nothing
@@ -117,7 +117,7 @@ class JavaScript extends TemplateEngine {
 
 	static wrapJavaScriptFunction(inst, fn) {
 		return function (...args) {
-			for (let key of JavaScript.DATA_KEYS_TO_BIND) {
+			for (const key of JavaScript.DATA_KEYS_TO_BIND) {
 				if (inst && inst[key]) {
 					this[key] = inst[key];
 				}
@@ -142,7 +142,7 @@ class JavaScript extends TemplateEngine {
 				// TODO does this do anything meaningful for non-classes?
 				// `inst` should have a normalized `render` function from _getInstance
 
-				for (let key of JavaScript.DATA_KEYS_TO_BIND) {
+				for (const key of JavaScript.DATA_KEYS_TO_BIND) {
 					if (!inst[key] && data[key]) {
 						// only blow away existing inst.page if it has a page.url
 						if (key !== "page" || !inst.page || inst.page.url) {

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -41,7 +41,7 @@ class Liquid extends TemplateEngine {
 	}
 
 	getLiquidOptions() {
-		let defaults = {
+		const defaults = {
 			root: [this.dirs.includes, this.dirs.input], // supplemented in compile with inputPath below
 			extname: ".liquid",
 			strictFilters: true,
@@ -49,7 +49,7 @@ class Liquid extends TemplateEngine {
 			// cache: true,
 		};
 
-		let options = Object.assign(defaults, this.liquidOptions || {});
+		const options = Object.assign(defaults, this.liquidOptions || {});
 		// debug("Liquid constructor options: %o", options);
 
 		return options;
@@ -68,7 +68,7 @@ class Liquid extends TemplateEngine {
 
 	// Shortcodes
 	static normalizeScope(context) {
-		let obj = {};
+		const obj = {};
 		if (context) {
 			obj.ctx = context;
 			obj.page = context.get(["page"]);
@@ -78,13 +78,13 @@ class Liquid extends TemplateEngine {
 	}
 
 	addCustomTags(tags) {
-		for (let name in tags) {
+		for (const name in tags) {
 			this.addTag(name, tags[name]);
 		}
 	}
 
 	addFilters(filters) {
-		for (let name in filters) {
+		for (const name in filters) {
 			this.addFilter(name, filters[name]);
 		}
 	}
@@ -106,19 +106,19 @@ class Liquid extends TemplateEngine {
 	}
 
 	addAllShortcodes(shortcodes) {
-		for (let name in shortcodes) {
+		for (const name in shortcodes) {
 			this.addShortcode(name, shortcodes[name]);
 		}
 	}
 
 	addAllPairedShortcodes(shortcodes) {
-		for (let name in shortcodes) {
+		for (const name in shortcodes) {
 			this.addPairedShortcode(name, shortcodes[name]);
 		}
 	}
 
 	static parseArguments(lexer, str) {
-		let argArray = [];
+		const argArray = [];
 
 		if (!lexer) {
 			lexer = moo.compile(Liquid.argumentLexerOptions);
@@ -153,7 +153,7 @@ class Liquid extends TemplateEngine {
 	}
 
 	addShortcode(shortcodeName, shortcodeFn) {
-		let _t = this;
+		const _t = this;
 		this.addTag(shortcodeName, function (liquidEngine) {
 			return {
 				parse(tagToken) {
@@ -161,15 +161,15 @@ class Liquid extends TemplateEngine {
 					this.args = tagToken.args;
 				},
 				render: function* (ctx) {
-					let rawArgs = Liquid.parseArguments(_t.argLexer, this.args);
-					let argArray = [];
-					let contextScope = ctx.getAll();
-					for (let arg of rawArgs) {
-						let b = yield liquidEngine.evalValue(arg, contextScope);
+					const rawArgs = Liquid.parseArguments(_t.argLexer, this.args);
+					const argArray = [];
+					const contextScope = ctx.getAll();
+					for (const arg of rawArgs) {
+						const b = yield liquidEngine.evalValue(arg, contextScope);
 						argArray.push(b);
 					}
 
-					let ret = yield shortcodeFn.call(Liquid.normalizeScope(ctx), ...argArray);
+					const ret = yield shortcodeFn.call(Liquid.normalizeScope(ctx), ...argArray);
 					return ret;
 				},
 			};
@@ -177,7 +177,7 @@ class Liquid extends TemplateEngine {
 	}
 
 	addPairedShortcode(shortcodeName, shortcodeFn) {
-		let _t = this;
+		const _t = this;
 		this.addTag(shortcodeName, function (liquidEngine) {
 			return {
 				parse(tagToken, remainTokens) {
@@ -196,17 +196,17 @@ class Liquid extends TemplateEngine {
 					stream.start();
 				},
 				render: function* (ctx /*, emitter*/) {
-					let rawArgs = Liquid.parseArguments(_t.argLexer, this.args);
-					let argArray = [];
-					let contextScope = ctx.getAll();
-					for (let arg of rawArgs) {
-						let b = yield liquidEngine.evalValue(arg, contextScope);
+					const rawArgs = Liquid.parseArguments(_t.argLexer, this.args);
+					const argArray = [];
+					const contextScope = ctx.getAll();
+					for (const arg of rawArgs) {
+						const b = yield liquidEngine.evalValue(arg, contextScope);
 						argArray.push(b);
 					}
 
 					const html = yield liquidEngine.renderer.renderTemplates(this.templates, ctx);
 
-					let ret = yield shortcodeFn.call(Liquid.normalizeScope(ctx), html, ...argArray);
+					const ret = yield shortcodeFn.call(Liquid.normalizeScope(ctx), html, ...argArray);
 					// emitter.write(ret);
 					return ret;
 				},
@@ -215,9 +215,9 @@ class Liquid extends TemplateEngine {
 	}
 
 	parseForSymbols(str) {
-		let tokenizer = new liquidLib.Tokenizer(str);
-		let tokens = tokenizer.readTopLevelTokens();
-		let symbols = tokens
+		const tokenizer = new liquidLib.Tokenizer(str);
+		const tokens = tokenizer.readTopLevelTokens();
+		const symbols = tokens
 			.filter((token) => token.kind === liquidLib.TokenKind.Output)
 			.map((token) => {
 				// manually remove filters 😅
@@ -234,7 +234,7 @@ class Liquid extends TemplateEngine {
 	}
 
 	needsCompilation(str) {
-		let options = this.liquidLib.options;
+		const options = this.liquidLib.options;
 
 		return (
 			str.indexOf(options.tagDelimiterLeft) !== -1 ||
@@ -243,11 +243,11 @@ class Liquid extends TemplateEngine {
 	}
 
 	async compile(str, inputPath) {
-		let engine = this.liquidLib;
-		let tmplReady = engine.parse(str, inputPath);
+		const engine = this.liquidLib;
+		const tmplReady = engine.parse(str, inputPath);
 
 		// Required for relative includes
-		let options = {};
+		const options = {};
 		if (!inputPath || inputPath === "liquid" || inputPath === "md") {
 			// do nothing
 		} else {
@@ -255,7 +255,7 @@ class Liquid extends TemplateEngine {
 		}
 
 		return async function (data) {
-			let tmpl = await tmplReady;
+			const tmpl = await tmplReady;
 
 			return engine.render(tmpl, data, options);
 		};

--- a/src/Engines/Markdown.js
+++ b/src/Engines/Markdown.js
@@ -51,7 +51,7 @@ class Markdown extends TemplateEngine {
 	}
 
 	async compile(str, inputPath, preTemplateEngine, bypassMarkdown) {
-		let mdlib = this.mdLib;
+		const mdlib = this.mdLib;
 
 		if (preTemplateEngine) {
 			let engine;
@@ -65,18 +65,18 @@ class Markdown extends TemplateEngine {
 				engine = preTemplateEngine;
 			}
 
-			let fnReady = engine.compile(str, inputPath);
+			const fnReady = engine.compile(str, inputPath);
 
 			if (bypassMarkdown) {
 				return async function (data) {
-					let fn = await fnReady;
+					const fn = await fnReady;
 					return fn(data);
 				};
 			} else {
 				return async function (data) {
-					let fn = await fnReady;
-					let preTemplateEngineRender = await fn(data);
-					let finishedRender = mdlib.render(preTemplateEngineRender, data);
+					const fn = await fnReady;
+					const preTemplateEngineRender = await fn(data);
+					const finishedRender = mdlib.render(preTemplateEngineRender, data);
 					return finishedRender;
 				};
 			}

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -44,7 +44,7 @@ class Nunjucks extends TemplateEngine {
 				this.nunjucksEnvironmentOptions,
 			);
 		} else {
-			let fsLoader = new NunjucksLib.FileSystemLoader([
+			const fsLoader = new NunjucksLib.FileSystemLoader([
 				super.getIncludesDir(),
 				TemplatePath.getWorkingDir(),
 			]);
@@ -88,7 +88,7 @@ class Nunjucks extends TemplateEngine {
 	}
 
 	addFilters(filters, isAsync) {
-		for (let name in filters) {
+		for (const name in filters) {
 			this.njkEnv.addFilter(name, Nunjucks.wrapFilter(filters[name]), isAsync);
 		}
 	}
@@ -108,7 +108,7 @@ class Nunjucks extends TemplateEngine {
 
 	// Shortcodes
 	static normalizeContext(context) {
-		let obj = {};
+		const obj = {};
 		if (context.ctx) {
 			obj.ctx = context.ctx;
 
@@ -124,7 +124,7 @@ class Nunjucks extends TemplateEngine {
 	}
 
 	addCustomTags(tags) {
-		for (let name in tags) {
+		for (const name in tags) {
 			this.addTag(name, tags[name]);
 		}
 	}
@@ -143,7 +143,7 @@ class Nunjucks extends TemplateEngine {
 	}
 
 	addGlobals(globals) {
-		for (let name in globals) {
+		for (const name in globals) {
 			this.addGlobal(name, globals[name]);
 		}
 	}
@@ -153,13 +153,13 @@ class Nunjucks extends TemplateEngine {
 	}
 
 	addAllShortcodes(shortcodes, isAsync = false) {
-		for (let name in shortcodes) {
+		for (const name in shortcodes) {
 			this.addShortcode(name, shortcodes[name], isAsync);
 		}
 	}
 
 	addAllPairedShortcodes(shortcodes, isAsync = false) {
-		for (let name in shortcodes) {
+		for (const name in shortcodes) {
 			this.addPairedShortcode(name, shortcodes[name], isAsync);
 		}
 	}
@@ -169,10 +169,8 @@ class Nunjucks extends TemplateEngine {
 			this.tags = [shortcodeName];
 
 			this.parse = function (parser, nodes) {
-				let args;
-				let tok = parser.nextToken();
-
-				args = parser.parseSignature(true, true);
+				const tok = parser.nextToken();
+				const args = parser.parseSignature(true, true);
 
 				// Nunjucks bug with non-paired custom tags bug still exists even
 				// though this issue is closed. Works fine for paired.
@@ -194,7 +192,7 @@ class Nunjucks extends TemplateEngine {
 					resolve = args.pop();
 				}
 
-				let [context, ...argArray] = args;
+				const [context, ...argArray] = args;
 
 				if (isAsync) {
 					shortcodeFn
@@ -214,7 +212,7 @@ class Nunjucks extends TemplateEngine {
 						});
 				} else {
 					try {
-						let ret = shortcodeFn.call(Nunjucks.normalizeContext(context), ...argArray);
+						const ret = shortcodeFn.call(Nunjucks.normalizeContext(context), ...argArray);
 						return new NunjucksLib.runtime.SafeString("" + ret);
 					} catch (e) {
 						throw new EleventyShortcodeError(
@@ -245,9 +243,9 @@ class Nunjucks extends TemplateEngine {
 			};
 
 			this.run = function (...args) {
-				let resolve = args.pop();
-				let body = args.pop();
-				let [context, ...argArray] = args;
+				const resolve = args.pop();
+				const body = args.pop();
+				const [context, ...argArray] = args;
 
 				body(function (e, bodyContent) {
 					if (e) {
@@ -300,12 +298,12 @@ class Nunjucks extends TemplateEngine {
 	}
 
 	addShortcode(shortcodeName, shortcodeFn, isAsync = false) {
-		let fn = this._getShortcodeFn(shortcodeName, shortcodeFn, isAsync);
+		const fn = this._getShortcodeFn(shortcodeName, shortcodeFn, isAsync);
 		this.njkEnv.addExtension(shortcodeName, new fn());
 	}
 
 	addPairedShortcode(shortcodeName, shortcodeFn, isAsync = false) {
-		let fn = this._getPairedShortcodeFn(shortcodeName, shortcodeFn, isAsync);
+		const fn = this._getPairedShortcodeFn(shortcodeName, shortcodeFn, isAsync);
 		this.njkEnv.addExtension(shortcodeName, new fn());
 	}
 
@@ -319,10 +317,10 @@ class Nunjucks extends TemplateEngine {
 	needsCompilation(str) {
 		// Defend against syntax customisations:
 		//    https://mozilla.github.io/nunjucks/api.html#customizing-syntax
-		let optsTags = this.njkEnv.opts.tags || {};
-		let blockStart = optsTags.blockStart || "{%";
-		let variableStart = optsTags.variableStart || "{{";
-		let commentStart = optsTags.variableStart || "{#";
+		const optsTags = this.njkEnv.opts.tags || {};
+		const blockStart = optsTags.blockStart || "{%";
+		const variableStart = optsTags.variableStart || "{{";
+		const commentStart = optsTags.variableStart || "{#";
 
 		return (
 			str.indexOf(blockStart) !== -1 ||
@@ -337,25 +335,25 @@ class Nunjucks extends TemplateEngine {
 		}
 
 		// add extensions so the parser knows about our custom tags/blocks
-		let ext = [];
-		for (let name in this.config.nunjucksTags) {
-			let fn = this._getShortcodeFn(name, () => {});
+		const ext = [];
+		for (const name in this.config.nunjucksTags) {
+			const fn = this._getShortcodeFn(name, () => {});
 			ext.push(new fn());
 		}
-		for (let name in this.config.nunjucksShortcodes) {
-			let fn = this._getShortcodeFn(name, () => {});
+		for (const name in this.config.nunjucksShortcodes) {
+			const fn = this._getShortcodeFn(name, () => {});
 			ext.push(new fn());
 		}
-		for (let name in this.config.nunjucksAsyncShortcodes) {
-			let fn = this._getShortcodeFn(name, () => {}, true);
+		for (const name in this.config.nunjucksAsyncShortcodes) {
+			const fn = this._getShortcodeFn(name, () => {}, true);
 			ext.push(new fn());
 		}
-		for (let name in this.config.nunjucksPairedShortcodes) {
-			let fn = this._getPairedShortcodeFn(name, () => {});
+		for (const name in this.config.nunjucksPairedShortcodes) {
+			const fn = this._getPairedShortcodeFn(name, () => {});
 			ext.push(new fn());
 		}
-		for (let name in this.config.nunjucksAsyncPairedShortcodes) {
-			let fn = this._getPairedShortcodeFn(name, () => {}, true);
+		for (const name in this.config.nunjucksAsyncPairedShortcodes) {
+			const fn = this._getPairedShortcodeFn(name, () => {}, true);
 			ext.push(new fn());
 		}
 
@@ -366,13 +364,13 @@ class Nunjucks extends TemplateEngine {
 	/* Outputs an Array of lodash get selectors */
 	parseForSymbols(str) {
 		const { parser, nodes } = NunjucksLib;
-		let obj = parser.parse(str, this._getParseExtensions());
-		let linesplit = str.split("\n");
-		let values = obj.findAll(nodes.Value);
-		let symbols = obj.findAll(nodes.Symbol).map((entry) => {
-			let name = [entry.value];
+		const obj = parser.parse(str, this._getParseExtensions());
+		const linesplit = str.split("\n");
+		const values = obj.findAll(nodes.Value);
+		const symbols = obj.findAll(nodes.Symbol).map((entry) => {
+			const name = [entry.value];
 			let nestedIndex = -1;
-			for (let val of values) {
+			for (const val of values) {
 				if (nestedIndex > -1) {
 					/* deep.object.syntax */
 					if (linesplit[val.lineno].charAt(nestedIndex) === ".") {
@@ -392,7 +390,7 @@ class Nunjucks extends TemplateEngine {
 			return name.join(".");
 		});
 
-		let uniqueSymbols = Array.from(new Set(symbols));
+		const uniqueSymbols = Array.from(new Set(symbols));
 		return uniqueSymbols;
 	}
 

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -88,7 +88,7 @@ class TemplateEngine {
 		this.engineLib = engineLib;
 
 		// Run engine amendments (via issue #2438)
-		for (let amendment of this.config.libraryAmendments[this.name] || []) {
+		for (const amendment of this.config.libraryAmendments[this.name] || []) {
 			// TODO it’d be nice if this were async friendly
 			amendment(engineLib);
 		}
@@ -100,7 +100,7 @@ class TemplateEngine {
 
 	async _testRender(str, data) {
 		/* TODO compile needs to pass in inputPath? */
-		let fn = await this.compile(str);
+		const fn = await this.compile(str);
 		return fn(data);
 	}
 

--- a/src/EventBus.js
+++ b/src/EventBus.js
@@ -15,7 +15,7 @@ debug("Setting up global EventBus.");
  * subscribe to from a global singleton for decoupled pub/sub.
  * @type {module:11ty/eleventy/Util/AsyncEventEmitter~AsyncEventEmitter}
  */
-let bus = new EventEmitter();
+const bus = new EventEmitter();
 bus.setMaxListeners(100);
 
 export default bus;

--- a/src/FileSystemSearch.js
+++ b/src/FileSystemSearch.js
@@ -36,7 +36,7 @@ class FileSystemSearch {
 			debug("Glob search (%o) ignoring: %o", key, options.ignore);
 		}
 
-		let cacheKey = this.getCacheKey(key, globs, options);
+		const cacheKey = this.getCacheKey(key, globs, options);
 
 		// Only after the promise has resolved
 		if (this.outputs[cacheKey]) {
@@ -75,10 +75,10 @@ class FileSystemSearch {
 	_modify(path, setOperation) {
 		path = TemplatePath.stripLeadingDotSlash(path);
 
-		let normalized = TemplatePath.addLeadingDotSlash(path);
+		const normalized = TemplatePath.addLeadingDotSlash(path);
 
-		for (let key in this.inputs) {
-			let { input, options } = this.inputs[key];
+		for (const key in this.inputs) {
+			const { input, options } = this.inputs[key];
 			if (
 				micromatch([path], input, {
 					dot: true,

--- a/src/Filters/GetCollectionItem.js
+++ b/src/Filters/GetCollectionItem.js
@@ -1,7 +1,7 @@
 export default function getCollectionItem(collection, page, modifier = 0) {
 	let j = 0;
 	let index;
-	for (let item of collection) {
+	for (const item of collection) {
 		if (
 			item.inputPath === page.inputPath &&
 			(item.outputPath === page.outputPath || item.url === page.url)

--- a/src/Filters/GetCollectionItemIndex.js
+++ b/src/Filters/GetCollectionItemIndex.js
@@ -5,7 +5,7 @@ export default function getCollectionItemIndex(collection, page) {
 	}
 
 	let j = 0;
-	for (let item of collection) {
+	for (const item of collection) {
 		if (
 			item.inputPath === page.inputPath &&
 			(item.outputPath === page.outputPath || item.url === page.url)

--- a/src/Filters/GetLocaleCollectionItem.js
+++ b/src/Filters/GetLocaleCollectionItem.js
@@ -2,7 +2,7 @@ import getCollectionItem from "./GetCollectionItem.js";
 
 // Work with I18n Plugin src/Plugins/I18nPlugin.js to retrieve root pages (not i18n pages)
 function resolveRootPage(config, pageOverride, languageCode) {
-	let localeFilter = config.getFilter("locale_page");
+	const localeFilter = config.getFilter("locale_page");
 	if (!localeFilter || typeof localeFilter !== "function") {
 		return pageOverride;
 	}
@@ -21,22 +21,27 @@ function getLocaleCollectionItem(config, collection, pageOverride, langCode, ind
 		}
 	}
 
-	let rootPage = resolveRootPage.call(this, config, pageOverride); // implied current page, default language
-	let modifiedRootItem = getCollectionItem(collection, rootPage, indexModifier);
+	const rootPage = resolveRootPage.call(this, config, pageOverride); // implied current page, default language
+	const modifiedRootItem = getCollectionItem(collection, rootPage, indexModifier);
 	if (!modifiedRootItem) {
 		return; // no root item exists for the previous/next page
 	}
 
 	// Resolve modified root `page` back to locale `page`
 	// This will return a non localized version of the page as a fallback
-	let modifiedLocalePage = resolveRootPage.call(this, config, modifiedRootItem.data.page, langCode);
+	const modifiedLocalePage = resolveRootPage.call(
+		this,
+		config,
+		modifiedRootItem.data.page,
+		langCode,
+	);
 	// already localized (or default language)
 	if (!("__locale_page_resolved" in modifiedLocalePage)) {
 		return modifiedRootItem;
 	}
 
 	// find the modified locale `page` again in `collections.all`
-	let all =
+	const all =
 		this.collections?.all ||
 		this.ctx?.collections?.all ||
 		this.context?.environments?.collections?.all ||

--- a/src/Filters/Url.js
+++ b/src/Filters/Url.js
@@ -25,10 +25,10 @@ export default function (url, pathPrefix) {
 		throw new Error("pathPrefix (String) is required in the `url` filter.");
 	}
 
-	let normUrl = TemplatePath.normalizeUrlPath(url);
-	let normRootDir = TemplatePath.normalizeUrlPath("/", pathPrefix);
-	let normFull = TemplatePath.normalizeUrlPath("/", pathPrefix, url);
-	let isRootDirTrailingSlash =
+	const normUrl = TemplatePath.normalizeUrlPath(url);
+	const normRootDir = TemplatePath.normalizeUrlPath("/", pathPrefix);
+	const normFull = TemplatePath.normalizeUrlPath("/", pathPrefix, url);
+	const isRootDirTrailingSlash =
 		normRootDir.length && normRootDir.charAt(normRootDir.length - 1) === "/";
 
 	// minor difference with straight `normalize`, "" resolves to root dir and not "."

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -28,9 +28,9 @@ class GlobalDependencyMap {
 	}
 
 	removeLayoutNodes(normalizedLayouts) {
-		let nodes = this.map.overallOrder();
-		for (let node of nodes) {
-			let data = this.map.getNodeData(node);
+		const nodes = this.map.overallOrder();
+		for (const node of nodes) {
+			const data = this.map.getNodeData(node);
 			if (!data || !data.type || data.type !== GlobalDependencyMap.LAYOUT_KEY) {
 				continue;
 			}
@@ -46,11 +46,11 @@ class GlobalDependencyMap {
 
 	// Eleventy Layouts don’t show up in the dependency graph, so we handle those separately
 	addLayoutsToMap(layouts) {
-		let normalizedLayouts = this.normalizeLayoutsObject(layouts);
+		const normalizedLayouts = this.normalizeLayoutsObject(layouts);
 		// Clear out any previous layout relationships to make way for the new ones
 		this.removeLayoutNodes(normalizedLayouts);
 
-		for (let layout in normalizedLayouts) {
+		for (const layout in normalizedLayouts) {
 			// We add this pre-emptively to add the `layout` data
 			if (!this.map.hasNode(layout)) {
 				this.map.addNode(layout, {
@@ -59,7 +59,7 @@ class GlobalDependencyMap {
 			}
 
 			// Potential improvement: only add the first template in the chain for a template and manage any upstream layouts by their own relationships
-			for (let pageTemplate of normalizedLayouts[layout]) {
+			for (const pageTemplate of normalizedLayouts[layout]) {
 				this.addDependency(pageTemplate, [layout]);
 			}
 		}
@@ -96,9 +96,9 @@ class GlobalDependencyMap {
 	}
 
 	normalizeLayoutsObject(layouts) {
-		let o = {};
-		for (let rawLayout in layouts) {
-			let layout = this.normalizeNode(rawLayout);
+		const o = {};
+		for (const rawLayout in layouts) {
+			const layout = this.normalizeNode(rawLayout);
 			o[layout] = layouts[rawLayout].map((entry) => this.normalizeNode(entry));
 		}
 		return o;
@@ -128,7 +128,7 @@ class GlobalDependencyMap {
 			return new Set();
 		}
 
-		let prevDeps = this.getDependantsFor(node)
+		const prevDeps = this.getDependantsFor(node)
 			.filter((entry) => {
 				return entry.startsWith(GlobalDependencyMap.COLLECTION_PREFIX);
 			})
@@ -136,9 +136,9 @@ class GlobalDependencyMap {
 				return GlobalDependencyMap.getEntryFromCollectionKey(entry);
 			});
 
-		let prevDepsSet = new Set(prevDeps);
-		let deleted = new Set();
-		for (let dep of prevDepsSet) {
+		const prevDepsSet = new Set(prevDeps);
+		const deleted = new Set();
+		for (const dep of prevDepsSet) {
 			if (!collectionNames.has(dep)) {
 				deleted.add(dep);
 			}
@@ -159,19 +159,19 @@ class GlobalDependencyMap {
 		//   this.map.removeDependency(dep, node);
 		// }
 
-		for (let dep of this.map.directDependenciesOf(node)) {
+		for (const dep of this.map.directDependenciesOf(node)) {
 			this.map.removeDependency(node, dep);
 		}
 	}
 
 	getTemplatesThatConsumeCollections(collectionNames) {
-		let templates = new Set();
-		for (let name of collectionNames) {
-			let collectionName = GlobalDependencyMap.getCollectionKeyForEntry(name);
+		const templates = new Set();
+		for (const name of collectionNames) {
+			const collectionName = GlobalDependencyMap.getCollectionKeyForEntry(name);
 			if (!this.map.hasNode(collectionName)) {
 				continue;
 			}
-			for (let node of this.map.dependantsOf(collectionName)) {
+			for (const node of this.map.dependantsOf(collectionName)) {
 				if (!node.startsWith(GlobalDependencyMap.COLLECTION_PREFIX)) {
 					templates.add(node);
 				}
@@ -187,7 +187,7 @@ class GlobalDependencyMap {
 			return [];
 		}
 
-		let layouts = [];
+		const layouts = [];
 
 		// include self, if layout
 		if (this.map.getNodeData(node)?.type === GlobalDependencyMap.LAYOUT_KEY) {
@@ -195,7 +195,7 @@ class GlobalDependencyMap {
 		}
 
 		this.map.dependantsOf(node).forEach((node) => {
-			let data = this.map.getNodeData(node);
+			const data = this.map.getNodeData(node);
 			// we only want layouts
 			if (data && data.type && data.type === GlobalDependencyMap.LAYOUT_KEY) {
 				return layouts.push(node);
@@ -220,7 +220,7 @@ class GlobalDependencyMap {
 			}
 
 			// When includeLayouts is `false` we want to filter out layouts
-			let data = this.map.getNodeData(node);
+			const data = this.map.getNodeData(node);
 			if (data && data.type && data.type === GlobalDependencyMap.LAYOUT_KEY) {
 				return false;
 			}
@@ -238,7 +238,7 @@ class GlobalDependencyMap {
 
 		// debug("%o depends on %o", from, toArray);
 
-		for (let to of toArray) {
+		for (const to of toArray) {
 			if (!this.map.hasNode(to)) {
 				this.map.addNode(to);
 			}
@@ -264,13 +264,13 @@ class GlobalDependencyMap {
 	}
 
 	addDependencyConsumesCollection(from, collectionName) {
-		let nodeName = this.normalizeNode(from);
+		const nodeName = this.normalizeNode(from);
 		debug("%o depends on collection: %o", nodeName, collectionName);
 		this._addDependency(nodeName, [GlobalDependencyMap.getCollectionKeyForEntry(collectionName)]);
 	}
 
 	addDependencyPublishesToCollection(from, collectionName) {
-		let normalizedFrom = this.normalizeNode(from);
+		const normalizedFrom = this.normalizeNode(from);
 		this._addDependency(GlobalDependencyMap.getCollectionKeyForEntry(collectionName), [
 			normalizedFrom,
 		]);
@@ -280,7 +280,7 @@ class GlobalDependencyMap {
 	hasDependency(from, to, includeLayouts) {
 		to = this.normalizeNode(to);
 
-		let deps = this.getDependencies(from, includeLayouts); // normalizes `from`
+		const deps = this.getDependencies(from, includeLayouts); // normalizes `from`
 
 		if (!deps) {
 			return false;
@@ -317,11 +317,11 @@ class GlobalDependencyMap {
 	}
 
 	restore(persisted) {
-		let obj = JSON.parse(persisted);
-		let graph = new DepGraph({ circular: true });
+		const obj = JSON.parse(persisted);
+		const graph = new DepGraph({ circular: true });
 
 		// https://github.com/jriecken/dependency-graph/issues/44
-		for (let key in obj) {
+		for (const key in obj) {
 			graph[key] = obj[key];
 		}
 		this.map = graph;

--- a/src/Plugins/HtmlBasePlugin.js
+++ b/src/Plugins/HtmlBasePlugin.js
@@ -29,7 +29,7 @@ function addPathPrefixToUrl(url, pathPrefix, base) {
 
 // pathprefix is only used when overrideBase is a full URL
 function transformUrl(url, base, opts = {}) {
-	let { pathPrefix, pageUrl } = opts;
+	const { pathPrefix, pageUrl } = opts;
 
 	// full URL, return as-is
 	if (isValidUrl(url)) {
@@ -52,7 +52,7 @@ function transformUrl(url, base, opts = {}) {
 }
 
 export default function (eleventyConfig, defaultOptions = {}) {
-	let opts = DeepCopy(
+	const opts = DeepCopy(
 		{
 			// eleventyConfig.pathPrefix is new in Eleventy 2.0.0-canary.15
 			// `base` can be a directory (for path prefix transformations)
@@ -80,7 +80,7 @@ export default function (eleventyConfig, defaultOptions = {}) {
 	});
 
 	eleventyConfig.addFilter(opts.filters.base, function (url, baseOverride, pageUrlOverride) {
-		let base = baseOverride || opts.baseHref;
+		const base = baseOverride || opts.baseHref;
 
 		// Do nothing with a default base
 		if (base === "/") {
@@ -96,7 +96,7 @@ export default function (eleventyConfig, defaultOptions = {}) {
 	eleventyConfig.addAsyncFilter(
 		opts.filters.html,
 		function (content, baseOverride, pageUrlOverride) {
-			let base = baseOverride || opts.baseHref;
+			const base = baseOverride || opts.baseHref;
 
 			// Do nothing with a default base
 			if (base === "/") {

--- a/src/Plugins/I18nPlugin.js
+++ b/src/Plugins/I18nPlugin.js
@@ -18,7 +18,7 @@ class LangUtils {
 	}
 
 	static getLanguageCodeFromUrl(url) {
-		let s = (url || "").split("/");
+		const s = (url || "").split("/");
 		return s.length > 0 && Comparator.isLangCode(s[1]) ? s[1] : "";
 	}
 
@@ -50,7 +50,7 @@ class Comparator {
 	// https://en.wikipedia.org/wiki/IETF_language_tag#Relation_to_other_standards
 	// Requires a ISO-639-1 language code at the start (2 characters before the first -)
 	static isLangCode(code) {
-		let [s] = (code || "").split("-");
+		const [s] = (code || "").split("-");
 		if (!iso639.validate(s)) {
 			return false;
 		}
@@ -91,13 +91,13 @@ function normalizeInputPath(inputPath, extensionMap) {
  * }
  */
 function getLocaleUrlsMap(urlToInputPath, extensionMap, options = {}) {
-	let filemap = {};
+	const filemap = {};
 
-	for (let url in urlToInputPath) {
+	for (const url in urlToInputPath) {
 		// Group number comes from Pagination.js
-		let { inputPath: originalFilepath, groupNumber } = urlToInputPath[url];
-		let filepath = normalizeInputPath(originalFilepath, extensionMap);
-		let replaced =
+		const { inputPath: originalFilepath, groupNumber } = urlToInputPath[url];
+		const filepath = normalizeInputPath(originalFilepath, extensionMap);
+		const replaced =
 			LangUtils.swapLanguageCodeNoCheck(filepath, "__11ty_i18n") + `_group:${groupNumber}`;
 
 		if (!filemap[replaced]) {
@@ -124,7 +124,7 @@ function getLocaleUrlsMap(urlToInputPath, extensionMap, options = {}) {
 	}
 
 	// Default sorted by lang code
-	for (let key in filemap) {
+	for (const key in filemap) {
 		filemap[key].sort(function (a, b) {
 			if (a.lang < b.lang) {
 				return -1;
@@ -137,10 +137,10 @@ function getLocaleUrlsMap(urlToInputPath, extensionMap, options = {}) {
 	}
 
 	// map of input paths => array of localized urls
-	let urlMap = {};
-	for (let filepath in filemap) {
-		for (let entry of filemap[filepath]) {
-			let url = entry.url;
+	const urlMap = {};
+	for (const filepath in filemap) {
+		for (const entry of filemap[filepath]) {
+			const url = entry.url;
 			if (!urlMap[url]) {
 				urlMap[url] = filemap[filepath].filter((entry) => {
 					if (entry.lang) {
@@ -156,7 +156,7 @@ function getLocaleUrlsMap(urlToInputPath, extensionMap, options = {}) {
 }
 
 function EleventyPlugin(eleventyConfig, opts = {}) {
-	let options = DeepCopy(
+	const options = DeepCopy(
 		{
 			defaultLanguage: "",
 			filters: {
@@ -179,10 +179,10 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 		extensionMap = map;
 	});
 
-	let bench = eleventyConfig.benchmarkManager.get("Aggregate");
-	let contentMaps = {};
+	const bench = eleventyConfig.benchmarkManager.get("Aggregate");
+	const contentMaps = {};
 	eleventyConfig.on("eleventy.contentMap", function ({ urlToInputPath, inputPathToUrl }) {
-		let b = bench.get("(i18n Plugin) Setting up content map.");
+		const b = bench.get("(i18n Plugin) Setting up content map.");
 		b.before();
 		contentMaps.inputPathToUrl = inputPathToUrl;
 		contentMaps.urlToInputPath = urlToInputPath;
@@ -203,7 +203,7 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 	// If a non-localized file exists, returns the URL without a language assigned
 	// Fails if no file exists (localized and not localized)
 	eleventyConfig.addFilter(options.filters.url, function (url, langCodeOverride) {
-		let langCode =
+		const langCode =
 			langCodeOverride ||
 			LangUtils.getLanguageCodeFromUrl(this.page?.url) ||
 			options.defaultLanguage;
@@ -213,7 +213,7 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 			contentMaps.localeUrlsMap[url] ||
 			(!url.endsWith("/") && contentMaps.localeUrlsMap[`${url}/`])
 		) {
-			for (let existingUrlObj of contentMaps.localeUrlsMap[url] ||
+			for (const existingUrlObj of contentMaps.localeUrlsMap[url] ||
 				contentMaps.localeUrlsMap[`${url}/`]) {
 				if (Comparator.urlHasLangCode(existingUrlObj.url, langCode)) {
 					return existingUrlObj.url;
@@ -222,7 +222,7 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 		}
 
 		// Needs the language code prepended to the URL
-		let prependedLangCodeUrl = `/${langCode}${url}`;
+		const prependedLangCodeUrl = `/${langCode}${url}`;
 		if (
 			contentMaps.localeUrlsMap[prependedLangCodeUrl] ||
 			(!prependedLangCodeUrl.endsWith("/") && contentMaps.localeUrlsMap[`${prependedLangCodeUrl}/`])
@@ -253,7 +253,7 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 	// Refactor to use url
 	// Find the links that are localized alternates to the inputPath argument
 	eleventyConfig.addFilter(options.filters.links, function (urlOverride) {
-		let url = urlOverride || this.page?.url;
+		const url = urlOverride || this.page?.url;
 		return (contentMaps.localeUrlsMap[url] || []).filter((entry) => {
 			return entry.url !== url;
 		});
@@ -269,17 +269,17 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 				languageCode = options.defaultLanguage;
 			}
 
-			let page = pageOverride || this.page;
+			const page = pageOverride || this.page;
 			let url; // new url
 			if (contentMaps.localeUrlsMap[page.url]) {
-				for (let entry of contentMaps.localeUrlsMap[page.url]) {
+				for (const entry of contentMaps.localeUrlsMap[page.url]) {
 					if (entry.lang === languageCode) {
 						url = entry.url;
 					}
 				}
 			}
 
-			let inputPath = LangUtils.swapLanguageCode(page.inputPath, languageCode);
+			const inputPath = LangUtils.swapLanguageCode(page.inputPath, languageCode);
 
 			if (
 				!url ||
@@ -290,7 +290,7 @@ function EleventyPlugin(eleventyConfig, opts = {}) {
 				return page;
 			}
 
-			let result = {
+			const result = {
 				// // note that the permalink/slug may be different for the localized file!
 				url,
 				inputPath,

--- a/src/Plugins/InputPathToUrl.js
+++ b/src/Plugins/InputPathToUrl.js
@@ -40,7 +40,7 @@ function FilterPlugin(eleventyConfig) {
 
 		filepath = normalizeInputPath(filepath, inputDir, contentMap);
 
-		let urls = contentMap[filepath];
+		const urls = contentMap[filepath];
 		if (!urls || urls.length === 0) {
 			throw new Error("`inputPathToUrl` filter could not find a matching target for " + filepath);
 		}
@@ -50,7 +50,7 @@ function FilterPlugin(eleventyConfig) {
 }
 
 function TransformPlugin(eleventyConfig, defaultOptions = {}) {
-	let opts = Object.assign(
+	const opts = Object.assign(
 		{
 			extensions: "html",
 		},
@@ -73,7 +73,7 @@ function TransformPlugin(eleventyConfig, defaultOptions = {}) {
 		}
 		filepathOrUrl = normalizeInputPath(filepathOrUrl, inputDir, contentMap);
 
-		let urls = contentMap[filepathOrUrl];
+		const urls = contentMap[filepathOrUrl];
 		if (!urls || urls.length === 0) {
 			// fallback, transforms don’t error on missing paths (though the pathToUrl filter does)
 			return filepathOrUrl;

--- a/src/Plugins/Pagination.js
+++ b/src/Plugins/Pagination.js
@@ -45,10 +45,10 @@ class Pagination {
 	}
 
 	circularReferenceCheck(data) {
-		let key = data.pagination.data;
-		let includedTags = TemplateData.getIncludedTagNames(data);
+		const key = data.pagination.data;
+		const includedTags = TemplateData.getIncludedTagNames(data);
 
-		for (let tag of includedTags) {
+		for (const tag of includedTags) {
 			if (`collections.${tag}` === key) {
 				throw new PaginationError(
 					`Pagination circular reference${this.inputPathForErrorMessages}, data:\`${key}\` iterates over both the \`${tag}\` collection and also supplies pages to that collection.`,
@@ -101,7 +101,7 @@ class Pagination {
 
 	isFiltered(value) {
 		if ("filter" in this.data.pagination) {
-			let filtered = this.data.pagination.filter;
+			const filtered = this.data.pagination.filter;
 			if (Array.isArray(filtered)) {
 				return filtered.indexOf(value) > -1;
 			}
@@ -113,14 +113,14 @@ class Pagination {
 	}
 
 	_has(target, key) {
-		let notFoundValue = "__NOT_FOUND_ERROR__";
-		let data = lodashGet(target, key, notFoundValue);
+		const notFoundValue = "__NOT_FOUND_ERROR__";
+		const data = lodashGet(target, key, notFoundValue);
 		return data !== notFoundValue;
 	}
 
 	_get(target, key) {
-		let notFoundValue = "__NOT_FOUND_ERROR__";
-		let data = lodashGet(target, key, notFoundValue);
+		const notFoundValue = "__NOT_FOUND_ERROR__";
+		const data = lodashGet(target, key, notFoundValue);
 		if (data === notFoundValue) {
 			throw new Error(
 				`Could not find pagination data${this.inputPathForErrorMessages}, went looking for: ${key}`,
@@ -212,7 +212,7 @@ class Pagination {
 	}
 
 	getOverrideDataLinks(pageNumber, templateCount, links) {
-		let obj = {};
+		const obj = {};
 
 		// links are okay but hrefs are better
 		obj.previousPageLink = pageNumber > 0 ? links[pageNumber - 1] : null;
@@ -231,7 +231,7 @@ class Pagination {
 	}
 
 	getOverrideDataHrefs(pageNumber, templateCount, hrefs) {
-		let obj = {};
+		const obj = {};
 
 		// hrefs are better than links
 		obj.previousPageHref = pageNumber > 0 ? hrefs[pageNumber - 1] : null;
@@ -264,25 +264,25 @@ class Pagination {
 			return [];
 		}
 
-		let entries = [];
-		let items = this.chunkedItems;
-		let pages = this.size === 1 ? items.map((entry) => entry[0]) : items;
+		const entries = [];
+		const items = this.chunkedItems;
+		const pages = this.size === 1 ? items.map((entry) => entry[0]) : items;
 
-		let links = [];
-		let hrefs = [];
+		const links = [];
+		const hrefs = [];
 
-		let hasPermalinkField = Boolean(this.data[this.config.keys.permalink]);
-		let hasComputedPermalinkField = Boolean(
+		const hasPermalinkField = Boolean(this.data[this.config.keys.permalink]);
+		const hasComputedPermalinkField = Boolean(
 			this.data.eleventyComputed && this.data.eleventyComputed[this.config.keys.permalink],
 		);
 
 		// Do *not* pass collections through DeepCopy, we’ll re-add them back in later.
-		let collections = this.data.collections;
+		const collections = this.data.collections;
 		if (collections) {
 			delete this.data.collections;
 		}
 
-		let parentData = DeepCopy(
+		const parentData = DeepCopy(
 			{
 				pagination: {
 					data: this.data.pagination.data,
@@ -308,19 +308,19 @@ class Pagination {
 		// so that we don’t have the memory cost of the full template (and can reuse the parent
 		// template for some things)
 
-		let indices = new Set();
+		const indices = new Set();
 		for (let j = 0; j <= items.length - 1; j++) {
 			indices.add(j);
 		}
 
-		for (let pageNumber of indices) {
-			let cloned = await this.template.clone();
+		for (const pageNumber of indices) {
+			const cloned = await this.template.clone();
 
 			if (pageNumber > 0 && !hasPermalinkField && !hasComputedPermalinkField) {
 				cloned.setExtraOutputSubdirectory(pageNumber);
 			}
 
-			let paginationData = {
+			const paginationData = {
 				pagination: {
 					items: items[pageNumber],
 				},
@@ -333,14 +333,14 @@ class Pagination {
 			}
 
 			// Do *not* deep merge pagination data! See https://github.com/11ty/eleventy/issues/147#issuecomment-440802454
-			let clonedData = ProxyWrap(paginationData, parentData, {
+			const clonedData = ProxyWrap(paginationData, parentData, {
 				benchmarkManager: this.config.benchmarkManager,
 			});
 
 			// Previous method:
 			// let clonedData = DeepCopy(paginationData, parentData);
 
-			let { /*linkInstance,*/ rawPath, path, href } = await cloned.getOutputLocations(clonedData);
+			const { /*linkInstance,*/ rawPath, path, href } = await cloned.getOutputLocations(clonedData);
 			// TODO subdirectory to links if the site doesn’t live at /
 			if (rawPath) {
 				links.push("/" + rawPath);
@@ -365,12 +365,12 @@ class Pagination {
 
 		// we loop twice to pass in the appropriate prev/next links (already full generated now)
 		let index = 0;
-		for (let pageEntry of entries) {
-			let linksObj = this.getOverrideDataLinks(index, items.length, links);
+		for (const pageEntry of entries) {
+			const linksObj = this.getOverrideDataLinks(index, items.length, links);
 
 			Object.assign(pageEntry.data.pagination, linksObj);
 
-			let hrefsObj = this.getOverrideDataHrefs(index, items.length, hrefs);
+			const hrefsObj = this.getOverrideDataHrefs(index, items.length, hrefs);
 			Object.assign(pageEntry.data.pagination, hrefsObj);
 			index++;
 		}

--- a/src/Plugins/RenderPlugin.js
+++ b/src/Plugins/RenderPlugin.js
@@ -36,7 +36,7 @@ async function compile(content, templateLang, { templateConfig, extensionMap } =
 		inputDir = templateConfig?.dir?.input;
 	}
 
-	let tr = new TemplateRender(templateLang, inputDir, templateConfig);
+	const tr = new TemplateRender(templateLang, inputDir, templateConfig);
 	tr.extensionMap = extensionMap;
 	if (templateLang) {
 		await tr.setEngineOverride(templateLang);
@@ -82,8 +82,8 @@ async function compileFile(inputPath, { templateConfig, extensionMap, config } =
 		await templateConfig.init();
 	}
 
-	let cfg = templateConfig.getConfig();
-	let tr = new TemplateRender(inputPath, cfg.dir.input, templateConfig);
+	const cfg = templateConfig.getConfig();
+	const tr = new TemplateRender(inputPath, cfg.dir.input, templateConfig);
 	tr.extensionMap = extensionMap;
 
 	if (templateLang) {
@@ -97,7 +97,7 @@ async function compileFile(inputPath, { templateConfig, extensionMap, config } =
 	}
 
 	// TODO we could make this work with full templates (with front matter?)
-	let content = await fsReadFile(inputPath, "utf8");
+	const content = await fsReadFile(inputPath, "utf8");
 	return tr.getCompiledTemplate(content);
 }
 
@@ -148,13 +148,13 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 	 * @property {module:11ty/eleventy/TemplateConfig} [templateConfig] - Configuration object
 	 * @property {boolean} [accessGlobalData] - Whether or not the template has access to the page’s data.
 	 */
-	let defaultOptions = {
+	const defaultOptions = {
 		tagName: "renderTemplate",
 		tagNameFile: "renderFile",
 		templateConfig: null,
 		accessGlobalData: false,
 	};
-	let opts = Object.assign(defaultOptions, options);
+	const opts = Object.assign(defaultOptions, options);
 
 	function liquidTemplateTag(liquidEngine, tagName) {
 		// via https://github.com/harttle/liquidjs/blob/b5a22fa0910c708fe7881ef170ed44d3594e18f3/src/builtin/tags/raw.ts
@@ -177,7 +177,7 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 				stream.start();
 			},
 			render: function* (ctx) {
-				let normalizedContext = {};
+				const normalizedContext = {};
 				if (ctx) {
 					if (opts.accessGlobalData) {
 						// parent template data cascade
@@ -188,18 +188,18 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 					normalizedContext.eleventy = ctx.get(["eleventy"]);
 				}
 
-				let rawArgs = Liquid.parseArguments(null, this.args);
-				let argArray = [];
-				let contextScope = ctx.getAll();
-				for (let arg of rawArgs) {
-					let b = yield liquidEngine.evalValue(arg, contextScope);
+				const rawArgs = Liquid.parseArguments(null, this.args);
+				const argArray = [];
+				const contextScope = ctx.getAll();
+				for (const arg of rawArgs) {
+					const b = yield liquidEngine.evalValue(arg, contextScope);
 					argArray.push(b);
 				}
 
 				// plaintext paired shortcode content
-				let body = this.tokens.map((token) => token.getText()).join("");
+				const body = this.tokens.map((token) => token.getText()).join("");
 
-				let ret = _renderStringShortcodeFn.call(
+				const ret = _renderStringShortcodeFn.call(
 					normalizedContext,
 					body,
 					// templateLang, data
@@ -258,18 +258,18 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 					}
 				}
 
-				let body = new nodes.Output(begun.lineno, begun.colno, [
+				const body = new nodes.Output(begun.lineno, begun.colno, [
 					new nodes.TemplateData(begun.lineno, begun.colno, str),
 				]);
 				return new nodes.CallExtensionAsync(this, "run", args, [body]);
 			};
 
 			this.run = function (...args) {
-				let resolve = args.pop();
-				let body = args.pop();
-				let [context, ...argArray] = args;
+				const resolve = args.pop();
+				const body = args.pop();
+				const [context, ...argArray] = args;
 
-				let normalizedContext = {};
+				const normalizedContext = {};
 				if (context.ctx && context.ctx.page) {
 					normalizedContext.ctx = context.ctx;
 
@@ -338,7 +338,7 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 			templateLang = false;
 		}
 
-		let fn = await compile.call(this, content, templateLang, {
+		const fn = await compile.call(this, content, templateLang, {
 			templateConfig: opts.templateConfig || templateConfig,
 			extensionMap,
 		});
@@ -347,7 +347,7 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 	}
 
 	async function _renderFileShortcodeFn(inputPath, data = {}, templateLang) {
-		let fn = await compileFile.call(
+		const fn = await compileFile.call(
 			this,
 			inputPath,
 			{
@@ -425,8 +425,8 @@ class RenderManager {
 	async getData(...data) {
 		await this.init();
 
-		let globalData = await this.initialGlobalData.getData();
-		let merged = Merge({}, globalData, ...data);
+		const globalData = await this.initialGlobalData.getData();
+		const merged = Merge({}, globalData, ...data);
 		return merged;
 	}
 
@@ -444,9 +444,9 @@ class RenderManager {
 	async render(fn, edgeData, buildTimeData) {
 		await this.init();
 
-		let mergedData = await this.getData(edgeData);
+		const mergedData = await this.getData(edgeData);
 		// Set .data for options.accessGlobalData feature
-		let context = {
+		const context = {
 			data: mergedData,
 		};
 

--- a/src/TemplateBehavior.js
+++ b/src/TemplateBehavior.js
@@ -38,16 +38,16 @@ class TemplateBehavior {
 		// render is false *only* if `build` key does not exist in permalink objects (both in data and eleventyComputed)
 		// (note that permalink: false means it won’t write but will still render)
 
-		let keys = new Set();
+		const keys = new Set();
 		if (isPlainObject(data.permalink)) {
-			for (let key of Object.keys(data.permalink)) {
+			for (const key of Object.keys(data.permalink)) {
 				keys.add(key);
 			}
 		}
 
-		let computedKey = this.config.keys.computed;
+		const computedKey = this.config.keys.computed;
 		if (computedKey in data && isPlainObject(data[computedKey].permalink)) {
-			for (let key of Object.keys(data[computedKey].permalink)) {
+			for (const key of Object.keys(data[computedKey].permalink)) {
 				keys.add(key);
 			}
 		}

--- a/src/TemplateCache.js
+++ b/src/TemplateCache.js
@@ -26,7 +26,7 @@ class TemplateCache {
 	}
 
 	add(layoutTemplate) {
-		let keys = new Set();
+		const keys = new Set();
 
 		if (typeof layoutTemplate === "string") {
 			throw new Error(
@@ -44,12 +44,12 @@ class TemplateCache {
 			keys.add(layoutTemplate.getKey());
 		}
 
-		for (let key of keys) {
+		for (const key of keys) {
 			this.cache[key] = layoutTemplate;
 		}
 
 		// also the full template input path for use with eleventy --serve/--watch e.g. `_includes/default.liquid` (see `remove` below)
-		let fullPath = TemplatePath.stripLeadingDotSlash(layoutTemplate.inputPath);
+		const fullPath = TemplatePath.stripLeadingDotSlash(layoutTemplate.inputPath);
 		this.cacheByInputPath[fullPath] = layoutTemplate;
 	}
 
@@ -72,11 +72,11 @@ class TemplateCache {
 			return;
 		}
 
-		let layoutTemplate = this.cacheByInputPath[layoutFilePath];
+		const layoutTemplate = this.cacheByInputPath[layoutFilePath];
 		layoutTemplate.resetCaches();
 
-		let keys = layoutTemplate.getCacheKeys();
-		for (let key of keys) {
+		const keys = layoutTemplate.getCacheKeys();
+		for (const key of keys) {
 			delete this.cache[key];
 		}
 
@@ -84,7 +84,7 @@ class TemplateCache {
 	}
 }
 
-let layoutCache = new TemplateCache();
+const layoutCache = new TemplateCache();
 
 eventBus.on("eleventy.resourceModified", (path, usedBy, metadata = {}) => {
 	// https://github.com/11ty/eleventy-plugin-bundle/issues/10
@@ -92,7 +92,7 @@ eventBus.on("eleventy.resourceModified", (path, usedBy, metadata = {}) => {
 		layoutCache.removeAll();
 	} else if (metadata.relevantLayouts?.length) {
 		// reset the appropriate layouts relevant to the file.
-		for (let layoutPath of metadata.relevantLayouts || []) {
+		for (const layoutPath of metadata.relevantLayouts || []) {
 			layoutCache.remove(layoutPath);
 		}
 	} else {

--- a/src/TemplateCollection.js
+++ b/src/TemplateCollection.js
@@ -36,7 +36,7 @@ class TemplateCollection extends Sortable {
 	getFilteredByGlob(globs) {
 		globs = this.getGlobs(globs);
 
-		let key = globs.join("::");
+		const key = globs.join("::");
 		if (!this._dirty) {
 			// Try to find a pre-sorted list and clone it.
 			if (this._filteredByGlobsCache.has(key)) {
@@ -47,7 +47,7 @@ class TemplateCollection extends Sortable {
 			this._filteredByGlobsCache = new Map();
 		}
 
-		let filtered = this.getAllSorted().filter((item) => {
+		const filtered = this.getAllSorted().filter((item) => {
 			if (multimatch([item.inputPath], globs).length) {
 				return true;
 			}
@@ -70,7 +70,7 @@ class TemplateCollection extends Sortable {
 
 	getFilteredByTags(...tags) {
 		return this.getAllSorted().filter((item) => {
-			let itemTags = TemplateData.getIncludedTagNames(item.data);
+			const itemTags = TemplateData.getIncludedTagNames(item.data);
 			return tags.every((requiredTag) => {
 				if (Array.isArray(itemTags)) {
 					return itemTags.includes(requiredTag);

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -102,9 +102,9 @@ class TemplateConfig {
 	 * @returns {String} - The normalised local project config file path.
 	 */
 	getLocalProjectConfigFile() {
-		let configFiles = this.getLocalProjectConfigFiles();
+		const configFiles = this.getLocalProjectConfigFiles();
 		// Add the configFiles[0] in case of a test, where no file exists on the file system
-		let configFile = configFiles.find((path) => path && fs.existsSync(path)) || configFiles[0];
+		const configFile = configFiles.find((path) => path && fs.existsSync(path)) || configFiles[0];
 		if (configFile) {
 			return configFile;
 		}
@@ -277,14 +277,14 @@ class TemplateConfig {
 		// for Nested addPlugin calls, Issue #1925
 		this.userConfig._enablePluginExecution();
 
-		let storedActiveNamespace = this.userConfig.activeNamespace;
-		for (let { plugin, options, pluginNamespace } of this.userConfig.plugins) {
+		const storedActiveNamespace = this.userConfig.activeNamespace;
+		for (const { plugin, options, pluginNamespace } of this.userConfig.plugins) {
 			try {
 				this.userConfig.activeNamespace = pluginNamespace;
 				await this.userConfig._executePlugin(plugin, options);
 			} catch (e) {
-				let name = this.userConfig._getPluginName(plugin);
-				let namespaces = [storedActiveNamespace, pluginNamespace].filter((entry) => !!entry);
+				const name = this.userConfig._getPluginName(plugin);
+				const namespaces = [storedActiveNamespace, pluginNamespace].filter((entry) => !!entry);
 
 				let namespaceStr = "";
 				if (namespaces.length) {
@@ -308,7 +308,7 @@ class TemplateConfig {
 	 */
 	async requireLocalConfigFile() {
 		let localConfig = {};
-		let path = this.projectConfigPaths.filter((path) => path).find((path) => fs.existsSync(path));
+		const path = this.projectConfigPaths.filter((path) => path).find((path) => fs.existsSync(path));
 
 		debug(`Merging config with ${path}`);
 
@@ -355,7 +355,7 @@ class TemplateConfig {
 	 * @returns {{}} merged - The merged config file.
 	 */
 	async mergeConfig() {
-		let localConfig = await this.requireLocalConfigFile();
+		const localConfig = await this.requireLocalConfigFile();
 
 		// Template Formats:
 		// 1. Root Config (usually defaultConfig.js)
@@ -367,7 +367,7 @@ class TemplateConfig {
 			delete localConfig.templateFormats;
 		}
 
-		let mergedConfig = merge({}, this.rootConfig, localConfig);
+		const mergedConfig = merge({}, this.rootConfig, localConfig);
 
 		// Setup a few properties for plugins:
 
@@ -390,15 +390,15 @@ class TemplateConfig {
 
 		await this.userConfig.events.emit("eleventy.beforeConfig", this.userConfig);
 
-		let benchmarkManager = this.userConfig.benchmarkManager.get("Aggregate");
-		let pluginsBench = benchmarkManager.get("Processing plugins in config");
+		const benchmarkManager = this.userConfig.benchmarkManager.get("Aggregate");
+		const pluginsBench = benchmarkManager.get("Processing plugins in config");
 		pluginsBench.before();
 		await this.processPlugins(mergedConfig);
 		pluginsBench.after();
 
 		delete mergedConfig.templateFormats;
 
-		let eleventyConfigApiMergingObject = this.userConfig.getMergingConfigObject();
+		const eleventyConfigApiMergingObject = this.userConfig.getMergingConfigObject();
 
 		// `templateFormats` is an override via `setTemplateFormats`
 		// `templateFormatsAdded` is additive via `addTemplateFormats`
@@ -407,7 +407,7 @@ class TemplateConfig {
 			delete eleventyConfigApiMergingObject.templateFormats;
 		}
 
-		let templateFormatsAdded = eleventyConfigApiMergingObject.templateFormatsAdded || [];
+		const templateFormatsAdded = eleventyConfigApiMergingObject.templateFormatsAdded || [];
 		delete eleventyConfigApiMergingObject.templateFormatsAdded;
 
 		templateFormats = unique([...templateFormats, ...templateFormatsAdded]);

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -169,10 +169,10 @@ class TemplateContent {
 
 			this.readingPromise = new Promise(async (resolve, reject) => {
 				try {
-					let content = await this.inputContent;
+					const content = await this.inputContent;
 
 					if (content) {
-						let options = this.config.frontMatterParsingOptions || {};
+						const options = this.config.frontMatterParsingOptions || {};
 						let fm;
 						try {
 							// Added in 3.0, passed along to front matter engines
@@ -186,7 +186,7 @@ class TemplateContent {
 						}
 
 						if (options.excerpt && fm.excerpt) {
-							let excerptString = fm.excerpt + (options.excerpt_separator || "---");
+							const excerptString = fm.excerpt + (options.excerpt_separator || "---");
 							if (fm.content.startsWith(excerptString + os.EOL)) {
 								// with an os-specific newline after excerpt separator
 								fm.content =
@@ -202,7 +202,7 @@ class TemplateContent {
 							}
 
 							// alias, defaults to page.excerpt
-							let alias = options.excerpt_alias || "page.excerpt";
+							const alias = options.excerpt_alias || "page.excerpt";
 							lodashSet(fm.data, alias, fm.excerpt);
 						}
 
@@ -246,12 +246,12 @@ class TemplateContent {
 	}
 
 	async getInputContent() {
-		let tr = await this.getTemplateRender();
+		const tr = await this.getTemplateRender();
 		if (!tr.engine.needsToReadFileContents()) {
 			return "";
 		}
 
-		let templateBenchmark = this.bench.get("Template Read");
+		const templateBenchmark = this.bench.get("Template Read");
 		templateBenchmark.before();
 
 		let content;
@@ -275,12 +275,12 @@ class TemplateContent {
 
 	// This might only be used in tests
 	async getFrontMatter() {
-		let fm = this.frontMatterOverride ? this.frontMatterOverride : await this.read();
+		const fm = this.frontMatterOverride ? this.frontMatterOverride : await this.read();
 		return fm;
 	}
 
 	async getPreRender() {
-		let fm = this.frontMatterOverride ? this.frontMatterOverride : await this.read();
+		const fm = this.frontMatterOverride ? this.frontMatterOverride : await this.read();
 
 		return fm.content;
 	}
@@ -289,12 +289,12 @@ class TemplateContent {
 		if (!this._frontMatterDataCache) {
 			this._frontMatterDataCache = new Promise(async (resolve, reject) => {
 				try {
-					let fm = await this.read();
+					const fm = await this.read();
 
-					let extraData = await this.engine.getExtraDataFromFile(this.inputPath);
-					let data = TemplateData.mergeDeep({}, fm.data, extraData);
+					const extraData = await this.engine.getExtraDataFromFile(this.inputPath);
+					const data = TemplateData.mergeDeep({}, fm.data, extraData);
 
-					let cleanedData = TemplateData.cleanupData(data);
+					const cleanedData = TemplateData.cleanupData(data);
 					resolve(cleanedData);
 				} catch (e) {
 					reject(e);
@@ -306,7 +306,7 @@ class TemplateContent {
 	}
 
 	async getEngineOverride() {
-		let frontMatterData = await this.getFrontMatterData();
+		const frontMatterData = await this.getFrontMatterData();
 		return frontMatterData[this.config.keys.engineOverride];
 	}
 
@@ -318,9 +318,10 @@ class TemplateContent {
 			TemplateContent._compileCache.set(this.inputPath, inputPathMap);
 		}
 
-		let cacheable = this.engine.cacheable;
-		let { useCache, key } = this.engine.getCompileCacheKey(str, this.inputPath);
-
+		const cacheable = this.engine.cacheable;
+		const cCacheKey = this.engine.getCompileCacheKey(str, this.inputPath);
+		const { useCache } = cCacheKey;
+		let { key } = cCacheKey;
 		// We also tie the compile cache key to the UserConfig instance, to alleviate issues with global template cache
 		// Better to move the cache to the Eleventy instance instead, no?
 		// (This specifically failed I18nPluginTest cases with filters being cached across tests and not having access to each plugin’s options)
@@ -330,7 +331,7 @@ class TemplateContent {
 	}
 
 	async compile(str, bypassMarkdown, engineOverride) {
-		let tr = await this.getTemplateRender();
+		const tr = await this.getTemplateRender();
 
 		if (engineOverride !== undefined) {
 			debugDev("%o overriding template engine to use %o", this.inputPath, engineOverride);
@@ -350,7 +351,7 @@ class TemplateContent {
 		try {
 			let res;
 			if (this.config.useTemplateCache) {
-				let [cacheable, key, cache, useCache] = this._getCompileCache(str);
+				const [cacheable, key, cache, useCache] = this._getCompileCache(str);
 				if (cacheable && key) {
 					if (useCache && cache.has(key)) {
 						this.bench.get("(count) Template Compile Cache Hit").incrementCount();
@@ -372,11 +373,11 @@ class TemplateContent {
 				}
 			}
 
-			let templateBenchmark = this.bench.get("Template Compile");
-			let inputPathBenchmark = this.bench.get(`> Compile > ${this.inputPath}`);
+			const templateBenchmark = this.bench.get("Template Compile");
+			const inputPathBenchmark = this.bench.get(`> Compile > ${this.inputPath}`);
 			templateBenchmark.before();
 			inputPathBenchmark.before();
-			let fn = await tr.getCompiledTemplate(str);
+			const fn = await tr.getCompiledTemplate(str);
 			inputPathBenchmark.after();
 			templateBenchmark.after();
 			debugDev("%o getCompiledTemplate function created", this.inputPath);
@@ -385,7 +386,7 @@ class TemplateContent {
 			}
 			return fn;
 		} catch (e) {
-			let [cacheable, key, cache] = this._getCompileCache(str);
+			const [cacheable, key, cache] = this._getCompileCache(str);
 			if (cacheable && key) {
 				cache.delete(key);
 			}
@@ -402,9 +403,9 @@ class TemplateContent {
 
 		// Don’t use markdown as the engine to parse for symbols
 		// TODO pass in engineOverride here
-		let preprocessorEngine = this.templateRender.getPreprocessorEngine();
+		const preprocessorEngine = this.templateRender.getPreprocessorEngine();
 		if (preprocessorEngine && engine.getName() !== preprocessorEngine) {
-			let replacementEngine = this.templateRender.getEngineByName(preprocessorEngine);
+			const replacementEngine = this.templateRender.getEngineByName(preprocessorEngine);
 			if (replacementEngine) {
 				engine = replacementEngine;
 			}
@@ -419,8 +420,8 @@ class TemplateContent {
 
 	// used by computed data or for permalink functions
 	async _renderFunction(fn, ...args) {
-		let mixins = Object.assign({}, this.config.javascriptFunctions);
-		let result = await fn.call(mixins, ...args);
+		const mixins = Object.assign({}, this.config.javascriptFunctions);
+		const result = await fn.call(mixins, ...args);
 
 		// normalize Buffer away if returned from permalink
 		if (Buffer.isBuffer(result)) {
@@ -444,7 +445,7 @@ class TemplateContent {
 			.get(`(count) > Render Permalink > ${this.inputPath}${this._getPaginationLogSuffix(data)}`)
 			.incrementCount();
 
-		let permalinkCompilation = this.engine.permalinkNeedsCompilation(permalink);
+		const permalinkCompilation = this.engine.permalinkNeedsCompilation(permalink);
 
 		// No string compilation:
 		//    ({ compileOptions: { permalink: "raw" }})
@@ -480,7 +481,7 @@ class TemplateContent {
 	}
 
 	_getPaginationLogSuffix(data) {
-		let suffix = [];
+		const suffix = [];
 		if ("pagination" in data) {
 			suffix.push(" (");
 			if (data.pagination.pages) {
@@ -501,7 +502,7 @@ class TemplateContent {
 				return str;
 			}
 
-			let fn = await this.compile(str, bypassMarkdown, data[this.config.keys.engineOverride]);
+			const fn = await this.compile(str, bypassMarkdown, data[this.config.keys.engineOverride]);
 
 			if (fn === undefined) {
 				return;
@@ -510,10 +511,10 @@ class TemplateContent {
 			}
 
 			// Benchmark
-			let templateBenchmark = this.bench.get("Render");
+			const templateBenchmark = this.bench.get("Render");
 			// Skip benchmark for each individual pagination entry (very busy output)
-			let logRenderToOutputBenchmark = "pagination" in data;
-			let inputPathBenchmark = this.bench.get(
+			const logRenderToOutputBenchmark = "pagination" in data;
+			const inputPathBenchmark = this.bench.get(
 				`> Render > ${this.inputPath}${this._getPaginationLogSuffix(data)}`,
 			);
 			let outputPathBenchmark;
@@ -529,7 +530,7 @@ class TemplateContent {
 				outputPathBenchmark.before();
 			}
 
-			let rendered = await fn(data);
+			const rendered = await fn(data);
 
 			if (outputPathBenchmark) {
 				outputPathBenchmark.after();
@@ -544,8 +545,8 @@ class TemplateContent {
 			if (EleventyErrorUtil.isPrematureTemplateContentError(e)) {
 				throw e;
 			} else {
-				let tr = await this.getTemplateRender();
-				let engine = tr.getReadableEnginesList();
+				const tr = await this.getTemplateRender();
+				const engine = tr.getReadableEnginesList();
 				debug(`Having trouble rendering ${engine} template ${this.inputPath}: %O`, str);
 				throw new TemplateContentRenderError(
 					`Having trouble rendering ${engine} template ${this.inputPath}`,
@@ -565,9 +566,9 @@ class TemplateContent {
 			return true;
 		}
 
-		let hasDependencies = this.engine.hasDependencies(incrementalFile);
+		const hasDependencies = this.engine.hasDependencies(incrementalFile);
 
-		let isRelevant = this.engine.isFileRelevantTo(this.inputPath, incrementalFile);
+		const isRelevant = this.engine.isFileRelevantTo(this.inputPath, incrementalFile);
 
 		debug(
 			"Test dependencies to see if %o is relevant to %o: %o",
@@ -576,9 +577,11 @@ class TemplateContent {
 			isRelevant,
 		);
 
-		let extensionEntries = this.getExtensionEntries().filter((entry) => !!entry.isIncrementalMatch);
+		const extensionEntries = this.getExtensionEntries().filter(
+			(entry) => !!entry.isIncrementalMatch,
+		);
 		if (extensionEntries.length) {
-			for (let entry of extensionEntries) {
+			for (const entry of extensionEntries) {
 				if (
 					entry.isIncrementalMatch.call(
 						{
@@ -622,8 +625,8 @@ eventBus.on("eleventy.resourceModified", (path) => {
 	TemplateContent.deleteFromInputCache(path);
 
 	// delete from compile cache
-	let normalized = TemplatePath.addLeadingDotSlash(path);
-	let compileCache = TemplateContent._compileCache.get(normalized);
+	const normalized = TemplatePath.addLeadingDotSlash(path);
+	const compileCache = TemplateContent._compileCache.get(normalized);
 	if (compileCache) {
 		compileCache.clear();
 	}

--- a/src/TemplateData.js
+++ b/src/TemplateData.js
@@ -100,7 +100,7 @@ class TemplateData {
 		try {
 			this.rawImports[this.config.keys.package] = await EleventyImport("package.json", "json");
 		} catch (e) {
-			let pkgPath = TemplatePath.absolutePath("package.json");
+			const pkgPath = TemplatePath.absolutePath("package.json");
 			debug("Could not find and/or require package.json for data preprocessing at %o", pkgPath);
 		}
 
@@ -128,7 +128,7 @@ class TemplateData {
 
 	async _checkInputDir() {
 		if (this.inputDirNeedsCheck) {
-			let globalPathStat = await fsStatAsync(this.inputDir);
+			const globalPathStat = await fsStatAsync(this.inputDir);
 
 			if (!globalPathStat.isDirectory()) {
 				throw new Error("Could not find data path directory: " + this.inputDir);
@@ -158,7 +158,7 @@ class TemplateData {
 
 		// Backwards compatibility
 		if (this.config.jsDataFileSuffix) {
-			let suffixes = [];
+			const suffixes = [];
 			suffixes.push(this.config.jsDataFileSuffix); // e.g. filename.11tydata.json
 			suffixes.push(""); // suffix-less for free with old API, e.g. filename.json
 			return suffixes;
@@ -168,13 +168,13 @@ class TemplateData {
 
 	// This is used exclusively for --watch and --serve chokidar targets
 	async getTemplateDataFileGlob() {
-		let suffixes = this.getDataFileSuffixes();
-		let globSuffixesWithLeadingDot = new Set();
+		const suffixes = this.getDataFileSuffixes();
+		const globSuffixesWithLeadingDot = new Set();
 		globSuffixesWithLeadingDot.add("json"); // covers .11tydata.json too
-		let globSuffixesWithoutLeadingDot = new Set();
+		const globSuffixesWithoutLeadingDot = new Set();
 
 		// Typically using [ '.11tydata', '' ] suffixes to find data files
-		for (let suffix of suffixes) {
+		for (const suffix of suffixes) {
 			// TODO the `suffix` truthiness check is purely for backwards compat?
 			if (suffix && typeof suffix === "string") {
 				if (suffix.startsWith(".")) {
@@ -193,13 +193,13 @@ class TemplateData {
 
 		// Configuration Data Extensions e.g. yaml
 		if (this.hasUserDataExtensions()) {
-			for (let extension of this.getUserDataExtensions()) {
+			for (const extension of this.getUserDataExtensions()) {
 				globSuffixesWithLeadingDot.add(extension); // covers .11tydata.{extension} too
 			}
 		}
 
-		let dir = await this.getInputDir();
-		let paths = [];
+		const dir = await this.getInputDir();
+		const paths = [];
 		if (globSuffixesWithLeadingDot.size > 0) {
 			paths.push(`${dir}/**/*.{${Array.from(globSuffixesWithLeadingDot).join(",")}}`);
 		}
@@ -213,11 +213,11 @@ class TemplateData {
 	// For spidering dependencies
 	// TODO Can we reuse getTemplateDataFileGlob instead? Maybe just filter off the .json files before scanning for dependencies
 	async getTemplateJavaScriptDataFileGlob() {
-		let dir = await this.getInputDir();
+		const dir = await this.getInputDir();
 
-		let paths = [];
-		let suffixes = this.getDataFileSuffixes();
-		for (let suffix of suffixes) {
+		const paths = [];
+		const suffixes = this.getDataFileSuffixes();
+		for (const suffix of suffixes) {
 			if (suffix) {
 				// TODO this check is purely for backwards compat and I kinda feel like it shouldn’t be here
 				// paths.push(`${dir}/**/*${suffix || ""}.cjs`); // Same as above
@@ -229,9 +229,9 @@ class TemplateData {
 	}
 
 	async getGlobalDataGlob() {
-		let dir = await this.getInputDir();
+		const dir = await this.getInputDir();
 
-		let extGlob = this.getGlobalDataExtensionPriorities().join(",");
+		const extGlob = this.getGlobalDataExtensionPriorities().join(",");
 		return [this._getGlobalDataGlobByExtension(dir, "{" + extGlob + "}")];
 	}
 
@@ -245,7 +245,7 @@ class TemplateData {
 
 	static calculateExtensionPriority(path, priorities) {
 		for (let i = 0; i < priorities.length; i++) {
-			let ext = priorities[i];
+			const ext = priorities[i];
 			if (path.endsWith(ext)) {
 				return i;
 			}
@@ -254,11 +254,11 @@ class TemplateData {
 	}
 
 	async getGlobalDataFiles() {
-		let priorities = this.getGlobalDataExtensionPriorities();
+		const priorities = this.getGlobalDataExtensionPriorities();
 
-		let fsBench = this.benchmarks.aggregate.get("Searching the file system (data)");
+		const fsBench = this.benchmarks.aggregate.get("Searching the file system (data)");
 		fsBench.before();
-		let globs = await this.getGlobalDataGlob();
+		const globs = await this.getGlobalDataGlob();
 		let paths = await this.fileSystemSearch.search("global-data", globs);
 		fsBench.after();
 
@@ -266,8 +266,8 @@ class TemplateData {
 		// here we use reverse ordering, because paths with bigger index in array will override the first ones
 		// example [path/file.json, path/file.js] here js will override json
 		paths = paths.sort((first, second) => {
-			let p1 = TemplateData.calculateExtensionPriority(first, priorities);
-			let p2 = TemplateData.calculateExtensionPriority(second, priorities);
+			const p1 = TemplateData.calculateExtensionPriority(first, priorities);
+			const p2 = TemplateData.calculateExtensionPriority(second, priorities);
 			if (p1 < p2) {
 				return -1;
 			}
@@ -282,31 +282,31 @@ class TemplateData {
 	}
 
 	getObjectPathForDataFile(dataFilePath) {
-		let reducedPath = TemplatePath.stripLeadingSubPath(dataFilePath, this.dataDir);
-		let parsed = path.parse(reducedPath);
-		let folders = parsed.dir ? parsed.dir.split("/") : [];
+		const reducedPath = TemplatePath.stripLeadingSubPath(dataFilePath, this.dataDir);
+		const parsed = path.parse(reducedPath);
+		const folders = parsed.dir ? parsed.dir.split("/") : [];
 		folders.push(parsed.name);
 
 		return folders;
 	}
 
 	async getAllGlobalData() {
-		let globalData = {};
-		let files = TemplatePath.addLeadingDotSlashArray(await this.getGlobalDataFiles());
+		const globalData = {};
+		const files = TemplatePath.addLeadingDotSlashArray(await this.getGlobalDataFiles());
 
 		this.config.events.emit("eleventy.globalDataFiles", files);
 
-		let dataFileConflicts = {};
+		const dataFileConflicts = {};
 
 		for (let j = 0, k = files.length; j < k; j++) {
 			let data = await this.getDataValue(files[j]);
-			let objectPathTarget = this.getObjectPathForDataFile(files[j]);
+			const objectPathTarget = this.getObjectPathForDataFile(files[j]);
 
 			// Since we're joining directory paths and an array is not usable as an objectkey since two identical arrays are not double equal,
 			// we can just join the array by a forbidden character ("/"" is chosen here, since it works on Linux, Mac and Windows).
 			// If at some point this isn't enough anymore, it would be possible to just use JSON.stringify(objectPathTarget) since that
 			// is guaranteed to work but is signifivcantly slower.
-			let objectPathTargetString = objectPathTarget.join(path.sep);
+			const objectPathTargetString = objectPathTarget.join(path.sep);
 
 			// if two global files have the same path (but different extensions)
 			// and conflict, let’s merge them.
@@ -315,7 +315,7 @@ class TemplateData {
 					`merging global data from ${files[j]} with an already existing global data file (${dataFileConflicts[objectPathTargetString]}). Overriding existing keys.`,
 				);
 
-				let oldData = lodashGet(globalData, objectPathTarget);
+				const oldData = lodashGet(globalData, objectPathTarget);
 				data = TemplateData.mergeDeep(this.config, oldData, data);
 			}
 
@@ -330,7 +330,7 @@ class TemplateData {
 	async getInitialGlobalData() {
 		if (!this.configApiGlobalData) {
 			this.configApiGlobalData = new Promise(async (resolve) => {
-				let globalData = await this.initialGlobalData.getData();
+				const globalData = await this.initialGlobalData.getData();
 
 				if (this.environmentVariables) {
 					if (!("env" in globalData.eleventy)) {
@@ -354,14 +354,14 @@ class TemplateData {
 	}
 
 	async getGlobalData() {
-		let rawImports = await this.getRawImports();
+		const rawImports = await this.getRawImports();
 
 		if (!this.globalData) {
 			this.globalData = new Promise(async (resolve) => {
-				let configApiGlobalData = await this.getInitialGlobalData();
+				const configApiGlobalData = await this.getInitialGlobalData();
 
-				let globalJson = await this.getAllGlobalData();
-				let mergedGlobalData = merge(globalJson, configApiGlobalData);
+				const globalJson = await this.getAllGlobalData();
+				const mergedGlobalData = merge(globalJson, configApiGlobalData);
 
 				// OK: Shallow merge when combining rawImports (pkg) with global data files
 				resolve(Object.assign({}, mergedGlobalData, rawImports));
@@ -373,7 +373,7 @@ class TemplateData {
 
 	/* Template and Directory data files */
 	async combineLocalData(localDataPaths) {
-		let localData = {};
+		const localData = {};
 		if (!Array.isArray(localDataPaths)) {
 			localDataPaths = [localDataPaths];
 		}
@@ -398,9 +398,9 @@ class TemplateData {
 			return localData;
 		}
 
-		let dataSource = {};
-		for (let path of localDataPaths) {
-			let dataForPath = await this.getDataValue(path);
+		const dataSource = {};
+		for (const path of localDataPaths) {
+			const dataForPath = await this.getDataValue(path);
 			if (!isPlainObject(dataForPath)) {
 				debug(
 					"Warning: Template and Directory data files expect an object to be returned, instead `%o` returned `%o`",
@@ -409,8 +409,8 @@ class TemplateData {
 				);
 			} else {
 				// clean up data for template/directory data files only.
-				let cleanedDataForPath = TemplateData.cleanupData(dataForPath);
-				for (let key in cleanedDataForPath) {
+				const cleanedDataForPath = TemplateData.cleanupData(dataForPath);
+				for (const key in cleanedDataForPath) {
 					if (Object.prototype.hasOwnProperty.call(dataSource, key)) {
 						debugWarn(
 							"Local data files have conflicting data. Overwriting '%s' with data from '%s'. Previous data location was from '%s'",
@@ -429,8 +429,8 @@ class TemplateData {
 
 	async getTemplateDirectoryData(templatePath) {
 		if (!this.templateDirectoryData[templatePath]) {
-			let localDataPaths = await this.getLocalDataPaths(templatePath);
-			let importedData = await this.combineLocalData(localDataPaths);
+			const localDataPaths = await this.getLocalDataPaths(templatePath);
+			const importedData = await this.combineLocalData(localDataPaths);
 
 			this.templateDirectoryData[templatePath] = Object.assign({}, importedData);
 		}
@@ -460,7 +460,7 @@ class TemplateData {
 	}
 
 	async _parseDataFile(path, parser, options = {}) {
-		let readFile = !("read" in options) || options.read === true;
+		const readFile = !("read" in options) || options.read === true;
 		let rawInput;
 
 		if (readFile) {
@@ -487,12 +487,12 @@ class TemplateData {
 	// ignoreProcessing = false for global data files
 	// ignoreProcessing = true for local data files
 	async getDataValue(path) {
-		let extension = TemplatePath.getExtension(path);
+		const extension = TemplatePath.getExtension(path);
 
 		if (extension === "js" || extension === "cjs" || extension === "mjs") {
 			// JS data file or require’d JSON (no preprocessing needed)
-			let localPath = TemplatePath.absolutePath(path);
-			let exists = this._fsExistsCache.exists(localPath);
+			const localPath = TemplatePath.absolutePath(path);
+			const exists = this._fsExistsCache.exists(localPath);
 			// Make sure that relative lookups benefit from cache
 			this._fsExistsCache.markExists(path, exists);
 
@@ -500,9 +500,9 @@ class TemplateData {
 				return {};
 			}
 
-			let aggregateDataBench = this.benchmarks.aggregate.get("Data File");
+			const aggregateDataBench = this.benchmarks.aggregate.get("Data File");
 			aggregateDataBench.before();
-			let dataBench = this.benchmarks.data.get(`\`${path}\``);
+			const dataBench = this.benchmarks.data.get(`\`${path}\``);
 			dataBench.before();
 
 			let type = "cjs";
@@ -517,7 +517,7 @@ class TemplateData {
 			// module.exports = (data) => `${data.page.filePathStem}/`; // Does not work
 			// module.exports = () => ((data) => `${data.page.filePathStem}/`); // Works
 			if (typeof returnValue === "function") {
-				let configApiGlobalData = await this.getInitialGlobalData();
+				const configApiGlobalData = await this.getInitialGlobalData();
 				returnValue = await returnValue(configApiGlobalData || {});
 			}
 
@@ -526,7 +526,7 @@ class TemplateData {
 			return returnValue;
 		} else if (this.isUserDataExtension(extension)) {
 			// Other extensions
-			let { parser, options } = this.getUserDataParser(extension);
+			const { parser, options } = this.getUserDataParser(extension);
 
 			return this._parseDataFile(path, parser, options);
 		} else if (extension === "json") {
@@ -541,13 +541,13 @@ class TemplateData {
 	}
 
 	_pushExtensionsToPaths(paths, curpath, extensions) {
-		for (let extension of extensions) {
+		for (const extension of extensions) {
 			paths.push(curpath + "." + extension);
 		}
 	}
 
 	_addBaseToPaths(paths, base, extensions, nonEmptySuffixesOnly = false) {
-		let suffixes = this.getDataFileSuffixes();
+		const suffixes = this.getDataFileSuffixes();
 
 		for (let suffix of suffixes) {
 			suffix = suffix || "";
@@ -570,39 +570,39 @@ class TemplateData {
 	}
 
 	async getLocalDataPaths(templatePath) {
-		let paths = [];
-		let parsed = path.parse(templatePath);
-		let inputDir = TemplatePath.addLeadingDotSlash(TemplatePath.normalize(this.inputDir));
+		const paths = [];
+		const parsed = path.parse(templatePath);
+		const inputDir = TemplatePath.addLeadingDotSlash(TemplatePath.normalize(this.inputDir));
 
 		debugDev("getLocalDataPaths(%o)", templatePath);
 		debugDev("parsed.dir: %o", parsed.dir);
 
-		let userExtensions = this.getUserDataExtensions();
+		const userExtensions = this.getUserDataExtensions();
 
 		if (parsed.dir) {
-			let fileNameNoExt = this.extensionMap.removeTemplateExtension(parsed.base);
+			const fileNameNoExt = this.extensionMap.removeTemplateExtension(parsed.base);
 
 			// default dataSuffix: .11tydata, is appended in _addBaseToPaths
 			debug("Using %o suffixes to find data files.", this.getDataFileSuffixes());
 
 			// Template data file paths
-			let filePathNoExt = parsed.dir + "/" + fileNameNoExt;
+			const filePathNoExt = parsed.dir + "/" + fileNameNoExt;
 			this._addBaseToPaths(paths, filePathNoExt, userExtensions);
 
 			// Directory data file paths
-			let allDirs = TemplatePath.getAllDirs(parsed.dir);
+			const allDirs = TemplatePath.getAllDirs(parsed.dir);
 
 			debugDev("allDirs: %o", allDirs);
-			for (let dir of allDirs) {
-				let lastDir = TemplatePath.getLastPathSegment(dir);
-				let dirPathNoExt = dir + "/" + lastDir;
+			for (const dir of allDirs) {
+				const lastDir = TemplatePath.getLastPathSegment(dir);
+				const dirPathNoExt = dir + "/" + lastDir;
 
 				if (inputDir) {
 					debugDev("dirStr: %o; inputDir: %o", dir, inputDir);
 				}
 				if (!inputDir || (dir.startsWith(inputDir) && dir !== inputDir)) {
 					if (this.config.dataFileDirBaseNameOverride) {
-						let indexDataFile = dir + "/" + this.config.dataFileDirBaseNameOverride;
+						const indexDataFile = dir + "/" + this.config.dataFileDirBaseNameOverride;
 						this._addBaseToPaths(paths, indexDataFile, userExtensions, true);
 					} else {
 						this._addBaseToPaths(paths, dirPathNoExt, userExtensions);
@@ -613,13 +613,13 @@ class TemplateData {
 			// 0.11.0+ include root input dir files
 			// if using `docs/` as input dir, looks for docs/docs.json et al
 			if (inputDir) {
-				let lastInputDir = TemplatePath.addLeadingDotSlash(
+				const lastInputDir = TemplatePath.addLeadingDotSlash(
 					TemplatePath.join(inputDir, TemplatePath.getLastPathSegment(inputDir)),
 				);
 
 				// in root input dir, search for index.11tydata.json et al
 				if (this.config.dataFileDirBaseNameOverride) {
-					let indexDataFile =
+					const indexDataFile =
 						TemplatePath.getDirFromFilePath(lastInputDir) +
 						"/" +
 						this.config.dataFileDirBaseNameOverride;
@@ -682,7 +682,7 @@ class TemplateData {
 		TemplateData.cleanupData(data);
 
 		if ("tags" in data) {
-			let excludes = TemplateData.getNormalizedExcludedCollections(data);
+			const excludes = TemplateData.getNormalizedExcludedCollections(data);
 			if (excludes.excludeAll) {
 				return [];
 			} else {
@@ -695,7 +695,7 @@ class TemplateData {
 
 	static getIncludedTagNames(data) {
 		if ("tags" in data) {
-			let excludes = TemplateData.getNormalizedExcludedCollections(data);
+			const excludes = TemplateData.getNormalizedExcludedCollections(data);
 			if (excludes.excludeAll) {
 				return [];
 			} else {

--- a/src/TemplateDataInitialGlobalData.js
+++ b/src/TemplateDataInitialGlobalData.js
@@ -19,12 +19,12 @@ class TemplateDataInitialGlobalData {
 	}
 
 	async getData() {
-		let globalData = {};
+		const globalData = {};
 
 		// via eleventyConfig.addGlobalData
 		if (this.config.globalData) {
-			let keys = Object.keys(this.config.globalData);
-			for (let key of keys) {
+			const keys = Object.keys(this.config.globalData);
+			for (const key of keys) {
 				let returnValue = this.config.globalData[key];
 
 				if (typeof returnValue === "function") {

--- a/src/TemplateEngineManager.js
+++ b/src/TemplateEngineManager.js
@@ -18,7 +18,7 @@ class TemplateEngineManager {
 	}
 
 	static isCustomEngineSimpleAlias(entry) {
-		let keys = Object.keys(entry);
+		const keys = Object.keys(entry);
 		if (keys.length > 2) {
 			return false;
 		}
@@ -39,7 +39,7 @@ class TemplateEngineManager {
 
 			// Custom entries *can* overwrite default entries above
 			if ("extensionMap" in this.config) {
-				for (let entry of this.config.extensionMap) {
+				for (const entry of this.config.extensionMap) {
 					// either the key does not already exist or it is not a simple alias and is an override: https://www.11ty.dev/docs/languages/custom/#overriding-an-existing-template-language
 					if (
 						!this._keyToClassNameMap[entry.key] ||
@@ -65,7 +65,7 @@ class TemplateEngineManager {
 	}
 
 	getClassNameFromTemplateKey(key) {
-		let keys = this.keyToClassNameMap;
+		const keys = this.keyToClassNameMap;
 
 		return keys[key];
 	}
@@ -109,7 +109,7 @@ class TemplateEngineManager {
 			return this.engineCache[name];
 		}
 
-		let cls = await this.getEngineClassByExtension(name);
+		const cls = await this.getEngineClassByExtension(name);
 		let instance = new cls(name, dirs, this.eleventyConfig);
 		instance.extensionMap = extensionMap;
 		instance.engineManager = this;

--- a/src/TemplateFileSlug.js
+++ b/src/TemplateFileSlug.js
@@ -10,7 +10,7 @@ class TemplateFileSlug {
 		this.inputPath = inputPath;
 		this.cleanInputPath = inputPath.replace(/^.\//, "");
 
-		let dirs = this.cleanInputPath.split("/");
+		const dirs = this.cleanInputPath.split("/");
 		this.dirs = dirs;
 		this.dirs.pop();
 
@@ -24,13 +24,13 @@ class TemplateFileSlug {
 	}
 
 	_getRawSlug() {
-		let slug = this.filenameNoExt;
+		const slug = this.filenameNoExt;
 		return this._stripDateFromSlug(slug);
 	}
 
 	/** Removes dates in the format of YYYY-MM-DD from a given slug string candidate. */
 	_stripDateFromSlug(slug) {
-		let reg = slug.match(/\d{4}-\d{2}-\d{2}-(.*)/);
+		const reg = slug.match(/\d{4}-\d{2}-\d{2}-(.*)/);
 		if (reg) {
 			return reg[1];
 		}
@@ -39,13 +39,13 @@ class TemplateFileSlug {
 
 	// `page.fileSlug` see https://www.11ty.dev/docs/data-eleventy-supplied/#page-variable
 	getSlug() {
-		let rawSlug = this._getRawSlug();
+		const rawSlug = this._getRawSlug();
 
 		if (rawSlug === "index") {
 			if (!this.dirs.length) {
 				return "";
 			}
-			let lastDir = this.dirs[this.dirs.length - 1];
+			const lastDir = this.dirs[this.dirs.length - 1];
 			return this._stripDateFromSlug(lastDir);
 		}
 

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -15,8 +15,8 @@ class TemplateLayout extends TemplateContent {
 			throw new Error("Expected `eleventyConfig` in TemplateLayout constructor.");
 		}
 
-		let resolver = new TemplateLayoutPathResolver(key, inputDir, extensionMap, eleventyConfig);
-		let resolvedPath = resolver.getFullPath();
+		const resolver = new TemplateLayoutPathResolver(key, inputDir, extensionMap, eleventyConfig);
+		const resolvedPath = resolver.getFullPath();
 
 		super(resolvedPath, inputDir, eleventyConfig);
 
@@ -48,14 +48,14 @@ class TemplateLayout extends TemplateContent {
 	}
 
 	static getTemplate(key, inputDir, eleventyConfig, extensionMap) {
-		let config = eleventyConfig.getConfig();
+		const config = eleventyConfig.getConfig();
 		if (!config.useTemplateCache) {
 			return new TemplateLayout(key, inputDir, extensionMap, eleventyConfig);
 		}
 
-		let fullKey = TemplateLayout.resolveFullKey(key, inputDir);
+		const fullKey = TemplateLayout.resolveFullKey(key, inputDir);
 		if (!templateCache.has(fullKey)) {
-			let layout = new TemplateLayout(key, inputDir, extensionMap, eleventyConfig);
+			const layout = new TemplateLayout(key, inputDir, extensionMap, eleventyConfig);
 
 			templateCache.add(layout);
 			debugDev("Added %o to TemplateCache", key);
@@ -82,20 +82,20 @@ class TemplateLayout extends TemplateContent {
 			this.cachedLayoutMap = new Promise(async (resolve, reject) => {
 				try {
 					// For both the eleventy.layouts event and cyclical layout chain checking  (e.g., a => b => c => a)
-					let layoutChain = new Set();
+					const layoutChain = new Set();
 					layoutChain.add(this.inputPath);
 
-					let cfgKey = this.config.keys.layout;
-					let map = [];
+					const cfgKey = this.config.keys.layout;
+					const map = [];
 					let mapEntry = await this.getTemplateLayoutMapEntry();
 
 					map.push(mapEntry);
 
 					while (mapEntry.frontMatterData && cfgKey in mapEntry.frontMatterData) {
 						// Layout of the current layout
-						let parentLayoutKey = mapEntry.frontMatterData[cfgKey];
+						const parentLayoutKey = mapEntry.frontMatterData[cfgKey];
 
-						let layout = TemplateLayout.getTemplate(
+						const layout = TemplateLayout.getTemplate(
 							parentLayoutKey,
 							mapEntry.inputDir,
 							this.eleventyConfig,
@@ -142,14 +142,14 @@ class TemplateLayout extends TemplateContent {
 		if (!this.dataCache) {
 			this.dataCache = new Promise(async (resolve, reject) => {
 				try {
-					let map = await this.getTemplateLayoutMap();
-					let dataToMerge = [];
+					const map = await this.getTemplateLayoutMap();
+					const dataToMerge = [];
 					for (let j = map.length - 1; j >= 0; j--) {
 						dataToMerge.push(map[j].frontMatterData);
 					}
 
 					// Deep merge of layout front matter
-					let data = TemplateData.mergeDeep(this.config, {}, ...dataToMerge);
+					const data = TemplateData.mergeDeep(this.config, {}, ...dataToMerge);
 					delete data[this.config.keys.layout];
 
 					resolve(data);
@@ -167,8 +167,8 @@ class TemplateLayout extends TemplateContent {
 		if (!this.cachedCompiledLayoutFunction) {
 			this.cachedCompiledLayoutFunction = new Promise(async (resolve, reject) => {
 				try {
-					let rawInput = await this.getPreRender();
-					let renderFunction = await this.compile(rawInput);
+					const rawInput = await this.getPreRender();
+					const renderFunction = await this.compile(rawInput);
 					resolve(renderFunction);
 				} catch (e) {
 					reject(e);
@@ -180,8 +180,8 @@ class TemplateLayout extends TemplateContent {
 	}
 
 	async getCompiledLayoutFunctions() {
-		let layoutMap = await this.getTemplateLayoutMap();
-		let fns = [];
+		const layoutMap = await this.getTemplateLayoutMap();
+		const fns = [];
 
 		try {
 			fns.push({
@@ -189,10 +189,10 @@ class TemplateLayout extends TemplateContent {
 			});
 
 			if (layoutMap.length > 1) {
-				let [, /*currentLayout*/ parentLayout] = layoutMap;
-				let { key, inputDir } = parentLayout;
+				const [, /*currentLayout*/ parentLayout] = layoutMap;
+				const { key, inputDir } = parentLayout;
 
-				let layoutTemplate = TemplateLayout.getTemplate(
+				const layoutTemplate = TemplateLayout.getTemplate(
 					key,
 					inputDir,
 					this.eleventyConfig,
@@ -200,7 +200,7 @@ class TemplateLayout extends TemplateContent {
 				);
 
 				// The parent already includes the rest of the layout chain
-				let upstreamFns = await layoutTemplate.getCompiledLayoutFunctions();
+				const upstreamFns = await layoutTemplate.getCompiledLayoutFunctions();
 				for (let j = 0, k = upstreamFns.length; j < k; j++) {
 					fns.push(upstreamFns[j]);
 				}
@@ -223,9 +223,9 @@ class TemplateLayout extends TemplateContent {
 	// This is called from Template->renderPageEntry
 	async renderPageEntry(pageEntry) {
 		let templateContent = pageEntry.templateContent;
-		let compiledFunctions = await this.getCompiledLayoutFunctions();
-		for (let { render } of compiledFunctions) {
-			let data = {
+		const compiledFunctions = await this.getCompiledLayoutFunctions();
+		for (const { render } of compiledFunctions) {
+			const data = {
 				content: templateContent,
 				...pageEntry.data,
 			};

--- a/src/TemplateLayoutPathResolver.js
+++ b/src/TemplateLayoutPathResolver.js
@@ -63,7 +63,7 @@ class TemplateLayoutPathResolver {
 			this.path = this.aliases[this.path];
 		}
 
-		let useLayoutResolution = this.config.layoutResolution;
+		const useLayoutResolution = this.config.layoutResolution;
 
 		this.pathAlreadyHasExtension = this.dir + "/" + this.path;
 
@@ -107,7 +107,7 @@ class TemplateLayoutPathResolver {
 			);
 		}
 
-		for (let filename of this.extensionMap.getFileList(this.path)) {
+		for (const filename of this.extensionMap.getFileList(this.path)) {
 			// TODO async
 			if (fs.existsSync(this.dir + "/" + filename)) {
 				return filename;

--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -64,9 +64,9 @@ class TemplateMap {
 		}
 
 		// IMPORTANT: This is where the data is first generated for the template
-		let data = await template.getData();
+		const data = await template.getData();
 
-		for (let map of await template.getTemplateMapEntries(data)) {
+		for (const map of await template.getTemplateMapEntries(data)) {
 			this.map.push(map);
 		}
 	}
@@ -110,8 +110,8 @@ class TemplateMap {
 		if (!Array.isArray(tags)) {
 			return;
 		}
-		for (let tag of tags) {
-			let tagWithPrefix = TemplateMap.tagPrefix + tag;
+		for (const tag of tags) {
+			const tagWithPrefix = TemplateMap.tagPrefix + tag;
 			if (!graph.hasNode(tagWithPrefix)) {
 				graph.addNode(tagWithPrefix);
 			}
@@ -127,8 +127,8 @@ class TemplateMap {
 			return;
 		}
 
-		for (let tag of deps) {
-			let tagWithPrefix = TemplateMap.tagPrefix + tag;
+		for (const tag of deps) {
+			const tagWithPrefix = TemplateMap.tagPrefix + tag;
 			if (!graph.hasNode(tagWithPrefix)) {
 				graph.addNode(tagWithPrefix);
 			}
@@ -144,18 +144,18 @@ class TemplateMap {
 	// Include: Pagination templates that don’t consume config API collections
 	// Include: Templates that don’t use Pagination
 	getMappedDependencies() {
-		let graph = new DependencyGraph();
-		let tagPrefix = TemplateMap.tagPrefix;
+		const graph = new DependencyGraph();
+		const tagPrefix = TemplateMap.tagPrefix;
 
 		graph.addNode(tagPrefix + "all");
 
-		for (let entry of this.map) {
+		for (const entry of this.map) {
 			if (this.isPaginationOverAllCollections(entry)) {
 				continue;
 			}
 
 			// using Pagination (but not targeting a user config collection)
-			let paginationTagTarget = this.getPaginationTagTarget(entry);
+			const paginationTagTarget = this.getPaginationTagTarget(entry);
 			if (paginationTagTarget) {
 				if (this.isUserConfigCollectionName(paginationTagTarget)) {
 					// delay this one to the second stage
@@ -173,7 +173,7 @@ class TemplateMap {
 				graph.addNode(entry.inputPath);
 			}
 
-			let collections = TemplateData.getIncludedCollectionNames(entry.data);
+			const collections = TemplateData.getIncludedCollectionNames(entry.data);
 			this.addTagsToGraph(graph, entry.inputPath, collections);
 
 			this.addDeclaredDependenciesToGraph(
@@ -189,31 +189,31 @@ class TemplateMap {
 	// Exclude: Pagination templates consuming `collections` or `collections.all`
 	// Include: Pagination templates that consume config API collections
 	getDelayedMappedDependencies() {
-		let graph = new DependencyGraph();
-		let tagPrefix = TemplateMap.tagPrefix;
+		const graph = new DependencyGraph();
+		const tagPrefix = TemplateMap.tagPrefix;
 
 		graph.addNode(tagPrefix + "all");
 
-		let userConfigCollections = this.getUserConfigCollectionNames();
+		const userConfigCollections = this.getUserConfigCollectionNames();
 
 		// Add tags from named user config collections
-		for (let tag of userConfigCollections) {
+		for (const tag of userConfigCollections) {
 			graph.addNode(tagPrefix + tag);
 		}
 
-		for (let entry of this.map) {
+		for (const entry of this.map) {
 			if (this.isPaginationOverAllCollections(entry)) {
 				continue;
 			}
 
-			let paginationTagTarget = this.getPaginationTagTarget(entry);
+			const paginationTagTarget = this.getPaginationTagTarget(entry);
 			if (paginationTagTarget && this.isUserConfigCollectionName(paginationTagTarget)) {
 				if (!graph.hasNode(entry.inputPath)) {
 					graph.addNode(entry.inputPath);
 				}
 				graph.addDependency(entry.inputPath, tagPrefix + paginationTagTarget);
 
-				let collections = TemplateData.getIncludedCollectionNames(entry.data);
+				const collections = TemplateData.getIncludedCollectionNames(entry.data);
 				this.addTagsToGraph(graph, entry.inputPath, collections);
 
 				this.addDeclaredDependenciesToGraph(
@@ -230,11 +230,11 @@ class TemplateMap {
 	// Exclude: Pagination templates consuming `collections.all`
 	// Include: Pagination templates consuming `collections`
 	getPaginatedOverCollectionsMappedDependencies() {
-		let graph = new DependencyGraph();
-		let tagPrefix = TemplateMap.tagPrefix;
+		const graph = new DependencyGraph();
+		const tagPrefix = TemplateMap.tagPrefix;
 		let allNodeAdded = false;
 
-		for (let entry of this.map) {
+		for (const entry of this.map) {
 			if (this.isPaginationOverAllCollections(entry) && !this.getPaginationTagTarget(entry)) {
 				if (!allNodeAdded) {
 					graph.addNode(tagPrefix + "all");
@@ -266,11 +266,11 @@ class TemplateMap {
 
 	// Include: Pagination templates consuming `collections.all`
 	getPaginatedOverAllCollectionMappedDependencies() {
-		let graph = new DependencyGraph();
-		let tagPrefix = TemplateMap.tagPrefix;
+		const graph = new DependencyGraph();
+		const tagPrefix = TemplateMap.tagPrefix;
 		let allNodeAdded = false;
 
-		for (let entry of this.map) {
+		for (const entry of this.map) {
 			if (
 				this.isPaginationOverAllCollections(entry) &&
 				this.getPaginationTagTarget(entry) === "all"
@@ -324,20 +324,20 @@ class TemplateMap {
 		}
 
 		// Only dependents: things that consume templates that have deleted dependencies, e.g. if index.md consumes collections.post and a file removes its post tag, regenerate index.md
-		let newCollectionNames = new Set(); // collections published to
-		for (let entry of this.map) {
+		const newCollectionNames = new Set(); // collections published to
+		for (const entry of this.map) {
 			if (!entry.data.eleventyExcludeFromCollections) {
 				newCollectionNames.add("all");
 
 				if (Array.isArray(entry.data.tags)) {
-					for (let tag of entry.data.tags) {
+					for (const tag of entry.data.tags) {
 						newCollectionNames.add(tag);
 					}
 				}
 			}
 		}
 
-		let deletedCollectionNames = this.config.uses.findCollectionsRemovedFrom(
+		const deletedCollectionNames = this.config.uses.findCollectionsRemovedFrom(
 			incrementalFile,
 			newCollectionNames,
 		);
@@ -351,8 +351,8 @@ class TemplateMap {
 
 	// Similar to getTemplateMapDependencyGraph but adds those relationships to the global dependency graph used for incremental builds
 	addToGlobalDependencyGraph() {
-		for (let entry of this.map) {
-			let paginationTagTarget = this.getPaginationTagTarget(entry);
+		for (const entry of this.map) {
+			const paginationTagTarget = this.getPaginationTagTarget(entry);
 			if (paginationTagTarget) {
 				this.config.uses.addDependencyConsumesCollection(entry.inputPath, paginationTagTarget);
 			}
@@ -361,14 +361,14 @@ class TemplateMap {
 				this.config.uses.addDependencyPublishesToCollection(entry.inputPath, "all");
 
 				if (Array.isArray(entry.data.tags)) {
-					for (let tag of entry.data.tags) {
+					for (const tag of entry.data.tags) {
 						this.config.uses.addDependencyPublishesToCollection(entry.inputPath, tag);
 					}
 				}
 			}
 
 			if (Array.isArray(entry.data.eleventyImport?.collections)) {
-				for (let tag of entry.data.eleventyImport.collections) {
+				for (const tag of entry.data.eleventyImport.collections) {
 					this.config.uses.addDependencyConsumesCollection(entry.inputPath, tag);
 				}
 			}
@@ -383,7 +383,7 @@ class TemplateMap {
 			this.collectionsData[tagName] = this.getTaggedCollection(tagName);
 		}
 
-		let precompiled = this.config.precompiledCollections;
+		const precompiled = this.config.precompiledCollections;
 		if (precompiled && precompiled[tagName]) {
 			if (
 				tagName === "all" ||
@@ -397,22 +397,22 @@ class TemplateMap {
 
 	// TODO(slightlyoff): major bottleneck
 	async initDependencyMap(dependencyMap) {
-		let tagPrefix = TemplateMap.tagPrefix;
-		for (let depEntry of dependencyMap) {
+		const tagPrefix = TemplateMap.tagPrefix;
+		for (const depEntry of dependencyMap) {
 			if (depEntry.startsWith(tagPrefix)) {
 				// is a tag (collection) entry
-				let tagName = depEntry.slice(tagPrefix.length);
+				const tagName = depEntry.slice(tagPrefix.length);
 				await this.setCollectionByTagName(tagName);
 			} else {
 				// is a template entry
-				let map = this.getMapEntryForInputPath(depEntry);
+				const map = this.getMapEntryForInputPath(depEntry);
 				map._pages = await map.template.getTemplates(map.data);
 
 				if (map._pages.length === 0) {
 					// Reminder: a serverless code path was removed here.
 				} else {
 					let counter = 0;
-					for (let page of map._pages) {
+					for (const page of map._pages) {
 						// Copy outputPath to map entry
 						if (!map.outputPath) {
 							map.outputPath = page.outputPath;
@@ -438,11 +438,11 @@ class TemplateMap {
 		debug("Caching collections objects.");
 		this.collectionsData = {};
 
-		for (let entry of this.map) {
+		for (const entry of this.map) {
 			entry.data.collections = this.collectionsData;
 		}
 
-		let [dependencyMap, delayedDependencyMap, firstPaginatedDepMap, secondPaginatedDepMap] =
+		const [dependencyMap, delayedDependencyMap, firstPaginatedDepMap, secondPaginatedDepMap] =
 			this.getFullTemplateMapOrder();
 
 		await this.initDependencyMap(dependencyMap);
@@ -452,14 +452,14 @@ class TemplateMap {
 
 		await this.resolveRemainingComputedData();
 
-		let orderedPaths = this.getOrderedInputPaths(
+		const orderedPaths = this.getOrderedInputPaths(
 			dependencyMap,
 			delayedDependencyMap,
 			firstPaginatedDepMap,
 			secondPaginatedDepMap,
 		);
 
-		let orderedMap = orderedPaths.map((inputPath) => {
+		const orderedMap = orderedPaths.map((inputPath) => {
 			return this.getMapEntryForInputPath(inputPath);
 		});
 
@@ -481,17 +481,17 @@ class TemplateMap {
 	}
 
 	generateInputUrlContentMap(orderedMap) {
-		let entries = {};
-		for (let entry of orderedMap) {
+		const entries = {};
+		for (const entry of orderedMap) {
 			entries[entry.inputPath] = entry._pages.map((entry) => entry.url);
 		}
 		return entries;
 	}
 
 	generateUrlMap(orderedMap) {
-		let entries = {};
-		for (let entry of orderedMap) {
-			for (let page of entry._pages) {
+		const entries = {};
+		for (const entry of orderedMap) {
+			for (const page of entry._pages) {
 				// duplicate urls throw an error, so we can return non array here
 				entries[page.url] = {
 					inputPath: entry.inputPath,
@@ -504,7 +504,7 @@ class TemplateMap {
 
 	// TODO(slightlyoff): hot inner loop?
 	getMapEntryForInputPath(inputPath) {
-		for (let map of this.map) {
+		for (const map of this.map) {
 			if (map.inputPath === inputPath) {
 				return map;
 			}
@@ -513,11 +513,11 @@ class TemplateMap {
 
 	// Filter out any tag nodes
 	getOrderedInputPaths(...maps) {
-		let orderedMap = [];
-		let tagPrefix = TemplateMap.tagPrefix;
+		const orderedMap = [];
+		const tagPrefix = TemplateMap.tagPrefix;
 
-		for (let map of maps) {
-			for (let dep of map) {
+		for (const map of maps) {
+			for (const dep of map) {
 				if (!dep.startsWith(tagPrefix)) {
 					orderedMap.push(dep);
 				}
@@ -527,8 +527,8 @@ class TemplateMap {
 	}
 
 	async populateContentDataInMap(orderedMap) {
-		let usedTemplateContentTooEarlyMap = [];
-		for (let map of orderedMap) {
+		const usedTemplateContentTooEarlyMap = [];
+		for (const map of orderedMap) {
 			if (!map._pages) {
 				throw new Error(`Content pages not found for ${map.inputPath}`);
 			}
@@ -540,7 +540,7 @@ class TemplateMap {
 
 			// IMPORTANT: this is where template content is rendered
 			try {
-				for (let pageEntry of map._pages) {
+				for (const pageEntry of map._pages) {
 					pageEntry.templateContent =
 						await pageEntry.template.renderPageEntryWithoutLayout(pageEntry);
 				}
@@ -554,9 +554,9 @@ class TemplateMap {
 			debugDev("Added this.map[...].templateContent, outputPath, et al for one map entry");
 		}
 
-		for (let map of usedTemplateContentTooEarlyMap) {
+		for (const map of usedTemplateContentTooEarlyMap) {
 			try {
-				for (let pageEntry of map._pages) {
+				for (const pageEntry of map._pages) {
 					pageEntry.templateContent =
 						await pageEntry.template.renderPageEntryWithoutLayout(pageEntry);
 				}
@@ -574,11 +574,11 @@ class TemplateMap {
 	}
 
 	_testGetAllTags() {
-		let allTags = {};
-		for (let map of this.map) {
-			let tags = map.data.tags;
+		const allTags = {};
+		for (const map of this.map) {
+			const tags = map.data.tags;
 			if (Array.isArray(tags)) {
-				for (let tag of tags) {
+				for (const tag of tags) {
 					allTags[tag] = true;
 				}
 			}
@@ -599,12 +599,12 @@ class TemplateMap {
 	}
 
 	async _testGetTaggedCollectionsData() {
-		let collections = {};
+		const collections = {};
 		collections.all = this.collection.getAllSorted();
 		debug(`Collection: collections.all size: ${collections.all.length}`);
 
-		let tags = this._testGetAllTags();
-		for (let tag of tags) {
+		const tags = this._testGetAllTags();
+		for (const tag of tags) {
 			collections[tag] = this.collection.getFilteredByTag(tag);
 			debug(`Collection: collections.${tag} size: ${collections[tag].length}`);
 		}
@@ -613,7 +613,7 @@ class TemplateMap {
 
 	/* 3.0.0-alpha.1: setUserConfigCollections method removed (was only used for testing) */
 	isUserConfigCollectionName(name) {
-		let collections = this.userConfig.getCollections();
+		const collections = this.userConfig.getCollections();
 		return name && !!collections[name];
 	}
 
@@ -622,20 +622,20 @@ class TemplateMap {
 	}
 
 	async getUserConfigCollection(name) {
-		let configCollections = this.userConfig.getCollections();
+		const configCollections = this.userConfig.getCollections();
 
 		// This works with async now
-		let result = await configCollections[name](this.collection);
+		const result = await configCollections[name](this.collection);
 
 		debug(`Collection: collections.${name} size: ${result.length}`);
 		return result;
 	}
 
 	async _testGetUserConfigCollectionsData() {
-		let collections = {};
-		let configCollections = this.userConfig.getCollections();
+		const collections = {};
+		const configCollections = this.userConfig.getCollections();
 
-		for (let name in configCollections) {
+		for (const name in configCollections) {
 			collections[name] = configCollections[name](this.collection);
 
 			debug(`Collection: collections.${name} size: ${collections[name].length}`);
@@ -645,34 +645,34 @@ class TemplateMap {
 	}
 
 	async _testGetAllCollectionsData() {
-		let collections = {};
-		let taggedCollections = await this._testGetTaggedCollectionsData();
+		const collections = {};
+		const taggedCollections = await this._testGetTaggedCollectionsData();
 		Object.assign(collections, taggedCollections);
 
-		let userConfigCollections = await this._testGetUserConfigCollectionsData();
+		const userConfigCollections = await this._testGetUserConfigCollectionsData();
 		Object.assign(collections, userConfigCollections);
 
 		return collections;
 	}
 
 	populateCollectionsWithContent() {
-		for (let collectionName in this.collectionsData) {
+		for (const collectionName in this.collectionsData) {
 			// skip custom collections set in configuration files that have arbitrary types
 			if (!Array.isArray(this.collectionsData[collectionName])) {
 				continue;
 			}
 
-			for (let item of this.collectionsData[collectionName]) {
+			for (const item of this.collectionsData[collectionName]) {
 				// skip custom collections set in configuration files that have arbitrary types
 				if (!isPlainObject(item) || !("inputPath" in item)) {
 					continue;
 				}
 
-				let entry = this.getMapEntryForInputPath(item.inputPath);
+				const entry = this.getMapEntryForInputPath(item.inputPath);
 				// This check skips precompiled collections
 				if (entry) {
-					let index = item.pageNumber || 0;
-					let content = entry._pages[index]._templateContent;
+					const index = item.pageNumber || 0;
+					const content = entry._pages[index]._templateContent;
 					if (content !== undefined) {
 						item.templateContent = content;
 					}
@@ -682,9 +682,9 @@ class TemplateMap {
 	}
 
 	async resolveRemainingComputedData() {
-		let promises = [];
-		for (let entry of this.map) {
-			for (let pageEntry of entry._pages) {
+		const promises = [];
+		for (const entry of this.map) {
+			for (const pageEntry of entry._pages) {
 				if (this.config.keys.computed in pageEntry.data) {
 					promises.push(await pageEntry.template.resolveRemainingComputedData(pageEntry.data));
 				}
@@ -694,22 +694,22 @@ class TemplateMap {
 	}
 
 	async generateLayoutsMap() {
-		let layouts = {};
+		const layouts = {};
 
-		for (let entry of this.map) {
-			for (let page of entry._pages) {
-				let tmpl = page.template;
-				let layoutKey = page.data[this.config.keys.layout];
+		for (const entry of this.map) {
+			for (const page of entry._pages) {
+				const tmpl = page.template;
+				const layoutKey = page.data[this.config.keys.layout];
 				if (layoutKey) {
-					let layout = tmpl.getLayout(layoutKey);
-					let layoutChain = await layout.getLayoutChain();
-					let priors = [];
-					for (let filepath of layoutChain) {
+					const layout = tmpl.getLayout(layoutKey);
+					const layoutChain = await layout.getLayoutChain();
+					const priors = [];
+					for (const filepath of layoutChain) {
 						if (!layouts[filepath]) {
 							layouts[filepath] = new Set();
 						}
 						layouts[filepath].add(page.inputPath);
-						for (let prior of priors) {
+						for (const prior of priors) {
 							layouts[filepath].add(prior);
 						}
 						priors.push(filepath);
@@ -718,7 +718,7 @@ class TemplateMap {
 			}
 		}
 
-		for (let key in layouts) {
+		for (const key in layouts) {
 			layouts[key] = Array.from(layouts[key]);
 		}
 
@@ -726,10 +726,10 @@ class TemplateMap {
 	}
 
 	checkForDuplicatePermalinks() {
-		let permalinks = {};
-		let warnings = {};
-		for (let entry of this.map) {
-			for (let page of entry._pages) {
+		const permalinks = {};
+		const warnings = {};
+		for (const entry of this.map) {
+			for (const page of entry._pages) {
 				if (page.outputPath === false || page.url === false) {
 					// do nothing (also serverless)
 				} else if (!permalinks[page.outputPath]) {
@@ -751,7 +751,7 @@ ${permalinks[page.outputPath]
 			}
 		}
 
-		let warningList = Object.values(warnings);
+		const warningList = Object.values(warnings);
 		if (warningList.length) {
 			// throw one at a time
 			throw new DuplicatePermalinkOutputError(warningList[0]);

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -49,7 +49,7 @@ class TemplatePassthrough {
 	}
 
 	async getOutputPath(inputFileFromGlob) {
-		let { inputDir, outputDir, outputPath, inputPath } = this;
+		const { inputDir, outputDir, outputPath, inputPath } = this;
 
 		if (outputPath === true) {
 			return TemplatePath.normalize(
@@ -67,14 +67,14 @@ class TemplatePassthrough {
 		// Bug when copying incremental file overwriting output directory (and making it a file)
 		// e.g. public/test.css -> _site
 		// https://github.com/11ty/eleventy/issues/2278
-		let fullOutputPath = TemplatePath.normalize(TemplatePath.join(outputDir, outputPath));
+		const fullOutputPath = TemplatePath.normalize(TemplatePath.join(outputDir, outputPath));
 
 		if (
 			(await fsExists(inputPath)) &&
 			!TemplatePath.isDirectorySync(inputPath) &&
 			TemplatePath.isDirectorySync(fullOutputPath)
 		) {
-			let filename = path.parse(inputPath).base;
+			const filename = path.parse(inputPath).base;
 			return TemplatePath.normalize(TemplatePath.join(fullOutputPath, filename));
 		}
 
@@ -106,9 +106,9 @@ class TemplatePassthrough {
 
 	async getFiles(glob) {
 		debug("Searching for: %o", glob);
-		let b = this.benchmarks.aggregate.get("Searching the file system (passthrough)");
+		const b = this.benchmarks.aggregate.get("Searching the file system (passthrough)");
 		b.before();
-		let files = TemplatePath.addLeadingDotSlashArray(
+		const files = TemplatePath.addLeadingDotSlashArray(
 			await this.fileSystemSearch.search("passthrough", glob),
 		);
 		b.after();
@@ -135,7 +135,7 @@ class TemplatePassthrough {
 		if (!isGlob(this.inputPath) && (await fsExists(this.inputPath))) {
 			// When inputPath is a directory, make sure it has a slash for passthrough copy aliasing
 			// https://github.com/11ty/eleventy/issues/2709
-			let inputPath = await this.addTrailingSlashIfDirectory(this.inputPath);
+			const inputPath = await this.addTrailingSlashIfDirectory(this.inputPath);
 			return [
 				{
 					inputPath,
@@ -144,10 +144,10 @@ class TemplatePassthrough {
 			];
 		}
 
-		let paths = [];
+		const paths = [];
 		// If not directory or file, attempt to get globs
-		let files = await this.getFiles(this.inputPath);
-		for (let inputPath of files) {
+		const files = await this.getFiles(this.inputPath);
+		for (const inputPath of files) {
 			paths.push({
 				inputPath,
 				outputPath: await this.getOutputPath(inputPath),
@@ -176,7 +176,7 @@ class TemplatePassthrough {
 		}
 
 		let fileCopyCount = 0;
-		let map = {};
+		const map = {};
 		// returns a promise
 		return copy(src, dest, copyOptions)
 			.on(copy.events.COPY_FILE_START, (copyOp) => {
@@ -206,11 +206,11 @@ class TemplatePassthrough {
 		}
 
 		debug("Copying %o", this.inputPath);
-		let fileMap = await this.getFileMap();
+		const fileMap = await this.getFileMap();
 
 		// default options for recursive-copy
 		// see https://www.npmjs.com/package/recursive-copy#arguments
-		let copyOptionsDefault = {
+		const copyOptionsDefault = {
 			overwrite: true, // overwrite output. fails when input is directory (mkdir) and output is file
 			dot: true, // copy dotfiles
 			junk: false, // copy cache files like Thumbs.db
@@ -223,12 +223,12 @@ class TemplatePassthrough {
 			// e.g. `{ filePaths: [ './img/coolkid.jpg' ], relativePaths: [ '' ] }`
 		};
 
-		let copyOptions = Object.assign(copyOptionsDefault, this.copyOptions);
+		const copyOptions = Object.assign(copyOptionsDefault, this.copyOptions);
 
-		let promises = fileMap.map((entry) => {
+		const promises = fileMap.map((entry) => {
 			// For-free passthrough copy
 			if (checkPassthroughCopyBehavior(this.config, this.runMode)) {
-				let aliasMap = {};
+				const aliasMap = {};
 				aliasMap[entry.inputPath] = entry.outputPath;
 
 				return Promise.resolve({
@@ -246,9 +246,9 @@ class TemplatePassthrough {
 			.then((results) => {
 				// collate the count and input/output map results from the array.
 				let count = 0;
-				let map = {};
+				const map = {};
 
-				for (let result of results) {
+				for (const result of results) {
 					count += result.count;
 					Object.assign(map, result.map);
 				}

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -73,10 +73,10 @@ class TemplatePassthroughManager {
 	}
 
 	getConfigPaths() {
-		let paths = [];
-		let pathsRaw = this.config.passthroughCopies || {};
+		const paths = [];
+		const pathsRaw = this.config.passthroughCopies || {};
 		debug("`addPassthroughCopy` config API paths: %o", pathsRaw);
-		for (let [inputPath, { outputPath, copyOptions }] of Object.entries(pathsRaw)) {
+		for (const [inputPath, { outputPath, copyOptions }] of Object.entries(pathsRaw)) {
 			paths.push(this._normalizePaths(inputPath, outputPath, copyOptions));
 		}
 		debug("`addPassthroughCopy` config API normalized paths: %o", paths);
@@ -90,8 +90,8 @@ class TemplatePassthroughManager {
 	}
 
 	getNonTemplatePaths(paths) {
-		let matches = [];
-		for (let path of paths) {
+		const matches = [];
+		for (const path of paths) {
 			if (!this.extensionMap.hasEngine(path)) {
 				matches.push(path);
 			}
@@ -109,7 +109,7 @@ class TemplatePassthroughManager {
 	}
 
 	getTemplatePassthroughForPath(path, isIncremental = false) {
-		let inst = new TemplatePassthrough(path, this.outputDir, this.inputDir, this.config);
+		const inst = new TemplatePassthrough(path, this.outputDir, this.inputDir, this.config);
 
 		inst.setFileSystemSearch(this.fileSystemSearch);
 		inst.setIsIncremental(isIncremental);
@@ -126,7 +126,7 @@ class TemplatePassthroughManager {
 			);
 		}
 
-		let { inputPath } = pass.getPath();
+		const { inputPath } = pass.getPath();
 
 		// TODO https://github.com/11ty/eleventy/issues/2452
 		// De-dupe both the input and output paired together to avoid the case
@@ -142,8 +142,8 @@ class TemplatePassthroughManager {
 		return pass
 			.write()
 			.then(({ count, map }) => {
-				for (let src in map) {
-					let dest = map[src];
+				for (const src in map) {
+					const dest = map[src];
 					if (this.conflictMap[dest]) {
 						if (src !== this.conflictMap[dest]) {
 							throw new TemplatePassthroughManagerCopyError(
@@ -194,13 +194,13 @@ class TemplatePassthroughManager {
 
 	isPassthroughCopyFile(paths, changedFile) {
 		// passthrough copy by non-matching engine extension (via templateFormats)
-		for (let path of paths) {
+		for (const path of paths) {
 			if (path === changedFile && !this.extensionMap.hasEngine(path)) {
 				return true;
 			}
 		}
 
-		for (let path of this.getConfigPaths()) {
+		for (const path of this.getConfigPaths()) {
 			if (TemplatePath.startsWithSubPath(changedFile, path.inputPath)) {
 				return path;
 			}
@@ -218,7 +218,7 @@ class TemplatePassthroughManager {
 
 	getAllNormalizedPaths(paths) {
 		if (this.incrementalFile) {
-			let isPassthrough = this.isPassthroughCopyFile(paths, this.incrementalFile);
+			const isPassthrough = this.isPassthroughCopyFile(paths, this.incrementalFile);
 
 			if (isPassthrough) {
 				if (isPassthrough.outputPath) {
@@ -234,17 +234,17 @@ class TemplatePassthroughManager {
 			}
 		}
 
-		let normalizedPaths = this.getConfigPaths();
+		const normalizedPaths = this.getConfigPaths();
 		if (debug.enabled) {
-			for (let path of normalizedPaths) {
+			for (const path of normalizedPaths) {
 				debug("TemplatePassthrough copying from config: %o", path);
 			}
 		}
 
 		if (paths && paths.length) {
-			let passthroughPaths = this.getNonTemplatePaths(paths);
-			for (let path of passthroughPaths) {
-				let normalizedPath = this._normalizePaths(path);
+			const passthroughPaths = this.getNonTemplatePaths(paths);
+			for (const path of passthroughPaths) {
+				const normalizedPath = this._normalizePaths(path);
 
 				debug(
 					`TemplatePassthrough copying from non-matching file extension: ${normalizedPath.inputPath}`,
@@ -260,10 +260,10 @@ class TemplatePassthroughManager {
 	// keys: output
 	// values: input
 	getAliasesFromPassthroughResults(result) {
-		let entries = {};
-		for (let entry of result) {
-			for (let src in entry.map) {
-				let dest = TemplatePath.stripLeadingSubPath(entry.map[src], this.outputDir);
+		const entries = {};
+		for (const entry of result) {
+			for (const src in entry.map) {
+				const dest = TemplatePath.stripLeadingSubPath(entry.map[src], this.outputDir);
 				entries["/" + dest] = src;
 			}
 		}
@@ -275,18 +275,18 @@ class TemplatePassthroughManager {
 	// write times in a significant way.
 	async copyAll(templateExtensionPaths) {
 		debug("TemplatePassthrough copy started.");
-		let normalizedPaths = this.getAllNormalizedPaths(templateExtensionPaths);
+		const normalizedPaths = this.getAllNormalizedPaths(templateExtensionPaths);
 
-		let passthroughs = normalizedPaths.map((path) => {
+		const passthroughs = normalizedPaths.map((path) => {
 			// if incrementalFile is set but it isn’t a passthrough copy, normalizedPaths will be an empty array
-			let isIncremental = !!this.incrementalFile;
+			const isIncremental = !!this.incrementalFile;
 
 			return this.getTemplatePassthroughForPath(path, isIncremental);
 		});
 
-		let promises = passthroughs.map((pass) => this.copyPassthrough(pass));
+		const promises = passthroughs.map((pass) => this.copyPassthrough(pass));
 		return Promise.all(promises).then(async (results) => {
-			let aliases = this.getAliasesFromPassthroughResults(results);
+			const aliases = this.getAliasesFromPassthroughResults(results);
 			await this.config.events.emit("eleventy.passthrough", {
 				map: aliases,
 			});

--- a/src/TemplatePermalink.js
+++ b/src/TemplatePermalink.js
@@ -5,7 +5,7 @@ import { TemplatePath, isPlainObject } from "@11ty/eleventy-utils";
 class TemplatePermalink {
 	// `link` with template syntax should have already been rendered in Template.js
 	constructor(link, extraSubdir) {
-		let isLinkAnObject = isPlainObject(link);
+		const isLinkAnObject = isPlainObject(link);
 
 		this._isRendered = true;
 		this._writeToFileSystem = true;
@@ -18,7 +18,7 @@ class TemplatePermalink {
 			}
 
 			// find the first string key
-			for (let key in link) {
+			for (const key in link) {
 				if (typeof key !== "string") {
 					continue;
 				}
@@ -74,8 +74,8 @@ class TemplatePermalink {
 			return false;
 		}
 
-		let cleanLink = this._addDefaultLinkFilename(this.buildLink);
-		let parsed = path.parse(cleanLink);
+		const cleanLink = this._addDefaultLinkFilename(this.buildLink);
+		const parsed = path.parse(cleanLink);
 
 		return TemplatePath.join(parsed.dir, this.extraPaginationSubdir, parsed.base);
 	}
@@ -90,11 +90,11 @@ class TemplatePermalink {
 	}
 
 	static normalizePathToUrl(original) {
-		let compare = original || "";
+		const compare = original || "";
 
-		let needleHtml = "/index.html";
-		let needleBareTrailingSlash = "/index/";
-		let needleBare = "/index";
+		const needleHtml = "/index.html";
+		const needleBareTrailingSlash = "/index/";
+		const needleBare = "/index";
 		if (compare.endsWith(needleHtml)) {
 			return compare.slice(0, compare.length - needleHtml.length) + "/";
 		} else if (compare.endsWith(needleBareTrailingSlash)) {
@@ -117,11 +117,11 @@ class TemplatePermalink {
 			return false;
 		}
 
-		let transformedLink = this.toOutputPath();
+		const transformedLink = this.toOutputPath();
 		let original = (transformedLink.charAt(0) !== "/" ? "/" : "") + transformedLink;
 
-		let normalized = TemplatePermalink.normalizePathToUrl(original) || "";
-		for (let transform of this.urlTransforms) {
+		const normalized = TemplatePermalink.normalizePathToUrl(original) || "";
+		for (const transform of this.urlTransforms) {
 			original =
 				transform({
 					url: normalized,
@@ -137,7 +137,7 @@ class TemplatePermalink {
 			return false;
 		}
 
-		let uri = this.toOutputPath();
+		const uri = this.toOutputPath();
 
 		if (uri === false) {
 			return false;
@@ -151,7 +151,7 @@ class TemplatePermalink {
 			return false;
 		}
 
-		let uri = this.toOutputPath();
+		const uri = this.toOutputPath();
 
 		if (uri === false) {
 			return false;
@@ -161,7 +161,7 @@ class TemplatePermalink {
 	}
 
 	static _hasDuplicateFolder(dir, base) {
-		let folders = dir.split("/");
+		const folders = dir.split("/");
 		if (!folders[folders.length - 1]) {
 			folders.pop();
 		}
@@ -171,7 +171,7 @@ class TemplatePermalink {
 	static generate(dir, filenameNoExt, extraSubdir, suffix, fileExtension = "html") {
 		let path;
 		if (fileExtension === "html") {
-			let hasDupeFolder = TemplatePermalink._hasDuplicateFolder(dir, filenameNoExt);
+			const hasDupeFolder = TemplatePermalink._hasDuplicateFolder(dir, filenameNoExt);
 
 			path =
 				(dir ? dir + "/" : "") +

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -55,7 +55,7 @@ class TemplateRender {
 	}
 
 	async getEngineByName(name) {
-		let engine = await this.extensionMap.engineManager.getEngine(
+		const engine = await this.extensionMap.engineManager.getEngine(
 			name,
 			this.getDirs(),
 			this.extensionMap,
@@ -67,7 +67,7 @@ class TemplateRender {
 
 	// Runs once per template
 	async init(engineNameOrPath) {
-		let name = engineNameOrPath || this.engineNameOrPath;
+		const name = engineNameOrPath || this.engineNameOrPath;
 		this.extensionMap.config = this.eleventyConfig;
 		this._engineName = this.extensionMap.getKey(name);
 		if (!this._engineName) {
@@ -103,8 +103,8 @@ class TemplateRender {
 		}
 
 		let overlappingEngineWarningCount = 0;
-		let engines = [];
-		let uniqueLookup = {};
+		const engines = [];
+		const uniqueLookup = {};
 		let usingMarkdown = false;
 		(engineName || "")
 			.split(",")
@@ -151,7 +151,7 @@ class TemplateRender {
 	}
 
 	getReadableEnginesListDifferingFromFileExtension() {
-		let keyFromFilename = this.extensionMap.getKey(this.engineNameOrPath);
+		const keyFromFilename = this.extensionMap.getKey(this.engineNameOrPath);
 		if (this.engine instanceof CustomEngine) {
 			if (
 				this.engine.entry &&
@@ -192,7 +192,7 @@ class TemplateRender {
 	// We pass in templateEngineOverride here because it isn’t yet applied to templateRender
 	getEnginesList(engineOverride) {
 		if (engineOverride) {
-			let engines = TemplateRender.parseEngineOverrides(engineOverride).reverse();
+			const engines = TemplateRender.parseEngineOverrides(engineOverride).reverse();
 			return engines.join(",");
 		}
 
@@ -208,7 +208,7 @@ class TemplateRender {
 	}
 
 	async setEngineOverride(engineName, bypassMarkdown) {
-		let engines = TemplateRender.parseEngineOverrides(engineName);
+		const engines = TemplateRender.parseEngineOverrides(engineName);
 
 		// when overriding, Template Engines with HTML will instead use the Template Engine as primary and output HTML
 		// So any HTML engine usage here will never use a preprocessor templating engine.
@@ -221,7 +221,7 @@ class TemplateRender {
 
 		await this.init(engines[0]);
 
-		let usingMarkdown = engines[0] === "md" && !bypassMarkdown;
+		const usingMarkdown = engines[0] === "md" && !bypassMarkdown;
 
 		this.setUseMarkdown(usingMarkdown);
 

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -149,7 +149,7 @@ class TemplateWriter {
 			return false;
 		}
 
-		let passthroughManager = this.eleventyFiles.getPassthroughManager();
+		const passthroughManager = this.eleventyFiles.getPassthroughManager();
 		return passthroughManager.isPassthroughCopyFile(paths, this.incrementalFile);
 	}
 
@@ -182,15 +182,15 @@ class TemplateWriter {
 			 *   return pretty(str, { ocd: true });
 			 * }
 			 */
-			for (let transformName in this.config.transforms) {
-				let transform = this.config.transforms[transformName];
+			for (const transformName in this.config.transforms) {
+				const transform = this.config.transforms[transformName];
 				if (typeof transform === "function") {
 					tmpl.addTransform(transformName, transform);
 				}
 			}
 
-			for (let linterName in this.config.linters) {
-				let linter = this.config.linters[linterName];
+			for (const linterName in this.config.linters) {
+				const linter = this.config.linters[linterName];
 				if (typeof linter === "function") {
 					tmpl.addLinter(linter);
 				}
@@ -208,20 +208,20 @@ class TemplateWriter {
 	}
 
 	async _addToTemplateMap(paths, to = "fs") {
-		let promises = [];
+		const promises = [];
 
-		let isIncrementalFileAFullTemplate = this.eleventyFiles.isFullTemplateFile(
+		const isIncrementalFileAFullTemplate = this.eleventyFiles.isFullTemplateFile(
 			paths,
 			this.incrementalFile,
 		);
-		let isIncrementalFileAPassthroughCopy = this._isIncrementalFileAPassthroughCopy(paths);
+		const isIncrementalFileAPassthroughCopy = this._isIncrementalFileAPassthroughCopy(paths);
 
 		let relevantToDeletions = new Set();
 
 		// Update the data cascade and the global dependency map for the one incremental template before everything else (only full templates)
 		if (isIncrementalFileAFullTemplate && this.incrementalFile) {
-			let path = this.incrementalFile;
-			let { template: tmpl, wasCached } = this._createTemplate(path, to);
+			const path = this.incrementalFile;
+			const { template: tmpl, wasCached } = this._createTemplate(path, to);
 			if (wasCached) {
 				tmpl.resetCaches(); // reset internal caches on the cached template instance
 			}
@@ -231,7 +231,7 @@ class TemplateWriter {
 				tmpl.setRenderableOverride(undefined); // reset to render enabled
 			}
 
-			let p = this.templateMap.add(tmpl);
+			const p = this.templateMap.add(tmpl);
 			promises.push(p);
 			await p;
 			debug(`${path} adding to template map.`);
@@ -244,7 +244,7 @@ class TemplateWriter {
 			this.templateMap.addToGlobalDependencyGraph();
 		}
 
-		for (let path of paths) {
+		for (const path of paths) {
 			if (!this.extensionMap.hasEngine(path)) {
 				continue;
 			}
@@ -259,7 +259,7 @@ class TemplateWriter {
 				continue;
 			}
 
-			let { template: tmpl, wasCached } = this._createTemplate(path, to);
+			const { template: tmpl, wasCached } = this._createTemplate(path, to);
 
 			if (!this.incrementalFile) {
 				// Render overrides are only used when `--ignore-initial` is in play and an initial build is not run
@@ -275,7 +275,7 @@ class TemplateWriter {
 					tmpl.resetCaches();
 				}
 			} else {
-				let isTemplateRelevantToDeletedCollections = relevantToDeletions.has(
+				const isTemplateRelevantToDeletedCollections = relevantToDeletions.has(
 					TemplatePath.stripLeadingDotSlash(tmpl.inputPath),
 				);
 
@@ -335,7 +335,7 @@ class TemplateWriter {
 	}
 
 	async _generateTemplate(mapEntry, to) {
-		let tmpl = mapEntry.template;
+		const tmpl = mapEntry.template;
 
 		return tmpl.generateMapEntry(mapEntry, to).then((pages) => {
 			this.writeCount += tmpl.getWriteCount();
@@ -344,7 +344,7 @@ class TemplateWriter {
 	}
 
 	async writePassthroughCopy(templateExtensionPaths) {
-		let passthroughManager = this.eleventyFiles.getPassthroughManager();
+		const passthroughManager = this.eleventyFiles.getPassthroughManager();
 		passthroughManager.setIncrementalFile(this.incrementalFile);
 
 		return passthroughManager.copyAll(templateExtensionPaths).catch((e) => {
@@ -354,7 +354,7 @@ class TemplateWriter {
 	}
 
 	async generateTemplates(paths, to = "fs") {
-		let promises = [];
+		const promises = [];
 
 		// console.time("generateTemplates:_createTemplateMap");
 		// TODO optimize await here
@@ -362,8 +362,8 @@ class TemplateWriter {
 		// console.timeEnd("generateTemplates:_createTemplateMap");
 		debug("Template map created.");
 
-		let usedTemplateContentTooEarlyMap = [];
-		for (let mapEntry of this.templateMap.getMap()) {
+		const usedTemplateContentTooEarlyMap = [];
+		for (const mapEntry of this.templateMap.getMap()) {
 			promises.push(
 				this._generateTemplate(mapEntry, to).catch(function (e) {
 					// Premature templateContent in layout render, this also happens in
@@ -382,7 +382,7 @@ class TemplateWriter {
 			);
 		}
 
-		for (let mapEntry of usedTemplateContentTooEarlyMap) {
+		for (const mapEntry of usedTemplateContentTooEarlyMap) {
 			promises.push(
 				this._generateTemplate(mapEntry, to).catch(function (e) {
 					return Promise.reject(
@@ -399,8 +399,8 @@ class TemplateWriter {
 	}
 
 	async write() {
-		let paths = await this._getAllPaths();
-		let promises = [];
+		const paths = await this._getAllPaths();
+		const promises = [];
 
 		// The ordering here is important to destructuring in Eleventy->_watch
 		promises.push(this.writePassthroughCopy(paths));
@@ -415,12 +415,12 @@ class TemplateWriter {
 	// Passthrough copy not supported in JSON output.
 	// --incremental not supported in JSON output.
 	async getJSON(to = "json") {
-		let paths = await this._getAllPaths();
-		let promises = await this.generateTemplates(paths, to);
+		const paths = await this._getAllPaths();
+		const promises = await this.generateTemplates(paths, to);
 
 		return Promise.all(promises)
 			.then((results) => {
-				let flat = results.flat();
+				const flat = results.flat();
 				return flat;
 			})
 			.catch((e) => {

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -77,7 +77,7 @@ class UserConfig {
 
 		this.useGitIgnore = true;
 
-		let defaultIgnores = new Set();
+		const defaultIgnores = new Set();
 		defaultIgnores.add("**/node_modules/**");
 		defaultIgnores.add(".git/**");
 		this.ignores = new Set(defaultIgnores);
@@ -118,7 +118,7 @@ class UserConfig {
 			// Supplementary engines
 			engines: {
 				node: (frontMatterCode, { filePath }) => {
-					let vm = new RetrieveGlobals(frontMatterCode, {
+					const vm = new RetrieveGlobals(frontMatterCode, {
 						filePath,
 						// ignored if vm.Module is stable (or --experimental-vm-modules)
 						transformEsmImports: true,
@@ -127,7 +127,7 @@ class UserConfig {
 					// Future warning until vm.Module is stable:
 					// If the frontMatterCode uses `import` this uses the `experimentalModuleApi`
 					// option in node-retrieve-globals to workaround https://github.com/zachleat/node-retrieve-globals/issues/2
-					let data = {
+					const data = {
 						page: {
 							// Theoretically fileSlug and filePathStem could be added here but require extensionMap
 							inputPath: filePath,
@@ -147,7 +147,7 @@ class UserConfig {
 
 	// compatibleRange is optional in 2.0.0-beta.2
 	versionCheck(compatibleRange) {
-		let compat = new EleventyCompatibility(compatibleRange);
+		const compat = new EleventyCompatibility(compatibleRange);
 
 		if (!compat.isCompatible()) {
 			throw new UserConfigError(compat.getErrorMessage());
@@ -270,7 +270,7 @@ class UserConfig {
 		this.addJavaScriptFunction(name, callback);
 
 		this.addNunjucksFilter(name, function (...args) {
-			let ret = callback.call(this, ...args);
+			const ret = callback.call(this, ...args);
 			if (ret instanceof Promise) {
 				throw new Error(
 					`Nunjucks *is* async-friendly with \`addFilter("${name}", async function() {})\` but you need to supply an \`async function\`. You returned a promise from \`addFilter("${name}", function() {})\`. Alternatively, use the \`addAsyncFilter("${name}")\` configuration API method.`,
@@ -288,8 +288,8 @@ class UserConfig {
 		this.addLiquidFilter(name, callback);
 		this.addJavaScriptFunction(name, callback);
 		this.addNunjucksAsyncFilter(name, async function (...args) {
-			let cb = args.pop();
-			let ret = await callback.call(this, ...args);
+			const cb = args.pop();
+			const ret = await callback.call(this, ...args);
 			cb(null, ret);
 		});
 	}
@@ -407,14 +407,14 @@ class UserConfig {
 
 	// Starting in 3.0 the plugin callback might be asynchronous!
 	_executePlugin(plugin, options) {
-		let name = this._getPluginName(plugin);
+		const name = this._getPluginName(plugin);
 		let ret;
 		debug(`Adding ${name || "anonymous"} plugin`);
-		let pluginBenchmark = this.benchmarks.aggregate.get("Configuration addPlugin");
+		const pluginBenchmark = this.benchmarks.aggregate.get("Configuration addPlugin");
 		if (typeof plugin === "function") {
 			pluginBenchmark.before();
 			this.benchmarks.config;
-			let configFunction = plugin;
+			const configFunction = plugin;
 			ret = configFunction(this, options);
 			pluginBenchmark.after();
 		} else if (plugin && plugin.configFunction) {
@@ -440,7 +440,7 @@ class UserConfig {
 	}
 
 	async namespace(pluginNamespace, callback) {
-		let validNamespace = pluginNamespace && typeof pluginNamespace === "string";
+		const validNamespace = pluginNamespace && typeof pluginNamespace === "string";
 		if (validNamespace) {
 			this.activeNamespace = pluginNamespace || "";
 		}
@@ -468,7 +468,7 @@ class UserConfig {
 		if (typeof fileOrDir === "string") {
 			this.passthroughCopies[fileOrDir] = { outputPath: true, copyOptions };
 		} else {
-			for (let [inputPath, outputPath] of Object.entries(fileOrDir)) {
+			for (const [inputPath, outputPath] of Object.entries(fileOrDir)) {
 				this.passthroughCopies[inputPath] = { outputPath, copyOptions };
 			}
 		}
@@ -486,12 +486,12 @@ class UserConfig {
 		if (Array.isArray(templateFormats)) {
 			set = new Set(templateFormats.map((format) => format.trim()));
 		} else if (typeof templateFormats === "string") {
-			for (let format of templateFormats.split(",")) {
+			for (const format of templateFormats.split(",")) {
 				set.add(format.trim());
 			}
 		}
 
-		for (let format of existingValues || []) {
+		for (const format of existingValues || []) {
 			set.add(format);
 		}
 
@@ -526,7 +526,7 @@ class UserConfig {
 
 	/* These callbacks run on both libraryOverrides and default library instances */
 	amendLibrary(engineName, callback) {
-		let name = engineName.toLowerCase();
+		const name = engineName.toLowerCase();
 		if (!this.libraryAmendments[name]) {
 			this.libraryAmendments[name] = [];
 		}
@@ -802,7 +802,7 @@ class UserConfig {
 			extensions = [fileExtension];
 		}
 
-		for (let extension of extensions) {
+		for (const extension of extensions) {
 			this.extensionMap.add(
 				Object.assign(
 					{
@@ -829,8 +829,8 @@ class UserConfig {
 			parser = options.parser;
 		}
 
-		let extensions = extensionList.split(",").map((s) => s.trim());
-		for (let extension of extensions) {
+		const extensions = extensionList.split(",").map((s) => s.trim());
+		for (const extension of extensions) {
 			this.dataExtensions.set(extension, {
 				extension,
 				parser,
@@ -866,7 +866,7 @@ class UserConfig {
 	}
 
 	getMergingConfigObject() {
-		let obj = {
+		const obj = {
 			templateFormats: this.templateFormats,
 			templateFormatsAdded: this.templateFormatsAdded,
 			// filters removed in 1.0 (use addTransform instead)

--- a/src/Util/AsyncEventEmitter.js
+++ b/src/Util/AsyncEventEmitter.js
@@ -11,7 +11,7 @@ class AsyncEventEmitter extends EventEmitter {
 	 * @returns {Promise} - Promise resolves once all listeners were invoked
 	 */
 	async emit(type, ...args) {
-		let listeners = this.listeners(type);
+		const listeners = this.listeners(type);
 		if (listeners.length === 0) {
 			return [];
 		}
@@ -25,13 +25,13 @@ class AsyncEventEmitter extends EventEmitter {
 	 * @returns {Promise} - Promise resolves once all listeners were invoked
 	 */
 	async emitLazy(type, ...args) {
-		let listeners = this.listeners(type);
+		const listeners = this.listeners(type);
 		if (listeners.length === 0) {
 			return [];
 		}
 
-		let argsMap = [];
-		for (let arg of args) {
+		const argsMap = [];
+		for (const arg of args) {
 			if (typeof arg === "function") {
 				let r = arg();
 				if (r instanceof Promise) {

--- a/src/Util/Compatibility.js
+++ b/src/Util/Compatibility.js
@@ -24,7 +24,7 @@ class Compatibility {
 
 		try {
 			// fetch from project’s package.json
-			let projectPackageJson = getWorkingProjectPackageJson();
+			const projectPackageJson = getWorkingProjectPackageJson();
 			return projectPackageJson["11ty"]?.compatibility;
 		} catch (e) {
 			debug("Could not find a project package.json for compatibility version check: %O", e);

--- a/src/Util/ConsoleLogger.js
+++ b/src/Util/ConsoleLogger.js
@@ -89,7 +89,7 @@ class ConsoleLogger {
 		} else if (this._logger !== false) {
 			message = `[11ty] ${message.split("\n").join("\n[11ty] ")}`;
 
-			let logger = this._logger || console;
+			const logger = this._logger || console;
 			if (chalkColor && this.isChalkEnabled) {
 				logger[type](chalk[chalkColor](message));
 			} else {

--- a/src/Util/DateGitFirstAdded.js
+++ b/src/Util/DateGitFirstAdded.js
@@ -17,7 +17,7 @@ function getGitFirstAddedTimeStamp(filePath) {
 
 // return a Date
 export default function (inputPath) {
-	let timestamp = getGitFirstAddedTimeStamp(inputPath);
+	const timestamp = getGitFirstAddedTimeStamp(inputPath);
 	if (timestamp) {
 		return new Date(timestamp);
 	}

--- a/src/Util/DateGitLastUpdated.js
+++ b/src/Util/DateGitLastUpdated.js
@@ -21,7 +21,7 @@ function getGitLastUpdatedTimeStamp(filePath) {
 
 // return a Date
 export default function (inputPath) {
-	let timestamp = getGitLastUpdatedTimeStamp(inputPath);
+	const timestamp = getGitLastUpdatedTimeStamp(inputPath);
 	if (timestamp) {
 		return new Date(timestamp);
 	}

--- a/src/Util/DeepFreeze.js
+++ b/src/Util/DeepFreeze.js
@@ -3,7 +3,7 @@ import { isPlainObject } from "@11ty/eleventy-utils";
 // via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
 
 function DeepFreeze(obj, topLevelExceptions) {
-	for (let name of Reflect.ownKeys(obj)) {
+	for (const name of Reflect.ownKeys(obj)) {
 		if ((topLevelExceptions || []).find((key) => key === name)) {
 			continue;
 		}

--- a/src/Util/ExistsCache.js
+++ b/src/Util/ExistsCache.js
@@ -21,8 +21,8 @@ class ExistsCache {
 			return false;
 		}
 
-		let allPaths = PathNormalizer.getAllPaths(path).filter((entry) => entry !== path);
-		for (let parentPath of allPaths) {
+		const allPaths = PathNormalizer.getAllPaths(path).filter((entry) => entry !== path);
+		for (const parentPath of allPaths) {
 			if (this._cache.has(parentPath)) {
 				if (this._cache.get(parentPath) === false) {
 					return true; // we know this parent doesn’t exist
@@ -64,8 +64,8 @@ class ExistsCache {
 			return;
 		}
 
-		let paths = PathNormalizer.getAllPaths(path);
-		for (let fullpath of paths) {
+		const paths = PathNormalizer.getAllPaths(path);
+		for (const fullpath of paths) {
 			this.markExists(fullpath, true, true);
 		}
 	}

--- a/src/Util/GetJavaScriptData.js
+++ b/src/Util/GetJavaScriptData.js
@@ -3,7 +3,7 @@ import EleventyBaseError from "../EleventyBaseError.js";
 class JavaScriptInvalidDataFormatError extends EleventyBaseError {}
 
 export default async function (inst, inputPath, key = "data", options = {}) {
-	let { mixins, isObjectRequired } = Object.assign(
+	const { mixins, isObjectRequired } = Object.assign(
 		{
 			mixins: {},
 			isObjectRequired: true,
@@ -14,7 +14,7 @@ export default async function (inst, inputPath, key = "data", options = {}) {
 	if (inst && key in inst) {
 		// get extra data from `data` method,
 		// either as a function or getter or object literal
-		let result = await (typeof inst[key] === "function"
+		const result = await (typeof inst[key] === "function"
 			? Object.keys(mixins).length > 0
 				? inst[key].call(mixins)
 				: inst[key]()

--- a/src/Util/ImportJsonSync.js
+++ b/src/Util/ImportJsonSync.js
@@ -33,19 +33,19 @@ function importJsonSync(filePath) {
 		throw new Error(`importJsonSync expects a .json file extension (received: ${filePath})`);
 	}
 
-	let rawInput = loadContentsSync(filePath);
+	const rawInput = loadContentsSync(filePath);
 	return JSON.parse(rawInput);
 }
 
 // TODO cache
 function getEleventyPackageJson() {
-	let filePath = normalizeFilePathInEleventyPackage("package.json");
+	const filePath = normalizeFilePathInEleventyPackage("package.json");
 	return importJsonSync(filePath);
 }
 
 // TODO cache
 function getModulePackageJson(dir) {
-	let filePath = TemplatePath.absolutePath(dir, "package.json");
+	const filePath = TemplatePath.absolutePath(dir, "package.json");
 	return importJsonSync(filePath);
 }
 

--- a/src/Util/JavaScriptDependencies.js
+++ b/src/Util/JavaScriptDependencies.js
@@ -4,32 +4,32 @@ import { TemplatePath } from "@11ty/eleventy-utils";
 
 class JavaScriptDependencies {
 	static async getDependencies(inputFiles, isProjectUsingEsm) {
-		let depSet = new Set();
+		const depSet = new Set();
 
 		// TODO does this need to work with aliasing? what other JS extensions will have deps?
-		let commonJsFiles = inputFiles.filter(
+		const commonJsFiles = inputFiles.filter(
 			(file) => (!isProjectUsingEsm && file.endsWith(".js")) || file.endsWith(".cjs"),
 		);
 
-		for (let file of commonJsFiles) {
-			let modules = dependencyTree(file, {
+		for (const file of commonJsFiles) {
+			const modules = dependencyTree(file, {
 				nodeModuleNames: "exclude",
 				allowNotFound: true,
 			}).map((dependency) => {
 				return TemplatePath.addLeadingDotSlash(TemplatePath.relativePath(dependency));
 			});
 
-			for (let dep of modules) {
+			for (const dep of modules) {
 				depSet.add(dep);
 			}
 		}
 
-		let esmFiles = inputFiles.filter(
+		const esmFiles = inputFiles.filter(
 			(file) => (isProjectUsingEsm && file.endsWith(".js")) || file.endsWith(".mjs"),
 		);
-		for (let file of esmFiles) {
-			let modules = await find(file);
-			for (let dep of modules) {
+		for (const file of esmFiles) {
+			const modules = await find(file);
+			for (const dep of modules) {
 				depSet.add(dep);
 			}
 		}

--- a/src/Util/Merge.js
+++ b/src/Util/Merge.js
@@ -10,7 +10,7 @@ function cleanKey(key, prefix) {
 }
 
 function getMergedItem(target, source, prefixes = {}) {
-	let { override } = prefixes;
+	const { override } = prefixes;
 
 	// deep copy objects to avoid sharing and to effect key renaming
 	if (!target && isPlainObject(source)) {
@@ -21,8 +21,8 @@ function getMergedItem(target, source, prefixes = {}) {
 		return target.concat(source);
 	} else if (isPlainObject(target)) {
 		if (isPlainObject(source)) {
-			for (let key in source) {
-				let overrideKey = cleanKey(key, override);
+			for (const key in source) {
+				const overrideKey = cleanKey(key, override);
 
 				target[overrideKey] = getMergedItem(target[key], source[key], prefixes);
 			}
@@ -35,7 +35,7 @@ function getMergedItem(target, source, prefixes = {}) {
 
 // The same as Merge but without override prefixes
 function DeepCopy(targetObject, ...sources) {
-	for (let source of sources) {
+	for (const source of sources) {
 		if (!source) {
 			continue;
 		}
@@ -48,7 +48,7 @@ function DeepCopy(targetObject, ...sources) {
 function Merge(target, ...sources) {
 	// Remove override prefixes from root target.
 	if (isPlainObject(target)) {
-		for (let key in target) {
+		for (const key in target) {
 			if (key.indexOf(OVERRIDE_PREFIX) === 0) {
 				target[key.slice(OVERRIDE_PREFIX.length)] = target[key];
 				delete target[key];
@@ -56,7 +56,7 @@ function Merge(target, ...sources) {
 		}
 	}
 
-	for (let source of sources) {
+	for (const source of sources) {
 		if (!source) {
 			continue;
 		}

--- a/src/Util/PathNormalizer.js
+++ b/src/Util/PathNormalizer.js
@@ -19,11 +19,11 @@ class PathNormalizer {
 	// order is important here: the top-most directory returns first
 	// array of file and all parent directories
 	static getAllPaths(inputPath) {
-		let parts = this.getParts(inputPath);
-		let allPaths = [];
+		const parts = this.getParts(inputPath);
+		const allPaths = [];
 
 		let fullpath = "";
-		for (let part of parts) {
+		for (const part of parts) {
 			fullpath += (fullpath.length > 0 ? "/" : "") + part;
 			allPaths.push(fullpath);
 		}

--- a/src/Util/ProxyWrap.js
+++ b/src/Util/ProxyWrap.js
@@ -25,12 +25,12 @@ function wrapObject(target, fallback) {
 			return Reflect.has(fallback, prop);
 		},
 		ownKeys(target) {
-			let s = new Set();
-			for (let k of Reflect.ownKeys(target)) {
+			const s = new Set();
+			for (const k of Reflect.ownKeys(target)) {
 				s.add(k);
 			}
 			if (isPlainObject(fallback)) {
-				for (let k of Reflect.ownKeys(fallback)) {
+				for (const k of Reflect.ownKeys(fallback)) {
 					s.add(k);
 				}
 			}
@@ -39,7 +39,7 @@ function wrapObject(target, fallback) {
 		get(target, prop) {
 			debug("handler:get", prop);
 
-			let value = Reflect.get(target, prop);
+			const value = Reflect.get(target, prop);
 
 			if (Reflect.has(target, prop)) {
 				// Already proxied
@@ -48,7 +48,7 @@ function wrapObject(target, fallback) {
 				}
 
 				if (isPlainObject(value) && Reflect.has(fallback, prop)) {
-					let ret = wrapObject(value, Reflect.get(fallback, prop));
+					const ret = wrapObject(value, Reflect.get(fallback, prop));
 					debug("handler:get (primary, object)", prop);
 					return ret;
 				}
@@ -60,12 +60,12 @@ function wrapObject(target, fallback) {
 			// Does not exist in primary
 			if (Reflect.has(fallback, prop)) {
 				// fallback has prop
-				let fallbackValue = Reflect.get(fallback, prop);
+				const fallbackValue = Reflect.get(fallback, prop);
 
 				if (isPlainObject(fallbackValue)) {
 					debug("handler:get (fallback, object)", prop);
 					// set empty object on primary
-					let emptyObject = {};
+					const emptyObject = {};
 					Reflect.set(target, prop, emptyObject);
 
 					return wrapObject(emptyObject, fallbackValue);

--- a/src/Util/Require.js
+++ b/src/Util/Require.js
@@ -33,10 +33,10 @@ async function loadContents(path, options = {}) {
 	return rawInput;
 }
 
-let lastModifiedPaths = new Map();
+const lastModifiedPaths = new Map();
 eventBus.on("eleventy.importCacheReset", (fileQueue) => {
-	for (let filePath of fileQueue) {
-		let absolutePath = TemplatePath.absolutePath(filePath);
+	for (const filePath of fileQueue) {
+		const absolutePath = TemplatePath.absolutePath(filePath);
 		lastModifiedPaths.set(absolutePath, Date.now());
 
 		// ESM Eleventy when using `import()` on a CJS project file still adds to require.cache
@@ -49,13 +49,13 @@ eventBus.on("eleventy.importCacheReset", (fileQueue) => {
 async function dynamicImportAbsolutePath(absolutePath, type) {
 	if (absolutePath.endsWith(".json") || type === "json") {
 		// https://v8.dev/features/import-assertions#dynamic-import() is still experimental in Node 20
-		let rawInput = await loadContents(absolutePath);
+		const rawInput = await loadContents(absolutePath);
 		return JSON.parse(rawInput);
 	}
 
 	let urlPath;
 	try {
-		let u = new URL(`file:${absolutePath}`);
+		const u = new URL(`file:${absolutePath}`);
 
 		// Bust the import cache if this is the last modified file
 		if (lastModifiedPaths.has(absolutePath)) {
@@ -67,7 +67,7 @@ async function dynamicImportAbsolutePath(absolutePath, type) {
 		urlPath = absolutePath;
 	}
 
-	let target = await import(urlPath);
+	const target = await import(urlPath);
 
 	// If the only export is `default`, elevate to top (for ESM and CJS)
 	if (Object.keys(target).length === 1 && "default" in target) {
@@ -94,7 +94,7 @@ async function dynamicImportAbsolutePath(absolutePath, type) {
 
 	if (type === "cjs" && "default" in target) {
 		let match = true;
-		for (let key in target) {
+		for (const key in target) {
 			if (key === "default") {
 				continue;
 			}
@@ -120,12 +120,12 @@ function normalizeFilePathInEleventyPackage(file) {
 
 async function dynamicImportFromEleventyPackage(file) {
 	// points to files relative to the top level Eleventy directory
-	let filePath = normalizeFilePathInEleventyPackage(file);
+	const filePath = normalizeFilePathInEleventyPackage(file);
 	return dynamicImportAbsolutePath(filePath);
 }
 
 async function dynamicImport(localPath, type) {
-	let absolutePath = TemplatePath.absolutePath(localPath);
+	const absolutePath = TemplatePath.absolutePath(localPath);
 	// async
 	return dynamicImportAbsolutePath(absolutePath, type);
 }

--- a/src/Util/Sortable.js
+++ b/src/Util/Sortable.js
@@ -26,7 +26,7 @@ class Sortable {
 		if (!sortFunction) {
 			sortFunction = this.getSortFunction();
 		} else if (typeof sortFunction === "string") {
-			let key = sortFunction;
+			const key = sortFunction;
 			let name;
 			if (key in this.sortFunctionStringMap) {
 				name = this.sortFunctionStringMap[key];
@@ -100,7 +100,10 @@ class Sortable {
 	}
 
 	static sortFunctionDateInputPath(mapA, mapB) {
-		let sortDate = Sortable.sortFunctionNumericAscending(mapA.date.getTime(), mapB.date.getTime());
+		const sortDate = Sortable.sortFunctionNumericAscending(
+			mapA.date.getTime(),
+			mapB.date.getTime(),
+		);
 		if (sortDate === 0) {
 			return Sortable.sortFunctionAlphabeticAscending(mapA.inputPath, mapB.inputPath);
 		}


### PR DESCRIPTION
I just used eslint’s `--fix` option for a single rule, `prefer-const`.

**Rationale:**
From the [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const) page:

> If a variable is never reassigned, using the `const` declaration is better.
>
> `const` declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.