### PR TITLE
Fixes a small typo in the output of the `--help` command.

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -711,7 +711,7 @@ Arguments:
        Change all url template filters to use this subdirectory.
 
      --dryrun
-       Don’t write any files. Useful with \`DEBUG=Eleventy* npx eleventy\`
+       Don’t write any files. Useful in DEBUG mode, for example: \`DEBUG=Eleventy* npx @11ty/eleventy --dryrun\`
 
      --to=json
      --to=ndjson


### PR DESCRIPTION
This closes [3230](https://github.com/11ty/eleventy/issues/3230). Changed the wording for the `--dryrun` help text to use the correct command for DEBUG mode. The new text also makes it a little more general in case someone has a different setup or expectations. 