### PR TITLE
Small simplifications

### DIFF
--- a/src/Benchmark/BenchmarkGroup.js
+++ b/src/Benchmark/BenchmarkGroup.js
@@ -8,7 +8,7 @@ const debugBenchmark = debugUtil("Eleventy:Benchmark");
 class BenchmarkGroup {
 	constructor() {
 		this.benchmarks = {};
-		// Warning: aggregate benchmarks automatically default to false via BenchmarkManager->getBenchmarkGroup
+		// Warning: aggregate benchmarks automatically default to false via `BenchmarkManager.getBenchmarkGroup()`
 		this.isVerbose = true;
 		this.logger = new ConsoleLogger(this.isVerbose);
 		this.minimumThresholdMs = 0;
@@ -21,8 +21,8 @@ class BenchmarkGroup {
 	}
 
 	reset() {
-		for (var type in this.benchmarks) {
-			this.benchmarks[type].reset();
+		for (let bench of Object.values(this.benchmarks)) {
+			bench.reset();
 		}
 	}
 
@@ -88,8 +88,7 @@ class BenchmarkGroup {
 	}
 
 	finish(label, totalTimeSpent) {
-		for (var type in this.benchmarks) {
-			let bench = this.benchmarks[type];
+		for (let [type, bench] of Object.entries(this.benchmarks)) {
 			let isAbsoluteMinimumComparison = this.minimumThresholdMs > 0;
 			let totalForBenchmark = bench.getTotal();
 			let percent = Math.round((totalForBenchmark * 100) / totalTimeSpent);

--- a/src/Benchmark/BenchmarkManager.js
+++ b/src/Benchmark/BenchmarkManager.js
@@ -14,8 +14,8 @@ class BenchmarkManager {
 	reset() {
 		this.start = this.getNewTimestamp();
 
-		for (var j in this.benchmarkGroups) {
-			this.benchmarkGroups[j].reset();
+		for (let bench of Object.values(this.benchmarkGroups)) {
+			bench.reset();
 		}
 	}
 
@@ -64,8 +64,8 @@ class BenchmarkManager {
 
 	finish() {
 		let totalTimeSpentBenchmarking = this.getNewTimestamp() - this.start;
-		for (var j in this.benchmarkGroups) {
-			this.benchmarkGroups[j].finish(j, totalTimeSpentBenchmarking);
+		for (let [groupName, group] of Object.entries(this.benchmarkGroups)) {
+			group.finish(groupName, totalTimeSpentBenchmarking);
 		}
 	}
 }

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -774,15 +774,19 @@ Arguments:
 
 	shouldTriggerConfigReset(changedFiles) {
 		let configFilePaths = new Set(this.eleventyConfig.getLocalProjectConfigFiles());
-		if (changedFiles.intersection(configFilePaths).size > 0) {
-			return true;
-		}
-
-		for (const configFilePath of configFilePaths) {
-			// Any dependencies of the config file changed
-			let configFileDependencies = new Set(this.watchTargets.getDependenciesOf(configFilePath));
-			if (changedFiles.intersection(configFileDependencies).size > 0) {
+		//	Has the config file itself changed?
+		for (let filePath of changedFiles) {
+			if (configFilePaths.has(filePath)) {
 				return true;
+			}
+		}
+		//	Has the config file’s depdendencies changed?
+		for (const configFilePath of configFilePaths) {
+			let configFileDependencies = new Set(this.watchTargets.getDependenciesOf(configFilePath));
+			for (let filePath of changedFiles) {
+				if (configFileDependencies.has(filePath)) {
+					return true;
+				}
 			}
 		}
 

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -390,14 +390,14 @@ class Eleventy {
 		// Restore from cache
 		if (this._privateCaches.has(key)) {
 			let c = this._privateCaches.get(key);
-			for (let cacheKey in c) {
-				inst[cacheKey] = c[cacheKey];
+			for (let [cacheKey, cacheValue] of Object.entries(c)) {
+				inst[cacheKey] = cacheValue;
 			}
 		} else {
 			// Set cache
 			let c = {};
-			for (let cacheKey of inst.caches || []) {
-				c[cacheKey] = inst[cacheKey];
+			for (let [cacheKey, cacheValue] of Object.entries(inst.caches || [])) {
+				c[cacheKey] = cacheValue;
 			}
 			this._privateCaches.set(key, c);
 		}

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -774,20 +774,15 @@ Arguments:
 
 	shouldTriggerConfigReset(changedFiles) {
 		let configFilePaths = new Set(this.eleventyConfig.getLocalProjectConfigFiles());
-		for (let filePath of changedFiles) {
-			if (configFilePaths.has(filePath)) {
-				return true;
-			}
+		if (changedFiles.intersection(configFilePaths).size > 0) {
+			return true;
 		}
 
 		for (const configFilePath of configFilePaths) {
 			// Any dependencies of the config file changed
 			let configFileDependencies = new Set(this.watchTargets.getDependenciesOf(configFilePath));
-
-			for (let filePath of changedFiles) {
-				if (configFileDependencies.has(filePath)) {
-					return true;
-				}
+			if (changedFiles.intersection(configFileDependencies).size > 0) {
+				return true;
 			}
 		}
 
@@ -799,12 +794,10 @@ Arguments:
 		if (!activeQueue.length) {
 			return false;
 		}
-
-		return this.shouldTriggerConfigReset(
-			activeQueue.map((path) => {
-				return PathNormalizer.normalizeSeperator(TemplatePath.addLeadingDotSlash(path));
-			}),
+		activeQueue = new Set(
+			activeQueue.map(TemplatePath.addLeadingDotSlash).map(PathNormalizer.normalizeSeperator),
 		);
+		return this.shouldTriggerConfigReset(activeQueue);
 	}
 
 	/**

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -873,7 +873,7 @@ Arguments:
 				build: {
 					templates: templateResults
 						.flat()
-						.filter((entry) => !!entry)
+						.filter(Boolean)
 						.map((entry) => {
 							entry.url = PathPrefixer.joinUrlParts(normalizedPathPrefix, entry.url);
 							return entry;
@@ -1237,10 +1237,10 @@ Arguments:
 
 			if (to === "fs") {
 				// New in 3.0: flatten return object for return.
-				ret[1] = templateResults.flat().filter((entry) => !!entry);
+				ret[1] = templateResults.flat().filter(Boolean);
 				eventsArg.results = ret[1];
 			} else {
-				eventsArg.results = templateResults.filter((entry) => !!entry);
+				eventsArg.results = templateResults.filter(Boolean);
 			}
 
 			if (to === "ndjson") {

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -798,10 +798,11 @@ Arguments:
 		if (!activeQueue.length) {
 			return false;
 		}
-		activeQueue = new Set(
-			activeQueue.map(TemplatePath.addLeadingDotSlash).map(PathNormalizer.normalizeSeperator),
+		return this.shouldTriggerConfigReset(
+			activeQueue.map((path) => {
+				return PathNormalizer.normalizeSeperator(TemplatePath.addLeadingDotSlash(path));
+			}),
 		);
-		return this.shouldTriggerConfigReset(activeQueue);
 	}
 
 	/**

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -90,9 +90,7 @@ class EleventyExtensionMap {
 
 	getValidExtensionsForPath(path) {
 		let extensions = new Set(
-			[...Object.keys(this.extensionToKeyMap)].filter((extension) =>
-				path.endsWith(`.${extension}`),
-			),
+			Object.keys(this.extensionToKeyMap).filter((extension) => path.endsWith(`.${extension}`)),
 		);
 
 		// if multiple extensions are valid, sort from longest to shortest

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -187,15 +187,16 @@ class EleventyExtensionMap {
 
 	// Only `addExtension` configuration API extensions
 	getExtensionEntriesFromKey(key) {
-		let entries = [];
-		if ("extensionMap" in this.config) {
+		if (this.config?.extensionMap) {
+			let entries = [];
 			for (let entry of this.config.extensionMap) {
 				if (entry.key === key) {
 					entries.push(entry);
+					return entries;
 				}
 			}
 		}
-		return entries;
+		return [];
 	}
 
 	hasEngine(pathOrKey) {
@@ -235,7 +236,7 @@ class EleventyExtensionMap {
 				"11ty.mjs": "11ty.js",
 			};
 
-			if ("extensionMap" in this.config) {
+			if (this.config?.extensionMap) {
 				for (let entry of this.config.extensionMap) {
 					this._extensionToKeyMap[entry.extension] = entry.key;
 				}

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -177,8 +177,8 @@ class EleventyExtensionMap {
 
 	getExtensionsFromKey(key) {
 		let extensions = [];
-		for (var extension in this.extensionToKeyMap) {
-			if (this.extensionToKeyMap[extension] === key) {
+		for (let [extension, entry] of Object.entries(this.extensionToKeyMap)) {
+			if (entry === key) {
 				extensions.push(extension);
 			}
 		}
@@ -205,23 +205,17 @@ class EleventyExtensionMap {
 	getKey(pathOrKey) {
 		pathOrKey = (pathOrKey || "").toLowerCase();
 
-		for (var extension in this.extensionToKeyMap) {
-			let key = this.extensionToKeyMap[extension];
-			if (pathOrKey === extension) {
-				return key;
-			} else if (pathOrKey.endsWith("." + extension)) {
+		for (let [extension, key] of Object.entries(this.extensionToKeyMap)) {
+			if (pathOrKey === extension || pathOrKey.endsWith(`.${extension}`)) {
 				return key;
 			}
 		}
 	}
 
 	removeTemplateExtension(path) {
-		for (var extension in this.extensionToKeyMap) {
-			if (path === extension || path.endsWith("." + extension)) {
-				return path.slice(
-					0,
-					path.length - 1 - extension.length < 0 ? 0 : path.length - 1 - extension.length,
-				);
+		for (let extension in this.extensionToKeyMap) {
+			if (path === extension || path.endsWith(`.${extension}`)) {
+				return path.slice(0, Math.max(0, path.length - 1 - extension.length));
 			}
 		}
 		return path;

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -91,12 +91,11 @@ class EleventyExtensionMap {
 	}
 
 	getValidExtensionsForPath(path) {
-		let extensions = new Set();
-		for (let extension in this.extensionToKeyMap) {
-			if (path.endsWith(`.${extension}`)) {
-				extensions.add(extension);
-			}
-		}
+		let extensions = new Set(
+			Array.from(Object.keys(this.extensionToKeyMap)).filter((extension) =>
+				path.endsWith(`.${extension}`),
+			),
+		);
 
 		// if multiple extensions are valid, sort from longest to shortest
 		// e.g. .11ty.js and .js

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -75,12 +75,7 @@ class EleventyExtensionMap {
 	// on paths found from the file system glob search.
 	// TODO: Method name might just need to be renamed to something more accurate.
 	isFullTemplateFilePath(path) {
-		for (let extension of this.validTemplateLanguageKeys) {
-			if (path.endsWith(`.${extension}`)) {
-				return true;
-			}
-		}
-		return false;
+		return this.validTemplateLanguageKeys.some((extension) => path.endsWith(`.${extension}`));
 	}
 
 	getCustomExtensionEntry(extension) {
@@ -167,12 +162,7 @@ class EleventyExtensionMap {
 	}
 
 	hasExtension(key) {
-		for (var extension in this.extensionToKeyMap) {
-			if (this.extensionToKeyMap[extension] === key) {
-				return true;
-			}
-		}
-		return false;
+		return [...Object.values(this.extensionToKeyMap)].includes(key);
 	}
 
 	getExtensionsFromKey(key) {

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -17,9 +17,7 @@ class EleventyExtensionMap {
 	}
 
 	setFormats(formatKeys = []) {
-		this.unfilteredFormatKeys = formatKeys.map(function (key) {
-			return key.trim().toLowerCase();
-		});
+		this.unfilteredFormatKeys = formatKeys.map((key) => key.trim().toLowerCase());
 
 		this.validTemplateLanguageKeys = this.unfilteredFormatKeys.filter((key) =>
 			this.hasExtension(key),

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -90,7 +90,7 @@ class EleventyExtensionMap {
 
 	getValidExtensionsForPath(path) {
 		let extensions = new Set(
-			Array.from(Object.keys(this.extensionToKeyMap)).filter((extension) =>
+			[...Object.keys(this.extensionToKeyMap)].filter((extension) =>
 				path.endsWith(`.${extension}`),
 			),
 		);

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -395,14 +395,7 @@ class EleventyFiles {
 		if (!filePath) {
 			return false;
 		}
-
-		for (let path of paths) {
-			if (path === filePath) {
-				return true;
-			}
-		}
-
-		return false;
+		return paths.includes(filePath);
 	}
 
 	/* For `eleventy --watch` */

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -203,12 +203,9 @@ class EleventyFiles {
 		}
 
 		let ignores = [];
-		for (let ignorePath of ignoreFiles) {
-			ignorePath = TemplatePath.normalize(ignorePath);
-
-			let dir = TemplatePath.getDirFromFilePath(ignorePath);
-
+		for (let ignorePath of ignoreFiles.map(TemplatePath.normalize)) {
 			if (fs.existsSync(ignorePath) && fs.statSync(ignorePath).size > 0) {
+				let dir = TemplatePath.getDirFromFilePath(ignorePath);
 				let ignoreContent = fs.readFileSync(ignorePath, "utf8");
 
 				ignores = ignores.concat(EleventyFiles.normalizeIgnoreContent(dir, ignoreContent));

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -215,9 +215,7 @@ class EleventyFiles {
 		if (ignoreContent) {
 			ignores = ignoreContent
 				.split("\n")
-				.map((line) => {
-					return line.trim();
-				})
+				.map((line) => line.trim())
 				.filter((line) => {
 					if (line.charAt(0) === "!") {
 						debug(

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -89,15 +89,13 @@ class EleventyFiles {
 	}
 
 	get passthroughGlobs() {
-		let paths = new Set();
-		// stuff added in addPassthroughCopy()
-		for (let path of this.passthroughManager.getConfigPathGlobs()) {
-			paths.add(path);
-		}
-		// non-template language extensions
-		for (let path of this.extensionMap.getPassthroughCopyGlobs(this.inputDir)) {
-			paths.add(path);
-		}
+		let paths = new Set([
+			// stuff added in addPassthroughCopy()
+			...this.passthroughManager.getConfigPathGlobs(),
+
+			// non-template language extensions
+			...this.extensionMap.getPassthroughCopyGlobs(this.inputDir),
+		]);
 		return Array.from(paths);
 	}
 
@@ -183,13 +181,7 @@ class EleventyFiles {
 	}
 
 	getIgnoreGlobs() {
-		let uniqueIgnores = new Set();
-		for (let ignore of this.fileIgnores) {
-			uniqueIgnores.add(ignore);
-		}
-		for (let ignore of this.extraIgnores) {
-			uniqueIgnores.add(ignore);
-		}
+		let uniqueIgnores = new Set([...this.fileIgnores, ...this.extraIgnores]);
 		// Placing the config ignores last here is important to the tests
 		for (let ignore of this.config.ignores) {
 			uniqueIgnores.add(TemplateGlob.normalizePath(this.localPathRoot || ".", ignore));
@@ -440,13 +432,12 @@ class EleventyFiles {
 	/* Ignored by `eleventy --watch` */
 	getGlobWatcherIgnores() {
 		// convert to format without ! since they are passed in as a separate argument to glob watcher
-		let entries = new Set(
-			this.fileIgnores.map((ignore) => TemplatePath.stripLeadingDotSlash(ignore)),
-		);
-
-		for (let ignore of this.config.watchIgnores) {
-			entries.add(TemplateGlob.normalizePath(this.localPathRoot || ".", ignore));
-		}
+		let entries = new Set([
+			...this.fileIgnores.map(TemplatePath.stripLeadingDotSlash),
+			...this.config.watchIgnores.map((ignore) =>
+				TemplateGlob.normalizePath(this.localPathRoot || ".", ignore),
+			),
+		]);
 
 		// de-duplicated
 		return Array.from(entries);

--- a/src/EleventyWatch.js
+++ b/src/EleventyWatch.js
@@ -78,12 +78,7 @@ class EleventyWatch {
 	}
 
 	hasQueuedFiles(files) {
-		for (const file of files) {
-			if (this.hasQueuedFile(file)) {
-				return true;
-			}
-		}
-		return false;
+		return files.some((file) => this.hasQueuedFile(file));
 	}
 
 	get pendingQueue() {

--- a/src/EleventyWatchTargets.js
+++ b/src/EleventyWatchTargets.js
@@ -100,9 +100,7 @@ class EleventyWatchTargets {
 	}
 
 	static normalizeToGlobs(targets) {
-		return EleventyWatchTargets.normalize(targets).map((entry) =>
-			TemplatePath.convertToRecursiveGlobSync(entry),
-		);
+		return EleventyWatchTargets.normalize(targets).map(TemplatePath.convertToRecursiveGlobSync);
 	}
 
 	addAndMakeGlob(targets) {

--- a/src/EleventyWatchTargets.js
+++ b/src/EleventyWatchTargets.js
@@ -132,21 +132,16 @@ class EleventyWatchTargets {
 	}
 
 	clearImportCacheFor(filePathArray) {
-		let paths = new Set();
-		for (const filePath of filePathArray) {
-			paths.add(filePath);
+		let paths = new Set([
+			...filePathArray,
 
-			// Delete from require cache so that updates to the module are re-required
-			let importsTheChangedFile = this.getDependantsOf(filePath);
-			for (let dep of importsTheChangedFile) {
-				paths.add(dep);
-			}
+			//	Imports changed the file
+			//	(Delete from require cache so that updates to the module are re-required)
+			...filePathArray.map((filePath) => this.getDependantsOf(filePath)),
 
-			let isImportedInTheChangedFile = this.getDependenciesOf(filePath);
-			for (let dep of isImportedInTheChangedFile) {
-				paths.add(dep);
-			}
-		}
+			//	Imported in the changed file
+			...filePathArray.map((filePath) => this.getDependenciesOf(filePath)),
+		]);
 
 		eventBus.emit("eleventy.importCacheReset", paths);
 	}

--- a/src/FileSystemSearch.js
+++ b/src/FileSystemSearch.js
@@ -29,10 +29,10 @@ class FileSystemSearch {
 		}
 
 		// Strip leading slashes from everything!
-		globs = globs.map((entry) => TemplatePath.stripLeadingDotSlash(entry));
+		globs = globs.map(TemplatePath.stripLeadingDotSlash);
 
 		if (options.ignore && Array.isArray(options.ignore)) {
-			options.ignore = options.ignore.map((entry) => TemplatePath.stripLeadingDotSlash(entry));
+			options.ignore = options.ignore.map(TemplatePath.stripLeadingDotSlash);
 			debug("Glob search (%o) ignoring: %o", key, options.ignore);
 		}
 
@@ -61,9 +61,7 @@ class FileSystemSearch {
 					options,
 				),
 			).then((results) => {
-				this.outputs[cacheKey] = new Set(
-					results.map((entry) => TemplatePath.addLeadingDotSlash(entry)),
-				);
+				this.outputs[cacheKey] = new Set(results.map(TemplatePath.addLeadingDotSlash));
 				return Array.from(this.outputs[cacheKey]);
 			});
 		}

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -129,12 +129,8 @@ class GlobalDependencyMap {
 		}
 
 		let prevDeps = this.getDependantsFor(node)
-			.filter((entry) => {
-				return entry.startsWith(GlobalDependencyMap.COLLECTION_PREFIX);
-			})
-			.map((entry) => {
-				return GlobalDependencyMap.getEntryFromCollectionKey(entry);
-			});
+			.filter((entry) => entry.startsWith(GlobalDependencyMap.COLLECTION_PREFIX))
+			.map((entry) => GlobalDependencyMap.getEntryFromCollectionKey(entry));
 
 		let prevDepsSet = new Set(prevDeps);
 		let deleted = new Set();

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -97,9 +97,9 @@ class GlobalDependencyMap {
 
 	normalizeLayoutsObject(layouts) {
 		let o = {};
-		for (let rawLayout in layouts) {
+		for (let [rawLayout, entry] of Object.entries(layouts)) {
 			let layout = this.normalizeNode(rawLayout);
-			o[layout] = layouts[rawLayout].map((entry) => this.normalizeNode(entry));
+			o[layout] = entry.map((entry) => this.normalizeNode(entry));
 		}
 		return o;
 	}

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -197,7 +197,7 @@ class GlobalDependencyMap {
 		this.map.dependantsOf(node).forEach((node) => {
 			let data = this.map.getNodeData(node);
 			// we only want layouts
-			if (data && data.type && data.type === GlobalDependencyMap.LAYOUT_KEY) {
+			if (data && data?.type === GlobalDependencyMap.LAYOUT_KEY) {
 				return layouts.push(node);
 			}
 		});
@@ -221,7 +221,7 @@ class GlobalDependencyMap {
 
 			// When includeLayouts is `false` we want to filter out layouts
 			let data = this.map.getNodeData(node);
-			if (data && data.type && data.type === GlobalDependencyMap.LAYOUT_KEY) {
+			if (data && data?.type === GlobalDependencyMap.LAYOUT_KEY) {
 				return false;
 			}
 			return true;

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -165,18 +165,14 @@ class GlobalDependencyMap {
 	}
 
 	getTemplatesThatConsumeCollections(collectionNames) {
-		let templates = new Set();
-		for (let name of collectionNames) {
-			let collectionName = GlobalDependencyMap.getCollectionKeyForEntry(name);
-			if (!this.map.hasNode(collectionName)) {
-				continue;
-			}
-			for (let node of this.map.dependantsOf(collectionName)) {
-				if (!node.startsWith(GlobalDependencyMap.COLLECTION_PREFIX)) {
-					templates.add(node);
-				}
-			}
-		}
+		let templates = new Set(
+			collectionNames
+				.map(GlobalDependencyMap.getCollectionKeyForEntry)
+				.filter((collectionName) => this.map.hasNode(collectionName))
+				.map((collectionName) => this.map.getdependantsOf(collectionName))
+				.filter((node) => !node.startsWith(GlobalDependencyMap.COLLECTION_PREFIX)),
+		);
+
 		return templates;
 	}
 

--- a/src/TemplateCache.js
+++ b/src/TemplateCache.js
@@ -73,8 +73,7 @@ class TemplateCache {
 		let layoutTemplate = this.cacheByInputPath[layoutFilePath];
 		layoutTemplate.resetCaches();
 
-		let keys = layoutTemplate.getCacheKeys();
-		for (let key of keys) {
+		for (let key of layoutTemplate.getCacheKeys()) {
 			delete this.cache[key];
 		}
 

--- a/src/TemplateCache.js
+++ b/src/TemplateCache.js
@@ -26,18 +26,16 @@ class TemplateCache {
 	}
 
 	add(layoutTemplate) {
-		let keys = new Set();
-
 		if (typeof layoutTemplate === "string") {
 			throw new Error(
 				"Invalid argument type passed to TemplateCache->add(). Should be a TemplateLayout.",
 			);
 		}
 
+		let keys = new Set();
 		if ("getFullKey" in layoutTemplate) {
 			keys.add(layoutTemplate.getFullKey());
 		}
-
 		if ("getKey" in layoutTemplate) {
 			// if `key` was an alias, also set to the pathed layout value too
 			// e.g. `layout: "default"` and `layout: "default.liquid"` will both map to the same template.

--- a/src/TemplateCollection.js
+++ b/src/TemplateCollection.js
@@ -28,9 +28,7 @@ class TemplateCollection extends Sortable {
 			globs = [globs];
 		}
 
-		globs = globs.map((glob) => TemplatePath.addLeadingDotSlash(glob));
-
-		return globs;
+		return globs.map(TemplatePath.addLeadingDotSlash);
 	}
 
 	getFilteredByGlob(globs) {

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -291,7 +291,7 @@ class TemplateConfig {
 				await this.userConfig._executePlugin(plugin, options);
 			} catch (e) {
 				let name = this.userConfig._getPluginName(plugin);
-				let namespaces = [storedActiveNamespace, pluginNamespace].filter((entry) => !!entry);
+				let namespaces = [storedActiveNamespace, pluginNamespace].filter(Boolean);
 
 				let namespaceStr = "";
 				if (namespaces.length) {

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -122,8 +122,8 @@ class TemplateConfig {
 	}
 
 	getLocalProjectConfigFiles() {
-		if (this.projectConfigPaths && this.projectConfigPaths.length > 0) {
-			return TemplatePath.addLeadingDotSlashArray(this.projectConfigPaths.filter((path) => path));
+		if (this?.projectConfigPaths?.length > 0) {
+			return TemplatePath.addLeadingDotSlashArray(this.projectConfigPaths.filter(Boolean));
 		}
 		return [];
 	}
@@ -348,7 +348,7 @@ class TemplateConfig {
 				// TODO the error message here is bad and I feel bad (needs more accurate info)
 				throw new EleventyConfigError(
 					`Error in your Eleventy config file '${path}'.` +
-						(err.message && err.message.includes("Cannot find module")
+						(err?.message.includes("Cannot find module")
 							? chalk.cyan(" You may need to run `npm install`.")
 							: ""),
 					err,

--- a/src/TemplateGlob.js
+++ b/src/TemplateGlob.js
@@ -23,9 +23,7 @@ class TemplateGlob {
 		if (typeof files === "string") {
 			return TemplateGlob.normalize(files);
 		} else if (Array.isArray(files)) {
-			return files.map(function (path) {
-				return TemplateGlob.normalize(path);
-			});
+			return files.map(TemplateGlob.normalize);
 		} else {
 			return files;
 		}

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -245,7 +245,7 @@ class TemplatePassthroughManager {
 			}
 		}
 
-		if (paths && paths.length) {
+		if (paths?.length) {
 			let passthroughPaths = this.getNonTemplatePaths(paths);
 			for (let path of passthroughPaths) {
 				let normalizedPath = this._normalizePaths(path);

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -168,15 +168,13 @@ class TemplateWriter {
 			 *   return pretty(str, { ocd: true });
 			 * }
 			 */
-			for (let transformName in this.config.transforms) {
-				let transform = this.config.transforms[transformName];
+			for (let [transformName, transform] of Object.entries(this.config.transforms)) {
 				if (typeof transform === "function") {
 					tmpl.addTransform(transformName, transform);
 				}
 			}
 
-			for (let linterName in this.config.linters) {
-				let linter = this.config.linters[linterName];
+			for (let linter of Object.values(this.config.linters)) {
 				if (typeof linter === "function") {
 					tmpl.addLinter(linter);
 				}

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -82,9 +82,7 @@ class UserConfig {
 
 		this.useGitIgnore = true;
 
-		let defaultIgnores = new Set();
-		defaultIgnores.add("**/node_modules/**");
-		defaultIgnores.add(".git/**");
+		let defaultIgnores = new Set(["**/node_modules/**", ".git/**"]);
 		this.ignores = new Set(defaultIgnores);
 		this.watchIgnores = new Set(defaultIgnores);
 

--- a/src/Util/JavaScriptDependencies.js
+++ b/src/Util/JavaScriptDependencies.js
@@ -15,9 +15,9 @@ class JavaScriptDependencies {
 			let modules = dependencyTree(file, {
 				nodeModuleNames: "exclude",
 				allowNotFound: true,
-			}).map((dependency) => {
-				return TemplatePath.addLeadingDotSlash(TemplatePath.relativePath(dependency));
-			});
+			})
+				.map(TemplatePath.relativePath)
+				.map(TemplatePath.addLeadingDotSlash);
 
 			for (let dep of modules) {
 				depSet.add(dep);


### PR DESCRIPTION
These are an assortment of small tweaks. 

My goal was to make these bits of code easier to understand at a glance. There’s plenty of subjectivity in that, to be sure.

Some of these make use of Javascript features that were not available a few years ago. (Both syntax and APIs of built-in objects.) Hopefully, I applied them in a way that makes it easier to understand each block of code. Since Eleventy v3 is still in alpha, I thought this would be a good time to introduce them, since they are supported pretty much everywhere and a major version increment doesn’t have to worry about breaking compatibility.