### PR TITLE
Allow accessing globals from rendered liquid partials

### DIFF
--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -25,7 +25,6 @@ class Liquid extends TemplateEngine {
 		this.setLibrary(this.config.libraryOverrides.liquid);
 
 		this.argLexer = moo.compile(Liquid.argumentLexerOptions);
-
 		this.cacheable = true;
 	}
 
@@ -293,6 +292,7 @@ class Liquid extends TemplateEngine {
 
 		return async function (data) {
 			let tmpl = await tmplReady;
+
 			return engine.render(tmpl, data, options);
 		};
 	}

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -19,7 +19,7 @@ class Liquid extends TemplateEngine {
 	constructor(name, eleventyConfig) {
 		super(name, eleventyConfig);
 
-		this.globalsReference = this.config.globalData
+		this.globalsReference = this.config.globalData;
 		this.liquidOptions = this.config.liquidOptions || {};
 
 		this.setLibrary(this.config.libraryOverrides.liquid);
@@ -52,17 +52,17 @@ class Liquid extends TemplateEngine {
 
 		let options = Object.assign(defaults, this.liquidOptions || {});
 
-		this.mergeGlobalData()
-		options.globals = this.globalsReference
+		this.mergeGlobalData();
+		options.globals = this.globalsReference;
 		// debug("Liquid constructor options: %o", options);
 
 		return options;
 	}
 
-	mergeGlobalData(){
-		for(let name in this.config.liquidOptions.globals){
-			if(name in this.config.globalData) continue;
-			this.config.globalData[name] = this.config.liquidOptions.globals[name]
+	mergeGlobalData() {
+		for (let name in this.config.liquidOptions.globals) {
+			if (name in this.config.globalData) continue;
+			this.config.globalData[name] = this.config.liquidOptions.globals[name];
 		}
 	}
 
@@ -70,9 +70,9 @@ class Liquid extends TemplateEngine {
 	 * Liquid needs to receive globals in order for {% render %} to have access to them
 	 *
 	 * @override
-	**/
-	needsGlobals(){
-		return true
+	 **/
+	needsGlobals() {
+		return true;
 	}
 
 	static wrapFilter(fn) {
@@ -131,14 +131,14 @@ class Liquid extends TemplateEngine {
 		this.liquidLib.registerTag(name, tagObj);
 	}
 
-	addGlobals(globals){
+	addGlobals(globals) {
 		for (let [name, value] of Object.entries(globals)) {
 			this.addGlobal(name, value);
 		}
 	}
 
-	addGlobal(name, value){
-		this.globalsReference[name] = value
+	addGlobal(name, value) {
+		this.globalsReference[name] = value;
 	}
 
 	addAllShortcodes(shortcodes) {

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -115,6 +115,10 @@ class TemplateEngine {
 		return true;
 	}
 
+	needsGlobals(){
+		return false;
+	}
+
 	getExtraDataFromFile() {
 		return {};
 	}

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -115,7 +115,7 @@ class TemplateEngine {
 		return true;
 	}
 
-	needsGlobals(){
+	needsGlobals() {
 		return false;
 	}
 

--- a/src/Template.js
+++ b/src/Template.js
@@ -356,11 +356,13 @@ class Template extends TemplateContent {
 		debugDev("%o getData mergedData", this.inputPath);
 
 		this._dataCache = mergedData;
-		if(this.templateRender.engine.needsGlobals()){
-			if(typeof this.templateRender.engine.addGlobals != 'function'){
-				throw new Error("Internal error: the engine's `.needsGlobals()` method returned `true`, but it does not have an `.addGlobals()` method");
+		if (this.templateRender.engine.needsGlobals()) {
+			if (typeof this.templateRender.engine.addGlobals != "function") {
+				throw new Error(
+					"Internal error: the engine's `.needsGlobals()` method returned `true`, but it does not have an `.addGlobals()` method",
+				);
 			}
-			this.templateRender.engine.addGlobals(globalData)
+			this.templateRender.engine.addGlobals(globalData);
 		}
 		return mergedData;
 	}

--- a/src/Template.js
+++ b/src/Template.js
@@ -356,6 +356,12 @@ class Template extends TemplateContent {
 		debugDev("%o getData mergedData", this.inputPath);
 
 		this._dataCache = mergedData;
+		if(this.templateRender.engine.needsGlobals()){
+			if(typeof this.templateRender.engine.addGlobals != 'function'){
+				throw new Error("Internal error: the engine's `.needsGlobals()` method returned `true`, but it does not have an `.addGlobals()` method");
+			}
+			this.templateRender.engine.addGlobals(globalData)
+		}
 		return mergedData;
 	}
 

--- a/test/TemplateRenderLiquidTest.js
+++ b/test/TemplateRenderLiquidTest.js
@@ -1057,14 +1057,3 @@ test("Issue 1541: global data in rendered templates passed through addGlobalData
   let fn = await tr.getCompiledTemplate(`<p>{% render "globals" %}</p>`);
   t.is(await fn(), "<p>Hello world</p>");
 });
-
-
-
-// test("Liquid Render Scope Leak", async (t) => {
-//   let tr1 = await getNewTemplateRender("liquid", "./test/stubs/");
-//   t.is(tr1.getEngineName(), "liquid");
-
-//   let tr2 = await getNewTemplateRender("liquid", "./test/stubs/");
-//   let fn = await tr2.getCompiledTemplate("<p>{% render 'scopeleak' %}{{ test }}</p>");
-//   t.is(await fn({ test: 1 }), "<p>21</p>");
-// });

--- a/test/_testHelpers.js
+++ b/test/_testHelpers.js
@@ -2,7 +2,7 @@ import { isPlainObject } from "@11ty/eleventy-utils";
 import TemplateConfig from "../src/TemplateConfig.js";
 import ProjectDirectories from "../src/Util/ProjectDirectories.js";
 
-async function getTemplateConfigInstance(configObj, dirs, configObjOverride = undefined) {
+async function getTemplateConfigInstance(configObj, dirs, configObjOverride = undefined, configCallback = undefined) {
 	let eleventyConfig;
 	if(configObj instanceof TemplateConfig) {
 		eleventyConfig = configObj;
@@ -24,6 +24,8 @@ async function getTemplateConfigInstance(configObj, dirs, configObjOverride = un
 	}
 
 	eleventyConfig.setDirectories(dirs);
+
+	configCallback?.(eleventyConfig);
 
 	await eleventyConfig.init(configObjOverride || configObj); // overrides
 

--- a/test/stubs/_includes/globals.liquid
+++ b/test/stubs/_includes/globals.liquid
@@ -1,0 +1,1 @@
+{{ globalVariable }}


### PR DESCRIPTION
This is a PR that fixes https://github.com/11ty/eleventy/issues/1541, and can probably be extended to include https://github.com/11ty/eleventy/issues/3172 and https://github.com/11ty/eleventy/issues/2453 as well.

In a nutshell, the problem is that liquid partials rendered with the `{% render %}` tag are encapsulated to the point they do not have access to global data configured through `addGlobalData`, global data files, directory- and page-specific data, and Eleventy-provided globals such as `page`. The only global data they have access to is that configured through LiquidJS's [`globals`](https://liquidjs.com/tutorials/options.html#globals) option (passed to `.setLiquidOptions()`).

This PR does not expose all of the data mentioned above to `{% render %}`-style partials (though can be extended to do so), but instead only exposes data configured through `addGlobalData` and global data files. LiquidJS's `globals` option has the lowest priority in this data cascade (which is consistent with the `{% include %}` equivalent).

A bit about the PR's contents; I've added a `.needsGlobals()` method to `TemplateEngine` instances. This method returns a boolean indicating whether it wants to receive all global data before rendering. Receiving the globals is not generally necessary, but as mentioned before, LiquidJS requires all global data be passed to its `globals` option in order to make it available in partials renderd with `{% render %}`. As such, by default, this `.needsGlobals()` method returns `false`; the `Liquid` engine then overrides this method with one returning `true`. Then, at the time the data is first retrieved, the necessary global data is passed to the engines that need it (for now, only the Liquid engine) using an `addGlobals` method (one the Nunjucks engine already possesses).

I also added two tests; if a test with an actual data file is desired, I'd like some pointers on how to accomplish that neatly (I didn't see other tests doing something like that).