### PR TITLE
Centralized directory references for input/output/layouts/data/includes, changes Virtual Templates to be input dir relative.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ charset = utf-8
 [*.yml]
 indent_style = space
 
+[/test/**/*]
+indent_style = space
+
 [/test/stubs*/**]
 insert_final_newline = false
 trim_trailing_whitespace = false

--- a/src/Data/TemplateData.js
+++ b/src/Data/TemplateData.js
@@ -188,8 +188,7 @@ class TemplateData {
 
 	// For spidering dependencies
 	// TODO Can we reuse getTemplateDataFileGlob instead? Maybe just filter off the .json files before scanning for dependencies
-	// TODO directorynorm: remove async?
-	async getTemplateJavaScriptDataFileGlob() {
+	getTemplateJavaScriptDataFileGlob() {
 		let paths = [];
 		let suffixes = this.getDataFileSuffixes();
 		for (let suffix of suffixes) {
@@ -203,8 +202,7 @@ class TemplateData {
 		return TemplatePath.addLeadingDotSlashArray(paths);
 	}
 
-	// TODO directorynorm: remove async?
-	async getGlobalDataGlob() {
+	getGlobalDataGlob() {
 		let extGlob = this.getGlobalDataExtensionPriorities().join(",");
 		return [this._getGlobalDataGlobByExtension("{" + extGlob + "}")];
 	}
@@ -232,7 +230,7 @@ class TemplateData {
 
 		let fsBench = this.benchmarks.aggregate.get("Searching the file system (data)");
 		fsBench.before();
-		let globs = await this.getGlobalDataGlob();
+		let globs = this.getGlobalDataGlob();
 		let paths = await this.fileSystemSearch.search("global-data", globs);
 		fsBench.after();
 

--- a/src/Data/TemplateData.js
+++ b/src/Data/TemplateData.js
@@ -73,10 +73,6 @@ class TemplateData {
 		this.fileSystemSearch = fileSystemSearch;
 	}
 
-	setGlobalDataDirectories(dirsObject) {
-		this.directories = dirsObject;
-	}
-
 	setProjectUsingEsm(isEsmProject) {
 		this.isEsm = !!isEsmProject;
 	}
@@ -311,11 +307,11 @@ class TemplateData {
 					Object.assign(globalData.eleventy.env, this.environmentVariables);
 				}
 
-				if (this.directories) {
+				if (this.dirs) {
 					if (!("directories" in globalData.eleventy)) {
 						globalData.eleventy.directories = {};
 					}
-					Object.assign(globalData.eleventy.directories, this.directories);
+					Object.assign(globalData.eleventy.directories, this.dirs.getUserspaceInstance());
 				}
 
 				resolve(globalData);

--- a/src/Data/TemplateData.js
+++ b/src/Data/TemplateData.js
@@ -1,6 +1,4 @@
-import util from "node:util";
 import path from "node:path";
-import fs from "graceful-fs";
 
 import lodash from "@11ty/lodash-custom";
 import { TemplatePath, isPlainObject } from "@11ty/eleventy-utils";
@@ -14,7 +12,6 @@ import EleventyBaseError from "../Errors/EleventyBaseError.js";
 import TemplateDataInitialGlobalData from "./TemplateDataInitialGlobalData.js";
 import { EleventyImport, EleventyLoadContent } from "../Util/Require.js";
 
-const fsStatAsync = util.promisify(fs.stat);
 const { set: lodashSet, get: lodashGet } = lodash;
 const debugWarn = debugUtil("Eleventy:Warnings");
 const debug = debugUtil("Eleventy:TemplateData");
@@ -24,19 +21,18 @@ class TemplateDataConfigError extends EleventyBaseError {}
 class TemplateDataParseError extends EleventyBaseError {}
 
 class TemplateData {
+	// TODO directorynorm
 	constructor(inputDir, eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new TemplateDataConfigError("Missing `config`.");
 		}
 		this.eleventyConfig = eleventyConfig;
 		this.config = this.eleventyConfig.getConfig();
+
 		this.benchmarks = {
 			data: this.config.benchmarkManager.get("Data"),
 			aggregate: this.config.benchmarkManager.get("Aggregate"),
 		};
-
-		this.inputDirNeedsCheck = false;
-		this.setInputDir(inputDir);
 
 		this.rawImports = {};
 		this.globalData = null;
@@ -44,6 +40,28 @@ class TemplateData {
 		this.isEsm = false;
 
 		this.initialGlobalData = new TemplateDataInitialGlobalData(this.eleventyConfig);
+	}
+
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	// if this was set but `falsy` we would fallback to inputDir
+	get dataDir() {
+		return this.dirs.data;
+	}
+
+	// This was async in 2.0 and prior but doesn’t need to be any more.
+	getInputDir() {
+		return this.dirs.input;
+	}
+
+	getDataDir() {
+		return this.dataDir;
 	}
 
 	get _fsExistsCache() {
@@ -88,14 +106,6 @@ class TemplateData {
 		this.config = config;
 	}
 
-	setInputDir(inputDir) {
-		this.inputDirNeedsCheck = true;
-		this.inputDir = inputDir;
-		this.dataDir = this.config.dir.data
-			? TemplatePath.join(inputDir, this.config.dir.data)
-			: inputDir;
-	}
-
 	async getRawImports() {
 		try {
 			this.rawImports[this.config.keys.package] = await EleventyImport("package.json", "json");
@@ -107,46 +117,14 @@ class TemplateData {
 		return this.rawImports;
 	}
 
-	getDataDir() {
-		return this.dataDir;
-	}
-
 	clearData() {
 		this.globalData = null;
 		this.configApiGlobalData = null;
 		this.templateDirectoryData = {};
 	}
 
-	_getGlobalDataGlobByExtension(dir, extension) {
-		return TemplateGlob.normalizePath(
-			dir,
-			"/",
-			this.config.dir.data !== "." ? this.config.dir.data : "",
-			`/**/*.${extension}`,
-		);
-	}
-
-	async _checkInputDir() {
-		if (this.inputDirNeedsCheck) {
-			let globalPathStat = await fsStatAsync(this.inputDir);
-
-			if (!globalPathStat.isDirectory()) {
-				throw new Error("Could not find data path directory: " + this.inputDir);
-			}
-
-			this.inputDirNeedsCheck = false;
-		}
-	}
-
-	async getInputDir() {
-		let dir = ".";
-
-		if (this.inputDir) {
-			await this._checkInputDir();
-			dir = this.inputDir;
-		}
-
-		return dir;
+	_getGlobalDataGlobByExtension(extension) {
+		return TemplateGlob.normalizePath(this.dataDir, `/**/*.${extension}`);
 	}
 
 	// This is a backwards compatibility helper with the old `jsDataFileSuffix` configuration API
@@ -198,13 +176,12 @@ class TemplateData {
 			}
 		}
 
-		let dir = await this.getInputDir();
 		let paths = [];
 		if (globSuffixesWithLeadingDot.size > 0) {
-			paths.push(`${dir}/**/*.{${Array.from(globSuffixesWithLeadingDot).join(",")}}`);
+			paths.push(`${this.inputDir}**/*.{${Array.from(globSuffixesWithLeadingDot).join(",")}}`);
 		}
 		if (globSuffixesWithoutLeadingDot.size > 0) {
-			paths.push(`${dir}/**/*{${Array.from(globSuffixesWithoutLeadingDot).join(",")}}`);
+			paths.push(`${this.inputDir}**/*{${Array.from(globSuffixesWithoutLeadingDot).join(",")}}`);
 		}
 
 		return TemplatePath.addLeadingDotSlashArray(paths);
@@ -212,27 +189,25 @@ class TemplateData {
 
 	// For spidering dependencies
 	// TODO Can we reuse getTemplateDataFileGlob instead? Maybe just filter off the .json files before scanning for dependencies
+	// TODO directorynorm: remove async?
 	async getTemplateJavaScriptDataFileGlob() {
-		let dir = await this.getInputDir();
-
 		let paths = [];
 		let suffixes = this.getDataFileSuffixes();
 		for (let suffix of suffixes) {
 			if (suffix) {
 				// TODO this check is purely for backwards compat and I kinda feel like it shouldn’t be here
-				// paths.push(`${dir}/**/*${suffix || ""}.cjs`); // Same as above
-				paths.push(`${dir}/**/*${suffix || ""}.js`);
+				// paths.push(`${this.inputDir}/**/*${suffix || ""}.cjs`); // Same as above
+				paths.push(`${this.inputDir}**/*${suffix || ""}.js`);
 			}
 		}
 
 		return TemplatePath.addLeadingDotSlashArray(paths);
 	}
 
+	// TODO directorynorm: remove async?
 	async getGlobalDataGlob() {
-		let dir = await this.getInputDir();
-
 		let extGlob = this.getGlobalDataExtensionPriorities().join(",");
-		return [this._getGlobalDataGlobByExtension(dir, "{" + extGlob + "}")];
+		return [this._getGlobalDataGlobByExtension("{" + extGlob + "}")];
 	}
 
 	getWatchPathCache() {
@@ -572,7 +547,7 @@ class TemplateData {
 	async getLocalDataPaths(templatePath) {
 		let paths = [];
 		let parsed = path.parse(templatePath);
-		let inputDir = TemplatePath.addLeadingDotSlash(TemplatePath.normalize(this.inputDir));
+		let inputDir = this.inputDir;
 
 		debugDev("getLocalDataPaths(%o)", templatePath);
 		debugDev("parsed.dir: %o", parsed.dir);

--- a/src/Data/TemplateData.js
+++ b/src/Data/TemplateData.js
@@ -21,7 +21,6 @@ class TemplateDataConfigError extends EleventyBaseError {}
 class TemplateDataParseError extends EleventyBaseError {}
 
 class TemplateData {
-	// TODO directorynorm
 	constructor(eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new TemplateDataConfigError("Missing `config`.");

--- a/src/Data/TemplateData.js
+++ b/src/Data/TemplateData.js
@@ -22,7 +22,7 @@ class TemplateDataParseError extends EleventyBaseError {}
 
 class TemplateData {
 	// TODO directorynorm
-	constructor(inputDir, eleventyConfig) {
+	constructor(eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new TemplateDataConfigError("Missing `config`.");
 		}

--- a/src/Data/TemplateDataInitialGlobalData.js
+++ b/src/Data/TemplateDataInitialGlobalData.js
@@ -11,8 +11,8 @@ class TemplateDataConfigError extends EleventyBaseError {}
 
 class TemplateDataInitialGlobalData {
 	constructor(templateConfig) {
-		if (!templateConfig) {
-			throw new TemplateDataConfigError("Missing `config`.");
+		if (!templateConfig || templateConfig.constructor.name !== "TemplateConfig") {
+			throw new TemplateDataConfigError("Missing or invalid `templateConfig` (via Render plugin).");
 		}
 		this.templateConfig = templateConfig;
 		this.config = this.templateConfig.getConfig();

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -436,12 +436,7 @@ class Eleventy {
 		}
 		this.templateData.setFileSystemSearch(this.fileSystemSearch);
 
-		this.eleventyFiles = new EleventyFiles(
-			this.inputDir,
-			this.outputDir,
-			formats,
-			this.eleventyConfig,
-		);
+		this.eleventyFiles = new EleventyFiles(formats, this.eleventyConfig);
 		this.eleventyFiles.setFileSystemSearch(this.fileSystemSearch);
 		this.eleventyFiles.setRunMode(this.runMode);
 		this.eleventyFiles.extensionMap = this.extensionMap;

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -1211,6 +1211,7 @@ Arguments:
 
 		try {
 			let eventsArg = {
+				// TODO directorynorm
 				inputDir: this.config.inputDir,
 				dir: this.config.dir,
 				runMode: this.runMode,

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -451,18 +451,7 @@ class Eleventy {
 		}
 
 		// Note these directories are all project root relative
-		// TODO directorynorm
-		let dirs = {
-			input: this.inputDir,
-			data: this.templateData.getDataDir(),
-			includes: this.eleventyFiles.getIncludesDir(),
-			layouts: this.eleventyFiles.getLayoutsDir(),
-			output: this.outputDir,
-		};
-
-		// eleventy.directories in global data
-		this.templateData.setGlobalDataDirectories(dirs);
-		this.config.events.emit("eleventy.directories", dirs);
+		this.config.events.emit("eleventy.directories", this.directories.getUserspaceInstance());
 
 		this.writer = new TemplateWriter(formats, this.templateData, this.eleventyConfig);
 
@@ -478,16 +467,18 @@ class Eleventy {
 		this.writer.setRunInitialBuild(this.isRunInitialBuild);
 		this.writer.setIncrementalBuild(this.isIncremental);
 
-		// TODO directorynorm
-		debug(`Directories:
-Input (Dir): ${dirs.input}
-Input (File): ${this.rawInput}
-Data: ${dirs.data}
-Includes: ${dirs.includes}
-Layouts: ${dirs.layouts}
-Output: ${dirs.output}
+		let debugStr = `Directories:
+  Input:
+    Directory: ${this.directories.input}
+    File: ${this.directories.inputFile || false}
+    Glob: ${this.directories.inputGlob || false}
+  Data: ${this.directories.data}
+  Includes: ${this.directories.includes}
+  Layouts: ${this.directories.layouts || false}
+  Output: ${this.directories.output}
 Template Formats: ${formats.join(",")}
-Verbose Output: ${this.verboseMode}`);
+Verbose Output: ${this.verboseMode}`;
+		debug(debugStr);
 
 		this.writer.setVerboseOutput(this.verboseMode);
 		this.writer.setDryRun(this.isDryRun);
@@ -1211,9 +1202,18 @@ Arguments:
 
 		try {
 			let eventsArg = {
-				// TODO directorynorm
-				inputDir: this.config.inputDir,
+				directories: this.directories.getUserspaceInstance(),
+
+				// Deprecated (not normalized), use `directories` instead.
+				get inputDir() {
+					throw new Error(
+						"The `inputDir` property in the `eleventy.before` and `eleventy.after` events has been removed. Use `directories.input` instead.",
+					);
+				},
+
+				// Deprecated (not normalized) use `directories` instead.
 				dir: this.config.dir,
+
 				runMode: this.runMode,
 				outputMode: to,
 				incremental: this.isIncremental,

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -1201,15 +1201,12 @@ Arguments:
 		let hasError = false;
 
 		try {
+			let directories = this.directories.getUserspaceInstance();
 			let eventsArg = {
-				directories: this.directories.getUserspaceInstance(),
+				directories,
 
-				// Deprecated (not normalized), use `directories` instead.
-				get inputDir() {
-					throw new Error(
-						"The `inputDir` property in the `eleventy.before` and `eleventy.after` events has been removed. Use `directories.input` instead.",
-					);
-				},
+				// v3.0.0-alpha.6, changed to use `directories` instead (this was only used by serverless plugin)
+				inputDir: directories.input,
 
 				// Deprecated (not normalized) use `directories` instead.
 				dir: this.config.dir,

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -469,13 +469,7 @@ class Eleventy {
 		this.templateData.setGlobalDataDirectories(dirs);
 		this.config.events.emit("eleventy.directories", dirs);
 
-		this.writer = new TemplateWriter(
-			this.inputDir,
-			this.outputDir,
-			formats,
-			this.templateData,
-			this.eleventyConfig,
-		);
+		this.writer = new TemplateWriter(formats, this.templateData, this.eleventyConfig);
 
 		if (!options.viaConfigReset) {
 			// set or restore cache

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -428,7 +428,7 @@ class Eleventy {
 		// TODO
 		// this.eleventyServe.setWatcherOptions(this.getChokidarConfig());
 
-		this.templateData = new TemplateData(this.inputDir, this.eleventyConfig);
+		this.templateData = new TemplateData(this.eleventyConfig);
 		this.templateData.setProjectUsingEsm(this.isEsm);
 		this.templateData.extensionMap = this.extensionMap;
 		if (this.env) {

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -142,9 +142,6 @@ class EleventyFiles {
 
 	initPassthroughManager() {
 		let mgr = new TemplatePassthroughManager(this.eleventyConfig);
-		// TODO directorynorm (low)
-		mgr.setInputDir(this.inputDir);
-		mgr.setOutputDir(this.outputDir);
 		mgr.setRunMode(this.runMode);
 		mgr.extensionMap = this.extensionMap;
 		mgr.setFileSystemSearch(this.fileSystemSearch);
@@ -166,8 +163,7 @@ class EleventyFiles {
 
 	get templateData() {
 		if (!this._templateData) {
-			// TODO directorynorm (low)
-			this._templateData = new TemplateData(this.inputDir, this.eleventyConfig);
+			this._templateData = new TemplateData(this.eleventyConfig);
 		}
 
 		return this._templateData;
@@ -308,12 +304,12 @@ class EleventyFiles {
 		return Array.from(ignoreFiles);
 	}
 
-	// TODO directorynorm (low)
+	/* Backwards compat */
 	getIncludesDir() {
 		return this.includesDir;
 	}
 
-	// TODO directorynorm (low)
+	/* Backwards compat */
 	getLayoutsDir() {
 		return this.layoutsDir;
 	}

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -24,53 +24,49 @@ class EleventyFiles {
 		this.config = eleventyConfig.getConfig();
 		this.aggregateBench = this.config.benchmarkManager.get("Aggregate");
 
-		this.rawInput = inputDir;
-		this.inputDir = inputDir;
-		this.outputDir = outputDir;
-
-		this.initConfig();
-
 		this.formats = formats;
 		this.eleventyIgnoreContent = false;
+	}
 
-		// init has not yet been called()
-		this.alreadyInit = false;
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	get outputDir() {
+		return this.dirs.output;
+	}
+
+	get includesDir() {
+		return this.dirs.includes;
+	}
+
+	get layoutsDir() {
+		return this.dirs.layouts;
+	}
+
+	get dataDir() {
+		return this.dirs.data;
+	}
+
+	// Backwards compat
+	getDataDir() {
+		return this.dataDir;
 	}
 
 	setFileSystemSearch(fileSystemSearch) {
 		this.fileSystemSearch = fileSystemSearch;
 	}
 
-	/* Overrides this.input and this.inputDir,
-	 * Useful when input is a file and inputDir is not its direct parent */
-	setInput(inputDir, input) {
-		this.inputDir = inputDir;
-		this.rawinput = input;
-
-		this.initConfig();
-
-		if (this.alreadyInit) {
-			this.init();
-		}
-	}
-
-	initConfig() {
-		this.includesDir = TemplatePath.join(this.inputDir, this.config.dir.includes);
-
-		if ("layouts" in this.config.dir) {
-			this.layoutsDir = TemplatePath.join(this.inputDir, this.config.dir.layouts);
-		}
-	}
-
 	init() {
-		this.alreadyInit = true;
-
-		// Input is a directory
-		if (this.rawInput === this.inputDir) {
-			this.templateGlobs = this.extensionMap.getGlobs(this.inputDir);
+		if (this.dirs.inputFile || this.dirs.inputGlob) {
+			this.templateGlobs = TemplateGlob.map([this.dirs.inputFile || this.dirs.inputGlob]);
 		} else {
-			// input is not a directory
-			this.templateGlobs = TemplateGlob.map([this.rawInput]);
+			// Input is a directory
+			this.templateGlobs = this.extensionMap.getGlobs(this.inputDir);
 		}
 
 		this.initPassthroughManager();
@@ -80,11 +76,12 @@ class EleventyFiles {
 	get validTemplateGlobs() {
 		if (!this._validTemplateGlobs) {
 			let globs;
-			// Input is a directory
-			if (this.rawInput === this.inputDir) {
-				globs = this.extensionMap.getValidGlobs(this.inputDir);
-			} else {
+			// Input is a file
+			if (this.inputFile) {
 				globs = this.templateGlobs;
+			} else {
+				// input is a directory
+				globs = this.extensionMap.getValidGlobs(this.inputDir);
 			}
 			this._validTemplateGlobs = globs;
 		}
@@ -116,8 +113,8 @@ class EleventyFiles {
 			config.ignores = new Set();
 			config.ignores.add("**/node_modules/**");
 		}
+
 		this.config = config;
-		this.initConfig();
 	}
 
 	/* Set command root for local project paths */
@@ -145,6 +142,7 @@ class EleventyFiles {
 
 	initPassthroughManager() {
 		let mgr = new TemplatePassthroughManager(this.eleventyConfig);
+		// TODO directorynorm (low)
 		mgr.setInputDir(this.inputDir);
 		mgr.setOutputDir(this.outputDir);
 		mgr.setRunMode(this.runMode);
@@ -168,15 +166,11 @@ class EleventyFiles {
 
 	get templateData() {
 		if (!this._templateData) {
+			// TODO directorynorm (low)
 			this._templateData = new TemplateData(this.inputDir, this.eleventyConfig);
 		}
+
 		return this._templateData;
-	}
-
-	getDataDir() {
-		let data = this.templateData;
-
-		return data.getDataDir();
 	}
 
 	setupGlobs() {
@@ -296,28 +290,30 @@ class EleventyFiles {
 	}
 
 	getIgnoreFiles() {
-		let ignoreFiles = [];
+		let ignoreFiles = new Set();
 		let rootDirectory = this.localPathRoot || ".";
 
 		if (this.config.useGitIgnore) {
-			ignoreFiles.push(TemplatePath.join(rootDirectory, ".gitignore"));
+			ignoreFiles.add(TemplatePath.join(rootDirectory, ".gitignore"));
 		}
 
 		if (this.eleventyIgnoreContent === false) {
 			let absoluteInputDir = TemplatePath.absolutePath(this.inputDir);
-			ignoreFiles.push(TemplatePath.join(rootDirectory, ".eleventyignore"));
+			ignoreFiles.add(TemplatePath.join(rootDirectory, ".eleventyignore"));
 			if (rootDirectory !== absoluteInputDir) {
-				ignoreFiles.push(TemplatePath.join(this.inputDir, ".eleventyignore"));
+				ignoreFiles.add(TemplatePath.join(this.inputDir, ".eleventyignore"));
 			}
 		}
 
-		return ignoreFiles;
+		return Array.from(ignoreFiles);
 	}
 
+	// TODO directorynorm (low)
 	getIncludesDir() {
 		return this.includesDir;
 	}
 
+	// TODO directorynorm (low)
 	getLayoutsDir() {
 		return this.layoutsDir;
 	}
@@ -363,7 +359,7 @@ class EleventyFiles {
 		// Support for virtual templates added in 3.0
 		if (this.config.virtualTemplates && isPlainObject(this.config.virtualTemplates)) {
 			let virtualTemplates = Object.keys(this.config.virtualTemplates).map((path) => {
-				return this.eleventyConfig.directories.getInputPath(path);
+				return this.dirs.getInputPath(path);
 			});
 
 			paths = paths.concat(virtualTemplates);
@@ -471,25 +467,21 @@ class EleventyFiles {
 	}
 
 	_getIncludesAndDataDirs() {
-		let files = [];
-		// we want this to fail on "" because we don’t want to ignore the
-		// entire input directory when using ""
-		if (this.config.dir.includes) {
-			files = files.concat(TemplateGlob.map(this.includesDir + "/**"));
+		let rawPaths = new Set();
+		rawPaths.add(this.includesDir);
+		if (this.layoutsDir) {
+			rawPaths.add(this.layoutsDir);
 		}
+		rawPaths.add(this.dataDir);
 
-		// we want this to fail on "" because we don’t want to ignore the
-		// entire input directory when using ""
-		if (this.config.dir.layouts) {
-			files = files.concat(TemplateGlob.map(this.layoutsDir + "/**"));
-		}
-
-		if (this.config.dir.data && this.config.dir.data !== ".") {
-			let dataDir = this.getDataDir();
-			files = files.concat(TemplateGlob.map(dataDir + "/**"));
-		}
-
-		return files;
+		return Array.from(rawPaths)
+			.filter((entry) => {
+				// never ignore the input directory (even if config file returns "" for these)
+				return entry && entry !== this.inputDir;
+			})
+			.map((entry) => {
+				return TemplateGlob.map(entry + "**");
+			});
 	}
 }
 

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -15,8 +15,7 @@ const debug = debugUtil("Eleventy:EleventyFiles");
 class EleventyFilesError extends EleventyBaseError {}
 
 class EleventyFiles {
-	// TODO directorynorm
-	constructor(inputDir, outputDir, formats, eleventyConfig) {
+	constructor(formats, eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new EleventyFilesError("Missing `eleventyConfig`` argument.");
 		}

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -435,7 +435,7 @@ class EleventyFiles {
 	/* For `eleventy --watch` */
 	// TODO this isn’t great but reduces complexity avoiding using TemplateData:getLocalDataPaths for each template in the cache
 	async getWatcherTemplateJavaScriptDataFiles() {
-		let globs = await this.templateData.getTemplateJavaScriptDataFileGlob();
+		let globs = this.templateData.getTemplateJavaScriptDataFileGlob();
 		let bench = this.aggregateBench.get("Searching the file system (watching)");
 		bench.before();
 		let results = TemplatePath.addLeadingDotSlashArray(

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -15,6 +15,7 @@ const debug = debugUtil("Eleventy:EleventyFiles");
 class EleventyFilesError extends EleventyBaseError {}
 
 class EleventyFiles {
+	// TODO directorynorm
 	constructor(inputDir, outputDir, formats, eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new EleventyFilesError("Missing `eleventyConfig`` argument.");

--- a/src/Engines/Custom.js
+++ b/src/Engines/Custom.js
@@ -8,8 +8,8 @@ eventBus.on("eleventy.resourceModified", (path) => {
 });
 
 class CustomEngine extends TemplateEngine {
-	constructor(name, dirs, config) {
-		super(name, dirs, config);
+	constructor(name, eleventyConfig) {
+		super(name, eleventyConfig);
 
 		this.entry = this.getExtensionMapEntry();
 		this.needsInit = "init" in this.entry && typeof this.entry.init === "function";

--- a/src/Engines/Html.js
+++ b/src/Engines/Html.js
@@ -1,18 +1,14 @@
 import TemplateEngine from "./TemplateEngine.js";
 
 class Html extends TemplateEngine {
-	constructor(name, dirs, config) {
-		super(name, dirs, config);
+	constructor(name, eleventyConfig) {
+		super(name, eleventyConfig);
 		this.cacheable = true;
 	}
 
 	async compile(str, inputPath, preTemplateEngine) {
 		if (preTemplateEngine) {
-			let engine = await this.engineManager.getEngine(
-				preTemplateEngine,
-				this.dirs,
-				this.extensionMap,
-			);
+			let engine = await this.engineManager.getEngine(preTemplateEngine, this.extensionMap);
 			let fnReady = engine.compile(str, inputPath);
 
 			return async function (data) {

--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -12,8 +12,8 @@ class JavaScript extends TemplateEngine {
 	// which data keys to bind to `this` in JavaScript template functions
 	static DATA_KEYS_TO_BIND = ["page", "eleventy"];
 
-	constructor(name, dirs, config) {
-		super(name, dirs, config);
+	constructor(name, eleventyConfig) {
+		super(name, eleventyConfig);
 		this.instances = {};
 
 		this.cacheable = false;

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -16,8 +16,8 @@ class Liquid extends TemplateEngine {
 		"ignore:whitespace": /[, \t]+/, // includes comma separator
 	};
 
-	constructor(name, dirs, config) {
-		super(name, dirs, config);
+	constructor(name, eleventyConfig) {
+		super(name, eleventyConfig);
 
 		this.liquidOptions = this.config.liquidOptions || {};
 

--- a/src/Engines/Markdown.js
+++ b/src/Engines/Markdown.js
@@ -3,8 +3,8 @@ import markdownIt from "markdown-it";
 import TemplateEngine from "./TemplateEngine.js";
 
 class Markdown extends TemplateEngine {
-	constructor(name, dirs, config) {
-		super(name, dirs, config);
+	constructor(name, eleventyConfig) {
+		super(name, eleventyConfig);
 
 		this.markdownOptions = {};
 
@@ -56,11 +56,7 @@ class Markdown extends TemplateEngine {
 		if (preTemplateEngine) {
 			let engine;
 			if (typeof preTemplateEngine === "string") {
-				engine = await this.engineManager.getEngine(
-					preTemplateEngine,
-					this.dirs,
-					this.extensionMap,
-				);
+				engine = await this.engineManager.getEngine(preTemplateEngine, this.extensionMap);
 			} else {
 				engine = preTemplateEngine;
 			}

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -7,8 +7,9 @@ import EleventyShortcodeError from "../Errors/EleventyShortcodeError.js";
 import EventBusUtil from "../Util/EventBusUtil.js";
 
 class Nunjucks extends TemplateEngine {
-	constructor(name, dirs, config) {
-		super(name, dirs, config);
+	constructor(name, eleventyConfig) {
+		super(name, eleventyConfig);
+
 		this.nunjucksEnvironmentOptions = this.config.nunjucksEnvironmentOptions || {};
 
 		this.nunjucksPrecompiledTemplates = this.config.nunjucksPrecompiledTemplates || {};

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -44,10 +44,12 @@ class Nunjucks extends TemplateEngine {
 				this.nunjucksEnvironmentOptions,
 			);
 		} else {
-			let fsLoader = new NunjucksLib.FileSystemLoader([
-				super.getIncludesDir(),
-				TemplatePath.getWorkingDir(),
-			]);
+			let paths = new Set();
+			paths.add(super.getIncludesDir());
+			paths.add(TemplatePath.getWorkingDir());
+
+			// Filter out undefined paths
+			let fsLoader = new NunjucksLib.FileSystemLoader(Array.from(paths).filter((entry) => entry));
 
 			this.njkEnv = new NunjucksLib.Environment(fsLoader, this.nunjucksEnvironmentOptions);
 		}

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -12,6 +12,7 @@ class TemplateEngine {
 		}
 
 		this.dirs = dirs;
+
 		this.inputDir = dirs.input;
 		this.includesDir = dirs.includes;
 

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -4,17 +4,8 @@ import EleventyBaseError from "../Errors/EleventyBaseError.js";
 class TemplateEngineConfigError extends EleventyBaseError {}
 
 class TemplateEngine {
-	constructor(name, dirs, eleventyConfig) {
+	constructor(name, eleventyConfig) {
 		this.name = name;
-
-		if (!dirs) {
-			dirs = {};
-		}
-
-		this.dirs = dirs;
-
-		this.inputDir = dirs.input;
-		this.includesDir = dirs.includes;
 
 		this.engineLib = null;
 		this.cacheable = false;
@@ -25,11 +16,24 @@ class TemplateEngine {
 		this.eleventyConfig = eleventyConfig;
 	}
 
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	get includesDir() {
+		return this.dirs.includes;
+	}
+
 	get config() {
-		if (this.eleventyConfig.constructor.name === "TemplateConfig") {
-			return this.eleventyConfig.getConfig();
+		if (this.eleventyConfig.constructor.name !== "TemplateConfig") {
+			throw new Error("Expecting a TemplateConfig instance.");
 		}
-		throw new Error("Expecting a TemplateConfig instance.");
+
+		return this.eleventyConfig.getConfig();
 	}
 
 	get benchmarks() {
@@ -78,6 +82,7 @@ class TemplateEngine {
 		return this.name;
 	}
 
+	// Backwards compat
 	getIncludesDir() {
 		return this.includesDir;
 	}

--- a/src/Engines/TemplateEngineManager.js
+++ b/src/Engines/TemplateEngineManager.js
@@ -5,8 +5,8 @@ class TemplateEngineManagerConfigError extends EleventyBaseError {}
 
 class TemplateEngineManager {
 	constructor(eleventyConfig) {
-		if (!eleventyConfig) {
-			throw new TemplateEngineManagerConfigError("Missing `config` argument.");
+		if (!eleventyConfig || eleventyConfig.constructor.name !== "TemplateConfig") {
+			throw new TemplateEngineManagerConfigError("Missing or invalid `config` argument.");
 		}
 		this.eleventyConfig = eleventyConfig;
 
@@ -98,9 +98,9 @@ class TemplateEngineManager {
 		return this._CustomEngine;
 	}
 
-	async getEngine(name, dirs, extensionMap) {
+	async getEngine(name, extensionMap) {
 		if (!this.hasEngine(name)) {
-			throw new Error(`Template Engine ${name} does not exist in getEngine (dirs: ${dirs})`);
+			throw new Error(`Template Engine ${name} does not exist in getEngine()`);
 		}
 
 		// TODO these cached engines should be based on extensions not name, then we can remove the error in
@@ -110,7 +110,7 @@ class TemplateEngineManager {
 		}
 
 		let cls = await this.getEngineClassByExtension(name);
-		let instance = new cls(name, dirs, this.eleventyConfig);
+		let instance = new cls(name, this.eleventyConfig);
 		instance.extensionMap = extensionMap;
 		instance.engineManager = this;
 
@@ -123,7 +123,7 @@ class TemplateEngineManager {
 			instance.constructor.name !== "CustomEngine"
 		) {
 			let CustomEngine = await this.getCustomEngineClass();
-			let overrideCustomEngine = new CustomEngine(name, dirs, this.eleventyConfig);
+			let overrideCustomEngine = new CustomEngine(name, this.eleventyConfig);
 			// Keep track of the "default" engine 11ty would normally use
 			// This allows the user to access the default engine in their override
 			overrideCustomEngine.setDefaultEngine(instance);

--- a/src/Plugins/InputPathToUrl.js
+++ b/src/Plugins/InputPathToUrl.js
@@ -1,6 +1,5 @@
 import { TemplatePath } from "@11ty/eleventy-utils";
 
-// TODO directorynorm
 function normalizeInputPath(inputPath, inputDir, contentMap) {
 	// inputDir is optional at the beginning of the developer supplied-path
 

--- a/src/Plugins/InputPathToUrl.js
+++ b/src/Plugins/InputPathToUrl.js
@@ -29,16 +29,12 @@ function FilterPlugin(eleventyConfig) {
 		contentMap = inputPathToUrl;
 	});
 
-	let inputDir;
-	eleventyConfig.on("eleventy.directories", function ({ input }) {
-		inputDir = input;
-	});
-
 	eleventyConfig.addFilter("inputPathToUrl", function (filepath) {
 		if (!contentMap) {
 			throw new Error("Internal error: contentMap not available for `inputPathToUrl` filter.");
 		}
 
+		let inputDir = eleventyConfig.directories.input;
 		filepath = normalizeInputPath(filepath, inputDir, contentMap);
 
 		let urls = contentMap[filepath];
@@ -63,15 +59,11 @@ function TransformPlugin(eleventyConfig, defaultOptions = {}) {
 		contentMap = inputPathToUrl;
 	});
 
-	let inputDir;
-	eleventyConfig.on("eleventy.directories", function ({ input }) {
-		inputDir = input;
-	});
-
 	eleventyConfig.htmlTransformer.addUrlTransform(opts.extensions, function (filepathOrUrl) {
 		if (!contentMap) {
 			throw new Error("Internal error: contentMap not available for the `pathToUrl` Transform.");
 		}
+		let inputDir = eleventyConfig.directories.input;
 		filepathOrUrl = normalizeInputPath(filepathOrUrl, inputDir, contentMap);
 
 		let urls = contentMap[filepathOrUrl];

--- a/src/Plugins/InputPathToUrl.js
+++ b/src/Plugins/InputPathToUrl.js
@@ -1,5 +1,6 @@
 import { TemplatePath } from "@11ty/eleventy-utils";
 
+// TODO directorynorm
 function normalizeInputPath(inputPath, inputDir, contentMap) {
 	// inputDir is optional at the beginning of the developer supplied-path
 

--- a/src/Plugins/RenderPlugin.js
+++ b/src/Plugins/RenderPlugin.js
@@ -12,6 +12,7 @@ import { ProxyWrap } from "../Util/ProxyWrap.js";
 import TemplateDataInitialGlobalData from "../Data/TemplateDataInitialGlobalData.js";
 import EleventyShortcodeError from "../Errors/EleventyShortcodeError.js";
 import TemplateRender from "../TemplateRender.js";
+import ProjectDirectories from "../Util/ProjectDirectories.js";
 import TemplateConfig from "../TemplateConfig.js";
 import EleventyErrorUtil from "../Errors/EleventyErrorUtil.js";
 import Liquid from "../Engines/Liquid.js";
@@ -19,6 +20,7 @@ import Liquid from "../Engines/Liquid.js";
 async function compile(content, templateLang, { templateConfig, extensionMap } = {}) {
 	if (!templateConfig) {
 		templateConfig = new TemplateConfig(null, false);
+		templateConfig.setDirectories(new ProjectDirectories());
 		await templateConfig.init();
 	}
 
@@ -64,6 +66,7 @@ async function compileFile(inputPath, { templateConfig, extensionMap, config } =
 	let wasTemplateConfigMissing = false;
 	if (!templateConfig) {
 		templateConfig = new TemplateConfig(null, false);
+		templateConfig.setDirectories(new ProjectDirectories());
 		wasTemplateConfigMissing = true;
 	}
 	if (config && typeof config === "function") {
@@ -375,6 +378,7 @@ function EleventyPlugin(eleventyConfig, options = {}) {
 class RenderManager {
 	constructor() {
 		this.templateConfig = new TemplateConfig(null, false);
+		this.templateConfig.setDirectories(new ProjectDirectories());
 
 		// This is the only plugin running on the Edge
 		this.templateConfig.userConfig.addPlugin(EleventyPlugin, {

--- a/src/Plugins/RenderPlugin.js
+++ b/src/Plugins/RenderPlugin.js
@@ -27,16 +27,7 @@ async function compile(content, templateLang, { templateConfig, extensionMap } =
 		templateLang = this.page.templateSyntax;
 	}
 
-	let inputDir;
-
-	// templateConfig *may* already be a userconfig
-	if (templateConfig.constructor.name === "TemplateConfig") {
-		inputDir = templateConfig.getConfig().dir.input;
-	} else {
-		inputDir = templateConfig?.dir?.input;
-	}
-
-	let tr = new TemplateRender(templateLang, inputDir, templateConfig);
+	let tr = new TemplateRender(templateLang, templateConfig);
 	tr.extensionMap = extensionMap;
 	if (templateLang) {
 		await tr.setEngineOverride(templateLang);
@@ -82,8 +73,7 @@ async function compileFile(inputPath, { templateConfig, extensionMap, config } =
 		await templateConfig.init();
 	}
 
-	let cfg = templateConfig.getConfig();
-	let tr = new TemplateRender(inputPath, cfg.dir.input, templateConfig);
+	let tr = new TemplateRender(inputPath, templateConfig);
 	tr.extensionMap = extensionMap;
 
 	if (templateLang) {

--- a/src/Template.js
+++ b/src/Template.js
@@ -72,9 +72,6 @@ class Template extends TemplateContent {
 
 	setTemplateData(templateData) {
 		this.templateData = templateData;
-		if (this.templateData) {
-			this.templateData.setInputDir(this.inputDir);
-		}
 	}
 
 	get existsCache() {

--- a/src/Template.js
+++ b/src/Template.js
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 
 import fs from "graceful-fs";
-import normalize from "normalize-path";
 import lodash from "@11ty/lodash-custom";
 import { DateTime } from "luxon";
 import { TemplatePath, isPlainObject } from "@11ty/eleventy-utils";
@@ -34,6 +33,7 @@ const debugDev = debugUtil("Dev:Eleventy:Template");
 class EleventyTransformError extends EleventyBaseError {}
 
 class Template extends TemplateContent {
+	// TODO directorynorm
 	constructor(templatePath, inputDir, outputDir, templateData, extensionMap, config) {
 		debugDev("new Template(%o)", templatePath);
 		super(templatePath, inputDir, config);
@@ -42,12 +42,6 @@ class Template extends TemplateContent {
 
 		// for pagination
 		this.extraOutputSubdirectory = "";
-
-		if (outputDir) {
-			this.outputDir = normalize(outputDir);
-		} else {
-			this.outputDir = false;
-		}
 
 		this.extensionMap = extensionMap;
 

--- a/src/Template.js
+++ b/src/Template.js
@@ -60,7 +60,7 @@ class Template extends TemplateContent {
 		this.isDryRun = false;
 		this.writeCount = 0;
 
-		this.fileSlug = new TemplateFileSlug(this.inputPath, this.inputDir, this.extensionMap);
+		this.fileSlug = new TemplateFileSlug(this.inputPath, this.extensionMap, this.eleventyConfig);
 		this.fileSlugStr = this.fileSlug.getSlug();
 		this.filePathStem = this.fileSlug.getFullPathWithoutExtension();
 

--- a/src/Template.js
+++ b/src/Template.js
@@ -33,10 +33,9 @@ const debugDev = debugUtil("Dev:Eleventy:Template");
 class EleventyTransformError extends EleventyBaseError {}
 
 class Template extends TemplateContent {
-	// TODO directorynorm
-	constructor(templatePath, inputDir, outputDir, templateData, extensionMap, config) {
+	constructor(templatePath, templateData, extensionMap, config) {
 		debugDev("new Template(%o)", templatePath);
-		super(templatePath, inputDir, config);
+		super(templatePath, config);
 
 		this.parsed = path.parse(templatePath);
 
@@ -137,12 +136,7 @@ class Template extends TemplateContent {
 
 	getLayout(layoutKey) {
 		// already cached downstream in TemplateLayout -> TemplateCache
-		return TemplateLayout.getTemplate(
-			layoutKey,
-			this.getInputDir(),
-			this.eleventyConfig,
-			this.extensionMap,
-		);
+		return TemplateLayout.getTemplate(layoutKey, this.eleventyConfig, this.extensionMap);
 	}
 
 	get baseFile() {
@@ -854,8 +848,6 @@ class Template extends TemplateContent {
 		// TODO do we need to even run the constructor here or can we simplify it even more
 		let tmpl = new Template(
 			this.inputPath,
-			this.inputDir,
-			this.outputDir,
 			this.templateData,
 			this.extensionMap,
 			this.eleventyConfig,

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -100,6 +100,11 @@ class TemplateConfig {
 		this.directories = directories;
 	}
 
+	/* Backwards compat */
+	get inputDir() {
+		return this.directories.input;
+	}
+
 	/**
 	 * Normalises local project config file path.
 	 *
@@ -120,14 +125,6 @@ class TemplateConfig {
 			return TemplatePath.addLeadingDotSlashArray(this.projectConfigPaths.filter((path) => path));
 		}
 		return [];
-	}
-
-	get inputDir() {
-		return this._inputDir;
-	}
-
-	set inputDir(inputDir) {
-		this._inputDir = inputDir;
 	}
 
 	setProjectUsingEsm(isEsmProject) {
@@ -326,16 +323,7 @@ class TemplateConfig {
 					// debug( "localConfig is a function, after calling, this.userConfig is %o", this.userConfig );
 				}
 
-				// Still using removed `filters`? this was renamed to transforms
-				if (
-					localConfig &&
-					localConfig.filters !== undefined &&
-					Object.keys(localConfig.filters).length
-				) {
-					throw new EleventyConfigError(
-						"The `filters` configuration option was renamed in Eleventy 0.3.3 and removed in Eleventy 1.0. Please use the `addTransform` configuration method instead. Read more: https://www.11ty.dev/docs/config/#transforms",
-					);
-				}
+				// Removed a check for `filters` in 3.0.0-alpha.6 (now using addTransform instead) https://www.11ty.dev/docs/config/#transforms
 			} catch (err) {
 				// TODO the error message here is bad and I feel bad (needs more accurate info)
 				throw new EleventyConfigError(
@@ -384,6 +372,11 @@ class TemplateConfig {
 		// Returning a falsy value (e.g. "") from user config should reset to the default value.
 		if (!mergedConfig.pathPrefix) {
 			mergedConfig.pathPrefix = this.rootConfig.pathPrefix;
+		}
+
+		// Add the ProjectDirectories instance to the user accessible config.
+		if (this.directories) {
+			mergedConfig.directories = this.directories.getUserspaceInstance();
 		}
 
 		// Delay processing plugins until after the result of localConfig is returned

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -95,6 +95,11 @@ class TemplateConfig {
 		this.logger = logger;
 	}
 
+	/* Setter for Directories instance */
+	setDirectories(directories) {
+		this.directories = directories;
+	}
+
 	/**
 	 * Normalises local project config file path.
 	 *

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -376,7 +376,9 @@ class TemplateConfig {
 
 		// Add the ProjectDirectories instance to the user accessible config.
 		if (this.directories) {
-			mergedConfig.directories = this.directories.getUserspaceInstance();
+			let dirs = this.directories.getUserspaceInstance();
+			mergedConfig.directories = dirs;
+			this.userConfig.directories = dirs;
 		}
 
 		// Delay processing plugins until after the result of localConfig is returned

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -98,6 +98,7 @@ class TemplateConfig {
 	/* Setter for Directories instance */
 	setDirectories(directories) {
 		this.directories = directories;
+		this.userConfig.directories = directories.getUserspaceInstance();
 	}
 
 	/* Backwards compat */
@@ -374,11 +375,10 @@ class TemplateConfig {
 			mergedConfig.pathPrefix = this.rootConfig.pathPrefix;
 		}
 
-		// Add the ProjectDirectories instance to the user accessible config.
+		// This is not set in UserConfig.js so that getters aren’t converted to strings
+		// We want to error if someone attempts to use a setter there.
 		if (this.directories) {
-			let dirs = this.directories.getUserspaceInstance();
-			mergedConfig.directories = dirs;
-			this.userConfig.directories = dirs;
+			mergedConfig.directories = this.directories.getUserspaceInstance();
 		}
 
 		// Delay processing plugins until after the result of localConfig is returned

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -34,6 +34,7 @@ class TemplateContent {
 
 		this.inputPath = inputPath;
 
+		// TODO directorynorm
 		if (inputDir) {
 			this.inputDir = normalize(inputDir);
 		} else {

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -2,7 +2,6 @@ import os from "node:os";
 import util from "node:util";
 
 import fs from "graceful-fs";
-import normalize from "normalize-path";
 import matter from "gray-matter";
 import lodash from "@11ty/lodash-custom";
 import { TemplatePath } from "@11ty/eleventy-utils";
@@ -26,6 +25,7 @@ class TemplateContentCompileError extends EleventyBaseError {}
 class TemplateContentRenderError extends EleventyBaseError {}
 
 class TemplateContent {
+	// TODO directorynorm
 	constructor(inputPath, inputDir, config) {
 		if (!config) {
 			throw new TemplateContentConfigError("Missing `config` argument to TemplateContent");
@@ -33,13 +33,18 @@ class TemplateContent {
 		this.eleventyConfig = config;
 
 		this.inputPath = inputPath;
+	}
 
-		// TODO directorynorm
-		if (inputDir) {
-			this.inputDir = normalize(inputDir);
-		} else {
-			this.inputDir = false;
-		}
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	get outputDir() {
+		return this.dirs.output;
 	}
 
 	getResetTypes(types) {

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -166,11 +166,14 @@ class TemplateContent {
 	}
 
 	isVirtualTemplate() {
-		return !!this.config.virtualTemplates[this.inputPath];
+		let def = this.getVirtualTemplateDefinition();
+		return !!def;
 	}
 
 	getVirtualTemplateDefinition() {
-		return this.config.virtualTemplates[this.inputPath];
+		let inputDirRelativeInputPath =
+			this.eleventyConfig.directories.getInputPathRelativeToInputDirectory(this.inputPath);
+		return this.config.virtualTemplates[inputDirRelativeInputPath];
 	}
 
 	async read() {
@@ -266,8 +269,9 @@ class TemplateContent {
 			return "";
 		}
 
-		if (this.isVirtualTemplate()) {
-			let { content } = this.getVirtualTemplateDefinition();
+		let virtualTemplateDefinition = this.getVirtualTemplateDefinition();
+		if (virtualTemplateDefinition) {
+			let { content } = virtualTemplateDefinition;
 			return content;
 		}
 
@@ -313,9 +317,10 @@ class TemplateContent {
 
 					let extraData = await this.engine.getExtraDataFromFile(this.inputPath);
 
-					let virtualTemplateData = null;
-					if (this.isVirtualTemplate()) {
-						virtualTemplateData = this.getVirtualTemplateDefinition().data;
+					let virtualTemplateDefinition = this.getVirtualTemplateDefinition();
+					let virtualTemplateData;
+					if (virtualTemplateDefinition) {
+						virtualTemplateData = virtualTemplateDefinition.data;
 					}
 
 					let data = TemplateData.mergeDeep({}, fm.data, extraData, virtualTemplateData);

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -132,7 +132,7 @@ class TemplateContent {
 
 	async getTemplateRender() {
 		if (!this._templateRender) {
-			this._templateRender = new TemplateRender(this.inputPath, this.inputDir, this.eleventyConfig);
+			this._templateRender = new TemplateRender(this.inputPath, this.eleventyConfig);
 			this._templateRender.extensionMap = this.extensionMap;
 			await this._templateRender.init();
 		}

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -25,13 +25,13 @@ class TemplateContentCompileError extends EleventyBaseError {}
 class TemplateContentRenderError extends EleventyBaseError {}
 
 class TemplateContent {
-	// TODO directorynorm
-	constructor(inputPath, inputDir, config) {
-		if (!config) {
-			throw new TemplateContentConfigError("Missing `config` argument to TemplateContent");
+	constructor(inputPath, templateConfig) {
+		if (!templateConfig || templateConfig.constructor.name !== "TemplateConfig") {
+			throw new TemplateContentConfigError(
+				"Missing or invalid `templateConfig` argument to TemplateContent",
+			);
 		}
-		this.eleventyConfig = config;
-
+		this.eleventyConfig = templateConfig;
 		this.inputPath = inputPath;
 	}
 

--- a/src/TemplateFileSlug.js
+++ b/src/TemplateFileSlug.js
@@ -2,7 +2,9 @@ import path from "node:path";
 import { TemplatePath } from "@11ty/eleventy-utils";
 
 class TemplateFileSlug {
-	constructor(inputPath, inputDir, extensionMap) {
+	// TODO directorynorm
+	constructor(inputPath, extensionMap, eleventyConfig) {
+		let inputDir = eleventyConfig.directories.input;
 		if (inputDir) {
 			inputPath = TemplatePath.stripLeadingSubPath(inputPath, inputDir);
 		}

--- a/src/TemplateFileSlug.js
+++ b/src/TemplateFileSlug.js
@@ -2,7 +2,6 @@ import path from "node:path";
 import { TemplatePath } from "@11ty/eleventy-utils";
 
 class TemplateFileSlug {
-	// TODO directorynorm
 	constructor(inputPath, extensionMap, eleventyConfig) {
 		let inputDir = eleventyConfig.directories.input;
 		if (inputDir) {

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -12,7 +12,7 @@ const debugDev = debugUtil("Dev:Eleventy:TemplateLayout");
 class TemplateLayout extends TemplateContent {
 	// TODO directorynorm
 	constructor(key, inputDir, extensionMap, eleventyConfig) {
-		if (!eleventyConfig) {
+		if (!eleventyConfig || eleventyConfig.constructor.name !== "TemplateConfig") {
 			throw new Error("Expected `eleventyConfig` in TemplateLayout constructor.");
 		}
 

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -10,8 +10,7 @@ import templateCache from "./TemplateCache.js";
 const debugDev = debugUtil("Dev:Eleventy:TemplateLayout");
 
 class TemplateLayout extends TemplateContent {
-	// TODO directorynorm
-	constructor(key, inputDir, extensionMap, eleventyConfig) {
+	constructor(key, extensionMap, eleventyConfig) {
 		if (!eleventyConfig || eleventyConfig.constructor.name !== "TemplateConfig") {
 			throw new Error("Expected `eleventyConfig` in TemplateLayout constructor.");
 		}
@@ -19,7 +18,7 @@ class TemplateLayout extends TemplateContent {
 		let resolver = new TemplateLayoutPathResolver(key, extensionMap, eleventyConfig);
 		let resolvedPath = resolver.getFullPath();
 
-		super(resolvedPath, inputDir, eleventyConfig);
+		super(resolvedPath, eleventyConfig);
 
 		if (!extensionMap) {
 			throw new Error("Expected `extensionMap` in TemplateLayout constructor.");
@@ -47,15 +46,16 @@ class TemplateLayout extends TemplateContent {
 		return TemplatePath.join(inputDir, key);
 	}
 
-	static getTemplate(key, inputDir, eleventyConfig, extensionMap) {
+	static getTemplate(key, eleventyConfig, extensionMap) {
 		let config = eleventyConfig.getConfig();
 		if (!config.useTemplateCache) {
-			return new TemplateLayout(key, inputDir, extensionMap, eleventyConfig);
+			return new TemplateLayout(key, extensionMap, eleventyConfig);
 		}
 
+		let inputDir = eleventyConfig.directories.input;
 		let fullKey = TemplateLayout.resolveFullKey(key, inputDir);
 		if (!templateCache.has(fullKey)) {
-			let layout = new TemplateLayout(key, inputDir, extensionMap, eleventyConfig);
+			let layout = new TemplateLayout(key, extensionMap, eleventyConfig);
 
 			templateCache.add(layout);
 			debugDev("Added %o to TemplateCache", key);
@@ -70,7 +70,6 @@ class TemplateLayout extends TemplateContent {
 		return {
 			// Used by `TemplateLayout.getTemplate()`
 			key: this.dataKeyLayoutPath,
-			inputDir: this.inputDir,
 
 			// used by `this.getData()`
 			frontMatterData: await this.getFrontMatterData(),
@@ -97,7 +96,6 @@ class TemplateLayout extends TemplateContent {
 
 						let layout = TemplateLayout.getTemplate(
 							parentLayoutKey,
-							mapEntry.inputDir,
 							this.eleventyConfig,
 							this.extensionMap,
 						);
@@ -190,11 +188,10 @@ class TemplateLayout extends TemplateContent {
 
 			if (layoutMap.length > 1) {
 				let [, /*currentLayout*/ parentLayout] = layoutMap;
-				let { key, inputDir } = parentLayout;
+				let { key } = parentLayout;
 
 				let layoutTemplate = TemplateLayout.getTemplate(
 					key,
-					inputDir,
 					this.eleventyConfig,
 					this.extensionMap,
 				);

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -16,7 +16,7 @@ class TemplateLayout extends TemplateContent {
 			throw new Error("Expected `eleventyConfig` in TemplateLayout constructor.");
 		}
 
-		let resolver = new TemplateLayoutPathResolver(key, inputDir, extensionMap, eleventyConfig);
+		let resolver = new TemplateLayoutPathResolver(key, extensionMap, eleventyConfig);
 		let resolvedPath = resolver.getFullPath();
 
 		super(resolvedPath, inputDir, eleventyConfig);
@@ -29,7 +29,6 @@ class TemplateLayout extends TemplateContent {
 		this.key = resolver.getNormalizedLayoutKey();
 		this.dataKeyLayoutPath = key;
 		this.inputPath = resolvedPath;
-		this.inputDir = inputDir;
 	}
 
 	getKey() {

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -10,6 +10,7 @@ import templateCache from "./TemplateCache.js";
 const debugDev = debugUtil("Dev:Eleventy:TemplateLayout");
 
 class TemplateLayout extends TemplateContent {
+	// TODO directorynorm
 	constructor(key, inputDir, extensionMap, eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new Error("Expected `eleventyConfig` in TemplateLayout constructor.");

--- a/src/TemplateLayoutPathResolver.js
+++ b/src/TemplateLayoutPathResolver.js
@@ -4,6 +4,7 @@ import { TemplatePath } from "@11ty/eleventy-utils";
 // const debug = debugUtil("Eleventy:TemplateLayoutPathResolver");
 
 class TemplateLayoutPathResolver {
+	// TODO directorynorm
 	constructor(path, inputDir, extensionMap, eleventyConfig) {
 		if (!eleventyConfig) {
 			throw new Error("Expected `eleventyConfig` in TemplateLayoutPathResolver constructor");
@@ -115,6 +116,7 @@ class TemplateLayoutPathResolver {
 		}
 	}
 
+	// TODO directorynorm
 	getLayoutsDir() {
 		let layoutsDir;
 		if ("layouts" in this.config.dir) {

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -21,12 +21,14 @@ class TemplatePassthrough {
 	#isExistsCache = {};
 	#isDirectoryCache = {};
 
-	// TODO directorynorm
-	constructor(path, outputDir, inputDir, config) {
-		if (!config) {
-			throw new TemplatePassthroughError("Missing `config`.");
+	constructor(path, eleventyConfig) {
+		if (!eleventyConfig || eleventyConfig.constructor.name !== "TemplateConfig") {
+			throw new TemplatePassthroughError(
+				"Missing `eleventyConfig` or was not an instance of `TemplateConfig`.",
+			);
 		}
-		this.config = config;
+		this.eleventyConfig = eleventyConfig;
+
 		this.benchmarks = {
 			aggregate: this.config.benchmarkManager.get("Aggregate"),
 		};
@@ -38,16 +40,29 @@ class TemplatePassthrough {
 		this.inputPath = this.normalizeDirectory(path.inputPath);
 		this.isInputPathGlob = isGlob(this.inputPath);
 
-		// inputDir is only used when stripping from output path in `getOutputPath`
-		this.inputDir = inputDir;
-
 		this.outputPath = path.outputPath;
-		this.outputDir = outputDir;
 
 		this.copyOptions = path.copyOptions; // custom options for recursive-copy
 
 		this.isDryRun = false;
 		this.isIncremental = false;
+	}
+
+	get config() {
+		return this.eleventyConfig.getConfig();
+	}
+
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	// inputDir is used when stripping from output path in `getOutputPath`
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	get outputDir() {
+		return this.dirs.output;
 	}
 
 	/* { inputPath, outputPath } though outputPath is *not* the full path: just the output directory */

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -91,6 +91,7 @@ class TemplatePassthrough {
 			fullOutputPath = ProjectDirectories.normalizeDirectory(fullOutputPath);
 		}
 
+		// TODO room for improvement here:
 		if (
 			!this.isInputPathGlob &&
 			(await fsExists(inputPath)) &&

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -21,6 +21,7 @@ class TemplatePassthrough {
 	#isExistsCache = {};
 	#isDirectoryCache = {};
 
+	// TODO directorynorm
 	constructor(path, outputDir, inputDir, config) {
 		if (!config) {
 			throw new TemplatePassthroughError("Missing `config`.");

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -42,13 +42,25 @@ class TemplatePassthroughManager {
 		return this._extensionMap;
 	}
 
-	setOutputDir(outputDir) {
-		this.outputDir = outputDir;
+	get dirs() {
+		return this.eleventyConfig.directories;
 	}
 
-	setInputDir(inputDir) {
-		this.inputDir = inputDir;
+	get inputDir() {
+		return this.dirs.input;
 	}
+
+	get outputDir() {
+		return this.dirs.output;
+	}
+
+	// setOutputDir(outputDir) {
+	// 	this.outputDir = outputDir;
+	// }
+
+	// setInputDir(inputDir) {
+	// 	this.inputDir = inputDir;
+	// }
 
 	setDryRun(isDryRun) {
 		this.isDryRun = !!isDryRun;

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -16,8 +16,8 @@ class TemplatePassthroughManagerCopyError extends EleventyBaseError {}
 
 class TemplatePassthroughManager {
 	constructor(eleventyConfig) {
-		if (!eleventyConfig) {
-			throw new TemplatePassthroughManagerConfigError("Missing `config` argument.");
+		if (!eleventyConfig || eleventyConfig.constructor.name !== "TemplateConfig") {
+			throw new TemplatePassthroughManagerConfigError("Missing or invalid `config` argument.");
 		}
 		this.eleventyConfig = eleventyConfig;
 		this.config = eleventyConfig.getConfig();
@@ -113,8 +113,7 @@ class TemplatePassthroughManager {
 	}
 
 	getTemplatePassthroughForPath(path, isIncremental = false) {
-		// TODO directorynorm
-		let inst = new TemplatePassthrough(path, this.outputDir, this.inputDir, this.config);
+		let inst = new TemplatePassthrough(path, this.eleventyConfig);
 
 		inst.setFileSystemSearch(this.fileSystemSearch);
 		inst.setIsIncremental(isIncremental);

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -54,14 +54,6 @@ class TemplatePassthroughManager {
 		return this.dirs.output;
 	}
 
-	// setOutputDir(outputDir) {
-	// 	this.outputDir = outputDir;
-	// }
-
-	// setInputDir(inputDir) {
-	// 	this.inputDir = inputDir;
-	// }
-
 	setDryRun(isDryRun) {
 		this.isDryRun = !!isDryRun;
 	}
@@ -121,6 +113,7 @@ class TemplatePassthroughManager {
 	}
 
 	getTemplatePassthroughForPath(path, isIncremental = false) {
+		// TODO directorynorm
 		let inst = new TemplatePassthrough(path, this.outputDir, this.inputDir, this.config);
 
 		inst.setFileSystemSearch(this.fileSystemSearch);

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -69,11 +69,7 @@ class TemplateRender {
 	}
 
 	async getEngineByName(name) {
-		let engine = await this.extensionMap.engineManager.getEngine(
-			name,
-			this.getDirs(),
-			this.extensionMap,
-		);
+		let engine = await this.extensionMap.engineManager.getEngine(name, this.extensionMap);
 		engine.eleventyConfig = this.eleventyConfig;
 
 		return engine;
@@ -247,17 +243,6 @@ class TemplateRender {
 
 	getEngineName() {
 		return this.engineName;
-	}
-
-	getDirs() {
-		if (!this.dirs) {
-			return {};
-		}
-
-		return {
-			input: this.inputDir,
-			includes: this.includesDir,
-		};
 	}
 
 	isEngine(engine) {

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -12,8 +12,7 @@ class TemplateRenderUnknownEngineError extends EleventyBaseError {}
 
 // works with full path names or short engine name
 class TemplateRender {
-	// TODO directorynorm
-	constructor(tmplPath, inputDir, config) {
+	constructor(tmplPath, config) {
 		if (!tmplPath) {
 			throw new Error(`TemplateRender requires a tmplPath argument, instead of ${tmplPath}`);
 		}

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -12,6 +12,7 @@ class TemplateRenderUnknownEngineError extends EleventyBaseError {}
 
 // works with full path names or short engine name
 class TemplateRender {
+	// TODO directorynorm
 	constructor(tmplPath, inputDir, config) {
 		if (!tmplPath) {
 			throw new Error(`TemplateRender requires a tmplPath argument, instead of ${tmplPath}`);
@@ -23,16 +24,30 @@ class TemplateRender {
 			this.eleventyConfig = config;
 			this.config = config.getConfig();
 		} else {
-			this.config = config;
+			throw new Error("Third argument to TemplateRender must be a TemplateConfig instance.");
 		}
 
 		this.engineNameOrPath = tmplPath;
 
-		this.inputDir = inputDir ? inputDir : this.config.dir.input;
-		this.includesDir = TemplatePath.join(this.inputDir, this.config.dir.includes);
-
 		this.parseMarkdownWith = this.config.markdownTemplateEngine;
 		this.parseHtmlWith = this.config.htmlTemplateEngine;
+	}
+
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	get includesDir() {
+		return this.dirs.includes;
+	}
+
+	/* Backwards compat */
+	getIncludesDir() {
+		return this.includesDir;
 	}
 
 	get config() {
@@ -236,14 +251,14 @@ class TemplateRender {
 	}
 
 	getDirs() {
+		if (!this.dirs) {
+			return {};
+		}
+
 		return {
 			input: this.inputDir,
 			includes: this.includesDir,
 		};
-	}
-
-	getIncludesDir() {
-		return this.includesDir;
 	}
 
 	isEngine(engine) {

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -1,5 +1,3 @@
-import { TemplatePath } from "@11ty/eleventy-utils";
-
 import EleventyBaseError from "./Errors/EleventyBaseError.js";
 import EleventyExtensionMap from "./EleventyExtensionMap.js";
 import CustomEngine from "./Engines/Custom.js";

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -123,12 +123,7 @@ class TemplateWriter {
 		// usually Eleventy.js will setEleventyFiles with the EleventyFiles manager
 		if (!this._eleventyFiles) {
 			// if not, we can create one (used only by tests)
-			this._eleventyFiles = new EleventyFiles(
-				this.inputDir,
-				this.outputDir,
-				this.templateFormats,
-				this.eleventyConfig,
-			);
+			this._eleventyFiles = new EleventyFiles(this.templateFormats, this.eleventyConfig);
 
 			this._eleventyFiles.setFileSystemSearch(new FileSystemSearch());
 			this._eleventyFiles.init();

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -20,9 +20,6 @@ class EleventyTemplateError extends EleventyBaseError {}
 
 class TemplateWriter {
 	constructor(
-		// TODO directorynorm
-		inputPath,
-		outputDir,
 		templateFormats, // TODO remove this, see `get eleventyFiles` first
 		templateData,
 		eleventyConfig,

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -155,14 +155,7 @@ class TemplateWriter {
 			// TODO reset other constructor things here like inputDir/outputDir/extensionMap/
 			tmpl.setTemplateData(this.templateData);
 		} else {
-			tmpl = new Template(
-				path,
-				this.inputDir,
-				this.outputDir,
-				this.templateData,
-				this.extensionMap,
-				this.eleventyConfig,
-			);
+			tmpl = new Template(path, this.templateData, this.extensionMap, this.eleventyConfig);
 
 			tmpl.setOutputFormat(to);
 

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -20,6 +20,7 @@ class EleventyTemplateError extends EleventyBaseError {}
 
 class TemplateWriter {
 	constructor(
+		// TODO directorynorm
 		inputPath,
 		outputDir,
 		templateFormats, // TODO remove this, see `get eleventyFiles` first
@@ -33,10 +34,6 @@ class TemplateWriter {
 		this.config = eleventyConfig.getConfig();
 		this.userConfig = eleventyConfig.userConfig;
 
-		this.input = inputPath;
-		this.inputDir = TemplatePath.getDir(inputPath);
-		this.outputDir = outputDir;
-
 		this.templateFormats = templateFormats;
 
 		this.templateData = templateData;
@@ -49,11 +46,16 @@ class TemplateWriter {
 		this._templatePathCache = new Map();
 	}
 
-	/* Overrides this.input and this.inputDir
-	 * Useful when input is a file and inputDir is not its direct parent */
-	setInput(inputDir, input) {
-		this.inputDir = inputDir;
-		this.input = input;
+	get dirs() {
+		return this.eleventyConfig.directories;
+	}
+
+	get inputDir() {
+		return this.dirs.input;
+	}
+
+	get outputDir() {
+		return this.dirs.output;
 	}
 
 	get templateFormats() {
@@ -131,7 +133,6 @@ class TemplateWriter {
 				this.eleventyConfig,
 			);
 
-			this._eleventyFiles.setInput(this.inputDir, this.input);
 			this._eleventyFiles.setFileSystemSearch(new FileSystemSearch());
 			this._eleventyFiles.init();
 		}

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -934,6 +934,7 @@ class UserConfig {
 			serverPassthroughCopyBehavior: this.serverPassthroughCopyBehavior,
 			urlTransforms: this.urlTransforms,
 			virtualTemplates: this.virtualTemplates,
+			// `directories` is merged manually prior to plugin processing
 		};
 
 		if (Array.isArray(this.dataFileSuffixesOverride)) {

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -2,6 +2,7 @@ import chalk from "kleur";
 import { DateTime } from "luxon";
 import debugUtil from "debug";
 import { RetrieveGlobals } from "node-retrieve-globals";
+import { TemplatePath } from "@11ty/eleventy-utils";
 
 import EventEmitter from "./Util/AsyncEventEmitter.js";
 import EleventyCompatibility from "./Util/Compatibility.js";
@@ -868,6 +869,11 @@ class UserConfig {
 	}
 
 	addTemplate(virtualInputPath, content, data) {
+		// Lookups keys must be normalized
+		virtualInputPath = TemplatePath.stripLeadingDotSlash(
+			TemplatePath.standardizeFilePath(virtualInputPath),
+		);
+
 		this.virtualTemplates[virtualInputPath] = {
 			inputPath: virtualInputPath,
 			data,

--- a/src/Util/ProjectDirectories.js
+++ b/src/Util/ProjectDirectories.js
@@ -262,6 +262,9 @@ class ProjectDirectories {
 			get inputFile() {
 				return d.inputFile;
 			},
+			get inputGlob() {
+				return d.inputGlob;
+			},
 			get data() {
 				return d.data;
 			},

--- a/src/Util/ProjectDirectories.js
+++ b/src/Util/ProjectDirectories.js
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import { TemplatePath } from "@11ty/eleventy-utils";
+
+/* Directories internally should always use *nix forward slashes */
+class ProjectDirectories {
+	#raw = {};
+
+	#defaults = {
+		input: "./",
+		data: "./_data/",
+		includes: "./_includes/",
+		layouts: "./_layouts/",
+		output: "./_site/",
+	};
+
+	#dirs = {};
+
+	// Must be a directory
+	// Use forward slashes
+	// Always include a trailing slash
+	static normalizeDirectory(dir) {
+		return ProjectDirectories.addTrailingSlash(TemplatePath.standardizeFilePath(dir));
+	}
+
+	static addTrailingSlash(path) {
+		if (path.slice(-1) === "/") {
+			return path;
+		}
+		return path + "/";
+	}
+
+	updateInputDependencies() {
+		// raw first, fall back to Eleventy defaults if not yet set
+		this.setData(this.#raw.data || this.#defaults.data);
+		this.setIncludes(this.#raw.includes || this.#defaults.includes);
+		this.setLayouts(this.#raw.layouts || this.#defaults.layouts);
+	}
+
+	setInputDir(inputDir) {
+		this.#dirs.input = ProjectDirectories.normalizeDirectory(inputDir);
+		this.updateInputDependencies();
+	}
+
+	/* Relative to project root, must exist */
+	setInput(dirOrFile, inputDir = undefined) {
+		if (!dirOrFile) {
+			return;
+		}
+
+		this.#raw.input = dirOrFile;
+
+		// Explicit input dir (may or may not exist)
+		if (inputDir) {
+			this.#dirs.input = ProjectDirectories.normalizeDirectory(inputDir);
+		} else {
+			// Must exist
+			if (!fs.existsSync(dirOrFile)) {
+				throw new Error("Input directory or file must exist.");
+			}
+
+			if (fs.statSync(dirOrFile).isDirectory()) {
+				this.#dirs.input = ProjectDirectories.normalizeDirectory(dirOrFile);
+			} else {
+				// is an input file that exists
+				// the input directory is implied to be the parent directory of the
+				// file, unless inputDir is explicitly specified (via Eleventy `options` argument)
+				this.#dirs.input = ProjectDirectories.normalizeDirectory(
+					TemplatePath.getDirFromFilePath(dirOrFile),
+				);
+			}
+		}
+
+		this.updateInputDependencies();
+	}
+
+	/* Relative to input dir */
+	setIncludes(dir) {
+		if (dir) {
+			this.#raw.includes = dir;
+			this.#dirs.includes = ProjectDirectories.normalizeDirectory(
+				TemplatePath.join(this.input, dir),
+			);
+		}
+	}
+
+	/* Relative to input dir */
+	/* Optional */
+	setLayouts(dir) {
+		if (dir) {
+			this.#raw.layouts = dir;
+			this.#dirs.layouts = ProjectDirectories.normalizeDirectory(
+				TemplatePath.join(this.input, dir),
+			);
+		}
+	}
+
+	/* Relative to input dir */
+	setData(dir) {
+		if (dir) {
+			this.#raw.data = dir;
+			this.#dirs.data = ProjectDirectories.normalizeDirectory(TemplatePath.join(this.input, dir));
+		}
+	}
+
+	/* Relative to project root */
+	setOutput(dir) {
+		if (dir) {
+			this.#raw.output = dir;
+			this.#dirs.output = ProjectDirectories.normalizeDirectory(dir);
+		}
+	}
+
+	get input() {
+		return this.#dirs.input || this.#defaults.input;
+	}
+
+	get data() {
+		return this.#dirs.data || this.#defaults.data;
+	}
+
+	get includes() {
+		return this.#dirs.includes || this.#defaults.includes;
+	}
+
+	get layouts() {
+		return this.#dirs.layouts || this.#defaults.layouts;
+	}
+
+	get output() {
+		return this.#dirs.output || this.#defaults.output;
+	}
+
+	// for a hypothetical template file
+	getInputPath(filePath) {
+		// TODO change ~/ to project root dir
+		return TemplatePath.addLeadingDotSlash(
+			TemplatePath.join(this.input, TemplatePath.standardizeFilePath(filePath)),
+		);
+	}
+
+	// Inverse of getInputPath
+	getInputPathRelativeToInputDirectory(filePath) {
+		let inputDir = TemplatePath.addLeadingDotSlash(TemplatePath.join(this.input));
+		return TemplatePath.stripLeadingSubPath(filePath, inputDir);
+	}
+
+	getProjectPath(filePath) {
+		return TemplatePath.addLeadingDotSlash(
+			TemplatePath.join(".", TemplatePath.standardizeFilePath(filePath)),
+		);
+	}
+}
+
+export default ProjectDirectories;

--- a/src/Util/ProjectDirectories.js
+++ b/src/Util/ProjectDirectories.js
@@ -137,7 +137,7 @@ class ProjectDirectories {
 			} else {
 				if (!isGlob(dirOrFile)) {
 					throw new Error(
-						"The `input` parameter (directory or file path) must exist on the file system (unless detected as a glob by the `is-glob` package)",
+						`The "${dirOrFile}" \`input\` parameter (directory or file path) must exist on the file system (unless detected as a glob by the \`is-glob\` package)`,
 					);
 				}
 

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -104,7 +104,7 @@ export default function (config) {
 
 	return {
 		templateFormats: ["liquid", "md", "njk", "html", "11ty.js"],
-		// if your site lives in a subdirectory, change this
+		// if your site deploys to a subdirectory, change this
 		pathPrefix: "/",
 		markdownTemplateEngine: "liquid",
 		htmlTemplateEngine: "liquid",

--- a/test/EleventyFilesGitIgnoreEleventyIgnoreTest.js
+++ b/test/EleventyFilesGitIgnoreEleventyIgnoreTest.js
@@ -16,7 +16,7 @@ test("Get ignores (no .eleventyignore no .gitignore)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore1", "test/stubs/ignore1/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
@@ -40,7 +40,7 @@ test("Get ignores (no .eleventyignore)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore2", "test/stubs/ignore2/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
 
@@ -64,7 +64,7 @@ test("Get ignores (no .eleventyignore, using setUseGitIgnore(false))", async (t)
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore2", "test/stubs/ignore2/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
@@ -88,7 +88,7 @@ test("Get ignores (no .gitignore)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore3", "test/stubs/ignore3/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
@@ -113,7 +113,7 @@ test("Get ignores (project .eleventyignore and root .gitignore)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore4", "test/stubs/ignore4/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
 
@@ -139,7 +139,7 @@ test("Get ignores (project .eleventyignore and root .gitignore, using setUseGitI
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore4", "test/stubs/ignore4/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
@@ -165,7 +165,7 @@ test("Get ignores (no .eleventyignore  .gitignore exists but empty)", async (t) 
     }
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore5", "test/stubs/ignore5/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
@@ -189,7 +189,7 @@ test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore is
     }
   });
 
-  let evf = new EleventyFiles("test/stubs/ignore6", "test/stubs/ignore6/_site", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
@@ -216,7 +216,7 @@ test("Bad expected output, this indicates a bug upstream in a dependency.  Input
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
+  let evf = new EleventyFiles(["liquid"], eleventyConfig);
   evf.setEleventyIgnoreContent("!" + TemplatePath.absolutePath("test/stubs-403/_includes") + "/**");
 
   evf.setFileSystemSearch(new FileSystemSearch());
@@ -239,7 +239,7 @@ test("Workaround for Bad expected output, this indicates a bug upstream in a dep
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
+  let evf = new EleventyFiles(["liquid"], eleventyConfig);
   evf.setEleventyIgnoreContent("!./test/stubs-403/_includes/**");
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
@@ -257,7 +257,7 @@ test("Issue #403: all .eleventyignores should be relative paths not absolute pat
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
+  let evf = new EleventyFiles(["liquid"], eleventyConfig);
   evf.init();
 
   let globs = await evf.getFileGlobs();
@@ -277,7 +277,7 @@ test("Same input and output directories, issues #186 and #1129", async (t) => {
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs/", undefined, [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   t.deepEqual(
@@ -295,7 +295,7 @@ test("Single input file is in the output directory, issues #186", async (t) => {
     eleventyConfig.setUseGitIgnore(false);
   });
 
-  let evf = new EleventyFiles("test/stubs/test.njk", undefined, ["njk"], eleventyConfig);
+  let evf = new EleventyFiles(["njk"], eleventyConfig);
 
   evf.init();
   t.deepEqual(
@@ -312,12 +312,7 @@ test("De-duplicated ignores", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "test/stubs/ignore-dedupe",
-    undefined,
-    [],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   evf._setLocalPathRoot("./test/stubs/ignore-dedupe");

--- a/test/EleventyFilesGitIgnoreEleventyIgnoreTest.js
+++ b/test/EleventyFilesGitIgnoreEleventyIgnoreTest.js
@@ -3,13 +3,18 @@ import { TemplatePath } from "@11ty/eleventy-utils";
 
 import FileSystemSearch from "../src/FileSystemSearch.js";
 import EleventyFiles from "../src/EleventyFiles.js";
-import TemplateConfig from "../src/TemplateConfig.js";
+
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 /* .eleventyignore and .gitignore combos */
 
 test("Get ignores (no .eleventyignore no .gitignore)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore1",
+      output: "test/stubs/ignore1/_site"
+    }
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore1", "test/stubs/ignore1/_site", [], eleventyConfig);
   evf.init();
@@ -28,8 +33,12 @@ test("Get ignores (no .eleventyignore no .gitignore)", async (t) => {
 });
 
 test("Get ignores (no .eleventyignore)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore2",
+      output: "test/stubs/ignore2/_site"
+    }
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore2", "test/stubs/ignore2/_site", [], eleventyConfig);
   evf.init();
@@ -48,18 +57,16 @@ test("Get ignores (no .eleventyignore)", async (t) => {
 });
 
 test("Get ignores (no .eleventyignore, using setUseGitIgnore(false))", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs/ignore2",
+    output: "test/stubs/ignore2/_site",
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore2", "test/stubs/ignore2/_site", [], eleventyConfig);
   evf.init();
 
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      includes: "_includes",
-    },
-  });
   evf._setLocalPathRoot("./test/stubs/ignorelocalroot");
 
   t.deepEqual(evf.getIgnores(), [
@@ -67,12 +74,19 @@ test("Get ignores (no .eleventyignore, using setUseGitIgnore(false))", async (t)
     "./test/stubs/ignore2/_site/**",
   ]);
 
-  t.deepEqual(evf.getIgnoreGlobs().slice(-1), ["./test/stubs/ignorelocalroot/**/node_modules/**"]);
+  t.deepEqual(evf.getIgnoreGlobs().slice(-2), [
+		"./test/stubs/ignorelocalroot/**/node_modules/**",
+		"./test/stubs/ignorelocalroot/.git/**",
+	]);
 });
 
 test("Get ignores (no .gitignore)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore3",
+      output: "test/stubs/ignore3/_site"
+    }
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore3", "test/stubs/ignore3/_site", [], eleventyConfig);
   evf.init();
@@ -92,8 +106,12 @@ test("Get ignores (no .gitignore)", async (t) => {
 });
 
 test("Get ignores (project .eleventyignore and root .gitignore)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore4",
+      output: "test/stubs/ignore4/_site"
+    }
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore4", "test/stubs/ignore4/_site", [], eleventyConfig);
   evf.init();
@@ -114,18 +132,16 @@ test("Get ignores (project .eleventyignore and root .gitignore)", async (t) => {
 });
 
 test("Get ignores (project .eleventyignore and root .gitignore, using setUseGitIgnore(false))", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+		input: "test/stubs/ignore4",
+		output: "test/stubs/ignore4/_site",
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore4", "test/stubs/ignore4/_site", [], eleventyConfig);
   evf.init();
 
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      includes: "_includes",
-    },
-  });
   evf._setLocalPathRoot("./test/stubs/ignorelocalrootgitignore");
 
   t.deepEqual(evf.getIgnores(), [
@@ -135,14 +151,19 @@ test("Get ignores (project .eleventyignore and root .gitignore, using setUseGitI
     "./test/stubs/ignore4/_site/**",
   ]);
 
-  t.deepEqual(evf.getIgnoreGlobs().slice(-1), [
+  t.deepEqual(evf.getIgnoreGlobs().slice(-2), [
     "./test/stubs/ignorelocalrootgitignore/**/node_modules/**",
+    "./test/stubs/ignorelocalrootgitignore/.git/**",
   ]);
 });
 
 test("Get ignores (no .eleventyignore  .gitignore exists but empty)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore5",
+      output: "test/stubs/ignore5/_site"
+    }
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore5", "test/stubs/ignore5/_site", [], eleventyConfig);
   evf.init();
@@ -161,8 +182,12 @@ test("Get ignores (no .eleventyignore  .gitignore exists but empty)", async (t) 
 });
 
 test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore is empty)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore6",
+      output: "test/stubs/ignore6/_site"
+    }
+  });
 
   let evf = new EleventyFiles("test/stubs/ignore6", "test/stubs/ignore6/_site", [], eleventyConfig);
   evf.init();
@@ -182,45 +207,40 @@ test("Get ignores (both .eleventyignore and .gitignore exists, but .gitignore is
 });
 
 test("Bad expected output, this indicates a bug upstream in a dependency.  Input to 'src' and empty includes dir (issue #403, full paths in eleventyignore)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
+	let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+		input: "test/stubs-403",
+		output: "_site",
+		includes: "",
+		data: false,
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
+  });
 
+  let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
   evf.setEleventyIgnoreContent("!" + TemplatePath.absolutePath("test/stubs-403/_includes") + "/**");
 
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      input: "test/stubs-403",
-      output: "_site",
-      includes: "",
-      data: false,
-    },
-  });
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
   t.deepEqual(await evf.getFiles(), [
     "./test/stubs-403/template.liquid",
-    // This is bad, because it uses an absolutePath above. it should be excluded
+    // This should be excluded from this list but is not because the ignore content used an absolutePath above.
     "./test/stubs-403/_includes/include.liquid",
   ]);
 });
 
 test("Workaround for Bad expected output, this indicates a bug upstream in a dependency.  Input to 'src' and empty includes dir (issue #403, full paths in eleventyignore)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+		input: "test/stubs-403",
+		output: "_site",
+		includes: "",
+		data: false,
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
+  });
+
   let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
   evf.setEleventyIgnoreContent("!./test/stubs-403/_includes/**");
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      input: "test/stubs-403",
-      output: "_site",
-      includes: "",
-      data: false,
-    },
-  });
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
@@ -228,19 +248,16 @@ test("Workaround for Bad expected output, this indicates a bug upstream in a dep
 });
 
 test("Issue #403: all .eleventyignores should be relative paths not absolute paths", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+		input: "test/stubs-403",
+		output: "_site",
+		includes: "",
+		data: false,
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
+  });
 
   let evf = new EleventyFiles("test/stubs-403", "test/stubs-403/_site", ["liquid"], eleventyConfig);
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      input: "test/stubs-403",
-      output: "_site",
-      includes: "",
-      data: false,
-    },
-  });
   evf.init();
 
   let globs = await evf.getFileGlobs();
@@ -253,18 +270,14 @@ test("Issue #403: all .eleventyignores should be relative paths not absolute pat
 });
 
 test("Same input and output directories, issues #186 and #1129", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
-  let evf = new EleventyFiles("test/stubs/", "test/stubs/", [], eleventyConfig);
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      input: "test/stubs",
-      output: "",
-      includes: "",
-    },
+	let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+		input: "test/stubs",
+		output: "",
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
   });
+
+  let evf = new EleventyFiles("test/stubs/", undefined, [], eleventyConfig);
   evf.init();
 
   t.deepEqual(
@@ -274,18 +287,16 @@ test("Same input and output directories, issues #186 and #1129", async (t) => {
 });
 
 test("Single input file is in the output directory, issues #186", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
-  let evf = new EleventyFiles("test/stubs/test.njk", "test/stubs/", ["njk"], eleventyConfig);
-  evf._setConfig({
-    useGitIgnore: false,
-    dir: {
-      input: "test/stubs",
-      output: "",
-      includes: "",
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "",
+    includes: "",
+  }, function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
   });
+
+  let evf = new EleventyFiles("test/stubs/test.njk", undefined, ["njk"], eleventyConfig);
+
   evf.init();
   t.deepEqual(
     evf.getIgnores().filter((entry) => entry.indexOf("_site") > -1),
@@ -294,12 +305,16 @@ test("Single input file is in the output directory, issues #186", async (t) => {
 });
 
 test("De-duplicated ignores", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/ignore-dedupe",
+      output: "test/stubs/ignore-dedupe/_site"
+    }
+  });
 
   let evf = new EleventyFiles(
     "test/stubs/ignore-dedupe",
-    "test/stubs/ignore-dedupe/_site",
+    undefined,
     [],
     eleventyConfig
   );

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -5,28 +5,30 @@ import EleventyFiles from "../src/EleventyFiles.js";
 import TemplateConfig from "../src/TemplateConfig.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
 import TemplatePassthroughManager from "../src/TemplatePassthroughManager.js";
+import ProjectDirectories from "../src/Util/ProjectDirectories.js";
+
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 test("Dirs paths", async (t) => {
-  let eleventyConfig = new TemplateConfig({
+  let eleventyConfig = await getTemplateConfigInstance({
     dir: {
       input: "src",
       includes: "includes",
       data: "data",
       output: "dist",
-    },
+    }
   });
-  await eleventyConfig.init();
 
   let evf = new EleventyFiles("src", "dist", [], eleventyConfig);
 
-  t.deepEqual(evf.inputDir, "src");
-  t.deepEqual(evf.includesDir, "src/includes");
-  t.deepEqual(evf.getDataDir(), "src/data");
-  t.deepEqual(evf.outputDir, "dist");
+  t.deepEqual(evf.inputDir, "./src/");
+  t.deepEqual(evf.includesDir, "./src/includes/");
+  t.deepEqual(evf.getDataDir(), "./src/data/");
+  t.deepEqual(evf.outputDir, "./dist/");
 });
 
 test("Dirs paths (relative)", async (t) => {
-  let eleventyConfig = new TemplateConfig({
+  let eleventyConfig = await getTemplateConfigInstance({
     dir: {
       input: "src",
       includes: "../includes",
@@ -34,22 +36,25 @@ test("Dirs paths (relative)", async (t) => {
       output: "dist",
     },
   });
-  await eleventyConfig.init();
 
   let evf = new EleventyFiles("src", "dist", [], eleventyConfig);
 
-  t.deepEqual(evf.inputDir, "src");
-  t.deepEqual(evf.includesDir, "includes");
-  t.deepEqual(evf.getDataDir(), "data");
-  t.deepEqual(evf.outputDir, "dist");
+  t.deepEqual(evf.inputDir, "./src/");
+  t.deepEqual(evf.includesDir, "./includes/");
+  t.deepEqual(evf.getDataDir(), "./data/");
+  t.deepEqual(evf.outputDir, "./dist/");
 });
 
 test("getFiles", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/writeTest",
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/writeTest",
-    "./test/stubs/_writeTestSite",
+    "./test/stubs/writeTest", // not used anymore
+    undefined,
     ["liquid", "md"],
     eleventyConfig
   );
@@ -60,11 +65,15 @@ test("getFiles", async (t) => {
 });
 
 test("getFiles (without 11ty.js)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/writeTestJS"
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite",
+    "./test/stubs/writeTestJS", // not used anymore
+    undefined,
     ["liquid", "md"],
     eleventyConfig
   );
@@ -75,11 +84,15 @@ test("getFiles (without 11ty.js)", async (t) => {
 });
 
 test("getFiles (with 11ty.js)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/writeTestJS",
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite",
+    "./test/stubs/writeTestJS", // not used anymore
+    undefined,
     ["liquid", "md", "11ty.js"],
     eleventyConfig
   );
@@ -90,11 +103,15 @@ test("getFiles (with 11ty.js)", async (t) => {
 });
 
 test("getFiles (with js, treated as passthrough copy)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/writeTestJS-passthrough",
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS-passthrough",
-    "./test/stubs/_writeTestJSSite",
+    "./test/stubs/writeTestJS-passthrough", // not used anymore
+    undefined,
     ["liquid", "md", "js"],
     eleventyConfig
   );
@@ -115,11 +132,15 @@ test("getFiles (with js, treated as passthrough copy)", async (t) => {
 });
 
 test("getFiles (with case insensitivity)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/writeTestJS-casesensitive",
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS-casesensitive",
-    "./test/stubs/_writeTestJSCaseSensitiveSite",
+    "./test/stubs/writeTestJS-casesensitive", // not used any more
+    undefined,
     ["JS"],
     eleventyConfig
   );
@@ -138,11 +159,15 @@ test("getFiles (with case insensitivity)", async (t) => {
 });
 
 test("Mutually exclusive Input and Output dirs", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/writeTest",
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/writeTest",
-    "./test/stubs/_writeTestSite",
+    "./test/stubs/writeTest", // not used
+    undefined,
     ["liquid", "md"],
     eleventyConfig
   );
@@ -155,11 +180,15 @@ test("Mutually exclusive Input and Output dirs", async (t) => {
 });
 
 test("Single File Input (deep path)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/index.html",
+    }
+  });
+
   let evf = new EleventyFiles(
-    "./test/stubs/index.html",
-    "./test/stubs/_site",
+    "./test/stubs/index.html", // not used any more
+    undefined,
     ["liquid", "md"],
     eleventyConfig
   );
@@ -172,9 +201,13 @@ test("Single File Input (deep path)", async (t) => {
 });
 
 test("Single File Input (shallow path)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("README.md", "./test/stubs/_site", ["md"], eleventyConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "README.md",
+    }
+  });
+
+  let evf = new EleventyFiles(/* not used */ "README.md", undefined, ["md"], eleventyConfig);
   evf.init();
 
   let globs = evf.getFileGlobs(); //.filter((path) => path !== "./README.md");
@@ -187,11 +220,14 @@ test("Single File Input (shallow path)", async (t) => {
 });
 
 test("Glob Input", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs/glob-pages/!(contact.md)",
+    }
+  });
   let evf = new EleventyFiles(
-    "./test/stubs/glob-pages/!(contact.md)",
-    "./test/stubs/_site",
+    "./test/stubs/glob-pages/!(contact.md)", // not used
+    undefined,
     ["md"],
     eleventyConfig
   );
@@ -231,9 +267,12 @@ test("Passed file name does not exist", (t) => {
 });
 
 test(".eleventyignore files", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["liquid", "md"], eleventyConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
+  let evf = new EleventyFiles("test/stubs", undefined, ["liquid", "md"], eleventyConfig);
   evf.init();
   let ignoredFiles = await fastglob("test/stubs/ignoredFolder/*.md");
   t.is(ignoredFiles.length, 1);
@@ -253,10 +292,13 @@ test(".eleventyignore files", async (t) => {
 });
 
 test("getTemplateData caching", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", [], eleventyConfig);
+  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
   evf.init();
   let templateDataFirstCall = evf.templateData;
   let templateDataSecondCall = evf.templateData;
@@ -264,27 +306,36 @@ test("getTemplateData caching", async (t) => {
 });
 
 test("getDataDir", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "."
+    }
+  });
 
-  let evf = new EleventyFiles(".", "_site", [], eleventyConfig);
+  let evf = new EleventyFiles(".", undefined, [], eleventyConfig);
   evf.init();
-  t.is(evf.getDataDir(), "_data");
+  t.is(evf.getDataDir(), "./_data/");
 });
 
 test("getDataDir subdir", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", [], eleventyConfig);
+  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
   evf.init();
-  t.is(evf.getDataDir(), "test/stubs/_data");
+  t.is(evf.getDataDir(), "./test/stubs/_data/");
 });
 
 test("Include and Data Dirs", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", [], eleventyConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
+  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
   evf.init();
 
   t.deepEqual(evf._getIncludesAndDataDirs(), [
@@ -294,9 +345,12 @@ test("Include and Data Dirs", async (t) => {
 });
 
 test("Input to 'src' and empty includes dir (issue #403)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("src", "src/_site", ["md", "liquid", "html"], eleventyConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "src"
+    }
+  });
+  let evf = new EleventyFiles("src", undefined, ["md", "liquid", "html"], eleventyConfig);
   evf.setEleventyIgnoreContent("!./src/_includes/**");
   evf._setConfig({
     useGitIgnore: false,
@@ -318,9 +372,12 @@ test("Input to 'src' and empty includes dir (issue #403)", async (t) => {
 });
 
 test("Glob Watcher Files", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk"], eleventyConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
+  let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
   evf.init();
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -331,9 +388,12 @@ test("Glob Watcher Files", async (t) => {
 });
 
 test("Glob Watcher Files with File Extension Passthroughs", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk", "png"], eleventyConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
+  let evf = new EleventyFiles("test/stubs", undefined, ["njk", "png"], eleventyConfig);
   evf.init();
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -345,13 +405,16 @@ test("Glob Watcher Files with File Extension Passthroughs", async (t) => {
 });
 
 test("Glob Watcher Files with File Extension Passthroughs with Dev Server (for free passthrough copy #2456)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   eleventyConfig.userConfig.setServerPassthroughCopyBehavior("passthrough");
   eleventyConfig.config.serverPassthroughCopyBehavior = "passthrough";
 
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk", "png"], eleventyConfig);
+  let evf = new EleventyFiles("test/stubs", undefined, ["njk", "png"], eleventyConfig);
   evf.setRunMode("serve");
   evf.init();
 
@@ -365,8 +428,11 @@ test("Glob Watcher Files with File Extension Passthroughs with Dev Server (for f
 });
 
 test("Glob Watcher Files with Config Passthroughs (one template format)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   eleventyConfig.userConfig.passthroughCopies = {
     "test/stubs/img/": { outputPath: true },
@@ -375,7 +441,7 @@ test("Glob Watcher Files with Config Passthroughs (one template format)", async 
     "test/stubs/img/": { outputPath: true },
   };
 
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk"], eleventyConfig);
+  let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
   evf.init();
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
@@ -392,8 +458,12 @@ test("Glob Watcher Files with Config Passthroughs (one template format)", async 
 });
 
 test("Glob Watcher Files with Config Passthroughs (one template format) with Dev Server (for free passthrough copy #2456)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
+
   eleventyConfig.userConfig.setServerPassthroughCopyBehavior("passthrough");
   eleventyConfig.config.serverPassthroughCopyBehavior = "passthrough";
 
@@ -404,7 +474,7 @@ test("Glob Watcher Files with Config Passthroughs (one template format) with Dev
     "test/stubs/img/": { outputPath: true },
   };
 
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", ["njk"], eleventyConfig);
+  let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
   evf.setRunMode("serve");
   evf.init();
 
@@ -423,10 +493,14 @@ test("Glob Watcher Files with Config Passthroughs (one template format) with Dev
 });
 
 test("Glob Watcher Files with Config Passthroughs (no template formats)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let templateConfig = new TemplateConfig();
+  let projectDirs = new ProjectDirectories();
+  projectDirs.setViaConfigObject({
+    input: "test/stubs"
+  });
+  let eleventyConfig = await getTemplateConfigInstance(templateConfig, projectDirs);
 
-  let evf = new EleventyFiles("test/stubs", "test/stubs/_site", [], eleventyConfig);
+  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
   evf.init();
 
   t.deepEqual(await evf.getGlobWatcherTemplateDataFiles(), [

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -19,7 +19,7 @@ test("Dirs paths", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("src", "dist", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
 
   t.deepEqual(evf.inputDir, "./src/");
   t.deepEqual(evf.includesDir, "./src/includes/");
@@ -37,7 +37,7 @@ test("Dirs paths (relative)", async (t) => {
     },
   });
 
-  let evf = new EleventyFiles("src", "dist", [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
 
   t.deepEqual(evf.inputDir, "./src/");
   t.deepEqual(evf.includesDir, "./includes/");
@@ -52,12 +52,7 @@ test("getFiles", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTest", // not used anymore
-    undefined,
-    ["liquid", "md"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["liquid", "md"], eleventyConfig);
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
@@ -71,12 +66,7 @@ test("getFiles (without 11ty.js)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS", // not used anymore
-    undefined,
-    ["liquid", "md"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["liquid", "md"], eleventyConfig);
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
@@ -90,12 +80,7 @@ test("getFiles (with 11ty.js)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS", // not used anymore
-    undefined,
-    ["liquid", "md", "11ty.js"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["liquid", "md", "11ty.js"], eleventyConfig);
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
@@ -109,12 +94,7 @@ test("getFiles (with js, treated as passthrough copy)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS-passthrough", // not used anymore
-    undefined,
-    ["liquid", "md", "js"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["liquid", "md", "js"], eleventyConfig);
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
@@ -138,12 +118,7 @@ test("getFiles (with case insensitivity)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS-casesensitive", // not used any more
-    undefined,
-    ["JS"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["JS"], eleventyConfig);
   evf.setFileSystemSearch(new FileSystemSearch());
   evf.init();
 
@@ -165,12 +140,7 @@ test("Mutually exclusive Input and Output dirs", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTest", // not used
-    undefined,
-    ["liquid", "md"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["liquid", "md"], eleventyConfig);
   evf.init();
 
   let files = await fastglob(evf.getFileGlobs());
@@ -186,12 +156,7 @@ test("Single File Input (deep path)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(
-    "./test/stubs/index.html", // not used any more
-    undefined,
-    ["liquid", "md"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["liquid", "md"], eleventyConfig);
   evf.init();
 
   let files = await fastglob(evf.getFileGlobs());
@@ -207,7 +172,7 @@ test("Single File Input (shallow path)", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(/* not used */ "README.md", undefined, ["md"], eleventyConfig);
+  let evf = new EleventyFiles(["md"], eleventyConfig);
   evf.init();
 
   let globs = evf.getFileGlobs(); //.filter((path) => path !== "./README.md");
@@ -225,12 +190,7 @@ test("Glob Input", async (t) => {
       input: "./test/stubs/glob-pages/!(contact.md)",
     }
   });
-  let evf = new EleventyFiles(
-    "./test/stubs/glob-pages/!(contact.md)", // not used
-    undefined,
-    ["md"],
-    eleventyConfig
-  );
+  let evf = new EleventyFiles(["md"], eleventyConfig);
   evf.init();
 
   let globs = evf.getFileGlobs();
@@ -272,7 +232,7 @@ test(".eleventyignore files", async (t) => {
       input: "test/stubs"
     }
   });
-  let evf = new EleventyFiles("test/stubs", undefined, ["liquid", "md"], eleventyConfig);
+  let evf = new EleventyFiles(["liquid", "md"], eleventyConfig);
   evf.init();
   let ignoredFiles = await fastglob("test/stubs/ignoredFolder/*.md");
   t.is(ignoredFiles.length, 1);
@@ -298,7 +258,7 @@ test("getTemplateData caching", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   let templateDataFirstCall = evf.templateData;
   let templateDataSecondCall = evf.templateData;
@@ -312,7 +272,7 @@ test("getDataDir", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles(".", undefined, [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   t.is(evf.getDataDir(), "./_data/");
 });
@@ -324,7 +284,7 @@ test("getDataDir subdir", async (t) => {
     }
   });
 
-  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
   t.is(evf.getDataDir(), "./test/stubs/_data/");
 });
@@ -335,7 +295,7 @@ test("Include and Data Dirs", async (t) => {
       input: "test/stubs"
     }
   });
-  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   t.deepEqual(evf._getIncludesAndDataDirs(), [
@@ -350,7 +310,7 @@ test("Input to 'src' and empty includes dir (issue #403)", async (t) => {
       input: "src"
     }
   });
-  let evf = new EleventyFiles("src", undefined, ["md", "liquid", "html"], eleventyConfig);
+  let evf = new EleventyFiles(["md", "liquid", "html"], eleventyConfig);
   evf.setEleventyIgnoreContent("!./src/_includes/**");
   evf._setConfig({
     useGitIgnore: false,
@@ -377,7 +337,7 @@ test("Glob Watcher Files", async (t) => {
       input: "test/stubs"
     }
   });
-  let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
+  let evf = new EleventyFiles(["njk"], eleventyConfig);
   evf.init();
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -393,7 +353,7 @@ test("Glob Watcher Files with File Extension Passthroughs", async (t) => {
       input: "test/stubs"
     }
   });
-  let evf = new EleventyFiles("test/stubs", undefined, ["njk", "png"], eleventyConfig);
+  let evf = new EleventyFiles(["njk", "png"], eleventyConfig);
   evf.init();
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -414,7 +374,7 @@ test("Glob Watcher Files with File Extension Passthroughs with Dev Server (for f
   eleventyConfig.userConfig.setServerPassthroughCopyBehavior("passthrough");
   eleventyConfig.config.serverPassthroughCopyBehavior = "passthrough";
 
-  let evf = new EleventyFiles("test/stubs", undefined, ["njk", "png"], eleventyConfig);
+  let evf = new EleventyFiles(["njk", "png"], eleventyConfig);
   evf.setRunMode("serve");
   evf.init();
 
@@ -438,7 +398,7 @@ test("Glob Watcher Files with Config Passthroughs (one template format)", async 
 	});
 
 
-  let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
+  let evf = new EleventyFiles(["njk"], eleventyConfig);
   evf.init();
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
@@ -463,7 +423,7 @@ test("Glob Watcher Files with Config Passthroughs (one template format) with Dev
 		};
 	});
 
-  let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
+  let evf = new EleventyFiles(["njk"], eleventyConfig);
   evf.setRunMode("serve");
   evf.init();
 
@@ -487,7 +447,7 @@ test("Glob Watcher Files with Config Passthroughs (no template formats)", async 
   });
   let eleventyConfig = await getTemplateConfigInstance(templateConfig, projectDirs);
 
-  let evf = new EleventyFiles("test/stubs", undefined, [], eleventyConfig);
+  let evf = new EleventyFiles([], eleventyConfig);
   evf.init();
 
   t.deepEqual(await evf.getGlobWatcherTemplateDataFiles(), [

--- a/test/EleventyFilesTest.js
+++ b/test/EleventyFilesTest.js
@@ -7,7 +7,7 @@ import FileSystemSearch from "../src/FileSystemSearch.js";
 import TemplatePassthroughManager from "../src/TemplatePassthroughManager.js";
 import ProjectDirectories from "../src/Util/ProjectDirectories.js";
 
-import { getTemplateConfigInstance } from "./_testHelpers.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 test("Dirs paths", async (t) => {
   let eleventyConfig = await getTemplateConfigInstance({
@@ -428,25 +428,20 @@ test("Glob Watcher Files with File Extension Passthroughs with Dev Server (for f
 });
 
 test("Glob Watcher Files with Config Passthroughs (one template format)", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance({
-    dir: {
-      input: "test/stubs"
-    }
-  });
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "test/stubs/_site"
+  }, function(cfg) {
+		cfg.passthroughCopies = {
+			"test/stubs/img/": { outputPath: true },
+		};
+	});
 
-  eleventyConfig.userConfig.passthroughCopies = {
-    "test/stubs/img/": { outputPath: true },
-  };
-  eleventyConfig.config.passthroughCopies = {
-    "test/stubs/img/": { outputPath: true },
-  };
 
   let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
   evf.init();
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
-  mgr.setInputDir("test/stubs");
-  mgr.setOutputDir("test/stubs/_site");
   evf.setPassthroughManager(mgr);
 
   t.deepEqual(evf.getGlobWatcherFiles(), [
@@ -458,29 +453,21 @@ test("Glob Watcher Files with Config Passthroughs (one template format)", async 
 });
 
 test("Glob Watcher Files with Config Passthroughs (one template format) with Dev Server (for free passthrough copy #2456)", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance({
-    dir: {
-      input: "test/stubs"
-    }
-  });
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.setServerPassthroughCopyBehavior("passthrough");
 
-  eleventyConfig.userConfig.setServerPassthroughCopyBehavior("passthrough");
-  eleventyConfig.config.serverPassthroughCopyBehavior = "passthrough";
-
-  eleventyConfig.userConfig.passthroughCopies = {
-    "test/stubs/img/": { outputPath: true },
-  };
-  eleventyConfig.config.passthroughCopies = {
-    "test/stubs/img/": { outputPath: true },
-  };
+		cfg.passthroughCopies = {
+			"test/stubs/img/": { outputPath: true },
+		};
+	});
 
   let evf = new EleventyFiles("test/stubs", undefined, ["njk"], eleventyConfig);
   evf.setRunMode("serve");
   evf.init();
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
-  mgr.setInputDir("test/stubs");
-  mgr.setOutputDir("test/stubs/_site");
   evf.setPassthroughManager(mgr);
 
   t.deepEqual(evf.getGlobWatcherFiles(), [

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -802,46 +802,17 @@ test("Access to raw input of file (dryRun), issue #1206", async (t) => {
 	rimrafSync("./test/stubs-1206/_site/");
 });
 
-test("eleventy.before Event Arguments, inputDir throws error", async (t) => {
-  let elev = new Eleventy("./test/noop/", "./test/noop/_site", {
-    config: function (eleventyConfig) {
-      eleventyConfig.on("eleventy.before", arg => {
-        arg.inputDir;
-      })
-    },
-  });
-  elev.disableLogger();
-
-  await t.throwsAsync(() => elev.toJSON(), {
-    message: "The `inputDir` property in the `eleventy.before` and `eleventy.after` events has been removed. Use `directories.input` instead."
-  });
-});
-
-test("eleventy.after Event Arguments, inputDir throws error", async (t) => {
-  let elev = new Eleventy("./test/noop/", "./test/noop/_site", {
-    config: function (eleventyConfig) {
-      eleventyConfig.on("eleventy.after", arg => {
-        arg.inputDir;
-      })
-    },
-  });
-  elev.disableLogger();
-
-  await t.throwsAsync(() => elev.toJSON(), {
-    message: "The `inputDir` property in the `eleventy.before` and `eleventy.after` events has been removed. Use `directories.input` instead."
-  });
-});
-
-
 test("eleventy.before and eleventy.after Event Arguments, directories", async (t) => {
-  t.plan(4);
+  t.plan(6);
   let elev = new Eleventy("./test/noop/", "./test/noop/_site", {
     config: function (eleventyConfig) {
       eleventyConfig.on("eleventy.before", arg => {
+        t.is(arg.inputDir, "./test/noop/");
         t.is(arg.directories.input, "./test/noop/");
         t.is(arg.directories.includes, "./test/noop/_includes/");
       })
       eleventyConfig.on("eleventy.after", arg => {
+        t.is(arg.inputDir, "./test/noop/");
         t.is(arg.directories.input, "./test/noop/");
         t.is(arg.directories.includes, "./test/noop/_includes/");
       })

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -801,3 +801,52 @@ test("Access to raw input of file (dryRun), issue #1206", async (t) => {
 
 	rimrafSync("./test/stubs-1206/_site/");
 });
+
+test("eleventy.before Event Arguments, inputDir throws error", async (t) => {
+  let elev = new Eleventy("./test/noop/", "./test/noop/_site", {
+    config: function (eleventyConfig) {
+      eleventyConfig.on("eleventy.before", arg => {
+        arg.inputDir;
+      })
+    },
+  });
+  elev.disableLogger();
+
+  await t.throwsAsync(() => elev.toJSON(), {
+    message: "The `inputDir` property in the `eleventy.before` and `eleventy.after` events has been removed. Use `directories.input` instead."
+  });
+});
+
+test("eleventy.after Event Arguments, inputDir throws error", async (t) => {
+  let elev = new Eleventy("./test/noop/", "./test/noop/_site", {
+    config: function (eleventyConfig) {
+      eleventyConfig.on("eleventy.after", arg => {
+        arg.inputDir;
+      })
+    },
+  });
+  elev.disableLogger();
+
+  await t.throwsAsync(() => elev.toJSON(), {
+    message: "The `inputDir` property in the `eleventy.before` and `eleventy.after` events has been removed. Use `directories.input` instead."
+  });
+});
+
+
+test("eleventy.before and eleventy.after Event Arguments, directories", async (t) => {
+  t.plan(4);
+  let elev = new Eleventy("./test/noop/", "./test/noop/_site", {
+    config: function (eleventyConfig) {
+      eleventyConfig.on("eleventy.before", arg => {
+        t.is(arg.directories.input, "./test/noop/");
+        t.is(arg.directories.includes, "./test/noop/_includes/");
+      })
+      eleventyConfig.on("eleventy.after", arg => {
+        t.is(arg.directories.input, "./test/noop/");
+        t.is(arg.directories.includes, "./test/noop/_includes/");
+      })
+    },
+  });
+
+  let results = await elev.toJSON();
+});

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -26,8 +26,10 @@ test("Eleventy, defaults inherit from config", async (t) => {
 
   t.truthy(elev.input);
   t.truthy(elev.outputDir);
-  t.is(elev.input, config.dir.input);
-  t.is(elev.outputDir, config.dir.output);
+  t.is(config.dir.input, ".");
+  t.is(elev.input, "./");
+  t.is(config.dir.output, "_site");
+  t.is(elev.outputDir, "./_site/");
 });
 
 test("Eleventy, get version", (t) => {
@@ -63,8 +65,8 @@ test("Eleventy, set is verbose (after config init)", async (t) => {
 test("Eleventy set input/output", async (t) => {
   let elev = new Eleventy("./test/stubs", "./test/stubs/_site");
 
-  t.is(elev.input, "./test/stubs");
-  t.is(elev.outputDir, "./test/stubs/_site");
+  t.is(elev.input, "./test/stubs/");
+  t.is(elev.outputDir, "./test/stubs/_site/");
 
   await elev.init();
   t.truthy(elev.templateData);
@@ -154,15 +156,18 @@ test("Eleventy set input/output, one file input", async (t) => {
   let elev = new Eleventy("./test/stubs/index.html", "./test/stubs/_site");
 
   t.is(elev.input, "./test/stubs/index.html");
+  t.is(elev.inputFile, "./test/stubs/index.html");
   t.is(elev.inputDir, "./test/stubs/");
   t.is(elev.outputDir, "./test/stubs/_site/");
 });
 
 test("Eleventy set input/output, one file input, deeper subdirectory", async (t) => {
-  let elev = new Eleventy("./test/stubs/subdir/index.html", "./test/stubs/_site");
-  elev.setInputDir("./test/stubs");
+  let elev = new Eleventy("./test/stubs/subdir/index.html", "./test/stubs/_site", {
+		inputDir: "./test/stubs"
+	});
 
   t.is(elev.input, "./test/stubs/subdir/index.html");
+  t.is(elev.inputFile, "./test/stubs/subdir/index.html");
   t.is(elev.inputDir, "./test/stubs/");
   t.is(elev.outputDir, "./test/stubs/_site/");
 });
@@ -171,16 +176,17 @@ test("Eleventy set input/output, one file input root dir", async (t) => {
   let elev = new Eleventy("./README.md", "./test/stubs/_site");
 
   t.is(elev.input, "./README.md");
+  t.is(elev.inputFile, "./README.md");
   t.is(elev.inputDir, "./");
-  t.is(elev.outputDir, "./test/stubs/_site");
+  t.is(elev.outputDir, "./test/stubs/_site/");
 });
 
 test("Eleventy set input/output, one file input root dir without leading dot/slash", async (t) => {
   let elev = new Eleventy("README.md", "./test/stubs/_site");
 
-  t.is(elev.input, "README.md");
+  t.is(elev.input, "./README.md");
   t.is(elev.inputDir, "./");
-  t.is(elev.outputDir, "./test/stubs/_site");
+  t.is(elev.outputDir, "./test/stubs/_site/");
 });
 
 test("Eleventy set input/output, one file input exitCode (script)", async (t) => {
@@ -226,7 +232,7 @@ test("Eleventy to json", async (t) => {
       {
         url: "/test/",
         inputPath: "./test/stubs--to/test.md",
-        outputPath: "_site/test/index.html",
+        outputPath: "./_site/test/index.html",
         rawInput: localizeNewLines("# hi\n"),
         content: "<h1>hi</h1>\n",
       },
@@ -238,7 +244,7 @@ test("Eleventy to json", async (t) => {
       {
         url: "/test2/",
         inputPath: "./test/stubs--to/test2.liquid",
-        outputPath: "_site/test2/index.html",
+        outputPath: "./_site/test2/index.html",
         rawInput: "{{ hi }}",
         content: "hello",
       },
@@ -261,7 +267,7 @@ test("Eleventy to ndjson", async (t) => {
         t.deepEqual(jsonObj, {
           url: "/test/",
           inputPath: "./test/stubs--to/test.md",
-          outputPath: "_site/test/index.html",
+          outputPath: "./_site/test/index.html",
           rawInput: localizeNewLines("# hi\n"),
           content: "<h1>hi</h1>\n",
         });
@@ -270,7 +276,7 @@ test("Eleventy to ndjson", async (t) => {
         t.deepEqual(jsonObj, {
           url: "/test2/",
           inputPath: "./test/stubs--to/test2.liquid",
-          outputPath: "_site/test2/index.html",
+          outputPath: "./_site/test2/index.html",
           rawInput: `{{ hi }}`,
           content: "hello",
         });
@@ -298,7 +304,7 @@ test("Eleventy to ndjson (returns a stream)", async (t) => {
         t.deepEqual(jsonObj, {
           url: "/test/",
           inputPath: "./test/stubs--to/test.md",
-          outputPath: "_site/test/index.html",
+          outputPath: "./_site/test/index.html",
           rawInput: localizeNewLines("# hi\n"),
           content: "<h1>hi</h1>\n",
         });
@@ -307,7 +313,7 @@ test("Eleventy to ndjson (returns a stream)", async (t) => {
         t.deepEqual(jsonObj, {
           url: "/test2/",
           inputPath: "./test/stubs--to/test2.liquid",
-          outputPath: "_site/test2/index.html",
+          outputPath: "./_site/test2/index.html",
           rawInput: "{{ hi }}",
           content: "hello",
         });
@@ -364,7 +370,7 @@ test("Eleventy programmatic API without init", async (t) => {
       {
         url: "/test/",
         inputPath: "./test/stubs--to/test.md",
-        outputPath: "_site/test/index.html",
+        outputPath: "./_site/test/index.html",
         rawInput: localizeNewLines("# hi\n"),
         content: "<h1>hi</h1>\n",
       },
@@ -376,7 +382,7 @@ test("Eleventy programmatic API without init", async (t) => {
       {
         url: "/test2/",
         inputPath: "./test/stubs--to/test2.liquid",
-        outputPath: "_site/test2/index.html",
+        outputPath: "./_site/test2/index.html",
         rawInput: `{{ hi }}`,
         content: "hello",
       },
@@ -396,7 +402,7 @@ test("Can Eleventy run two executeBuilds in parallel?", async (t) => {
     {
       url: "/test/",
       inputPath: "./test/stubs--to/test.md",
-      outputPath: "_site/test/index.html",
+      outputPath: "./_site/test/index.html",
       rawInput: localizeNewLines("# hi\n"),
       content: "<h1>hi</h1>\n",
     },
@@ -406,7 +412,7 @@ test("Can Eleventy run two executeBuilds in parallel?", async (t) => {
     {
       url: "/test2/",
       inputPath: "./test/stubs--to/test2.liquid",
-      outputPath: "_site/test2/index.html",
+      outputPath: "./_site/test2/index.html",
       rawInput: "{{ hi }}",
       content: "hello",
     },

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -154,8 +154,8 @@ test("Eleventy set input/output, one file input", async (t) => {
   let elev = new Eleventy("./test/stubs/index.html", "./test/stubs/_site");
 
   t.is(elev.input, "./test/stubs/index.html");
-  t.is(elev.inputDir, "./test/stubs");
-  t.is(elev.outputDir, "./test/stubs/_site");
+  t.is(elev.inputDir, "./test/stubs/");
+  t.is(elev.outputDir, "./test/stubs/_site/");
 });
 
 test("Eleventy set input/output, one file input, deeper subdirectory", async (t) => {
@@ -163,15 +163,15 @@ test("Eleventy set input/output, one file input, deeper subdirectory", async (t)
   elev.setInputDir("./test/stubs");
 
   t.is(elev.input, "./test/stubs/subdir/index.html");
-  t.is(elev.inputDir, "./test/stubs");
-  t.is(elev.outputDir, "./test/stubs/_site");
+  t.is(elev.inputDir, "./test/stubs/");
+  t.is(elev.outputDir, "./test/stubs/_site/");
 });
 
 test("Eleventy set input/output, one file input root dir", async (t) => {
   let elev = new Eleventy("./README.md", "./test/stubs/_site");
 
   t.is(elev.input, "./README.md");
-  t.is(elev.inputDir, ".");
+  t.is(elev.inputDir, "./");
   t.is(elev.outputDir, "./test/stubs/_site");
 });
 
@@ -179,7 +179,7 @@ test("Eleventy set input/output, one file input root dir without leading dot/sla
   let elev = new Eleventy("README.md", "./test/stubs/_site");
 
   t.is(elev.input, "README.md");
-  t.is(elev.inputDir, ".");
+  t.is(elev.inputDir, "./");
   t.is(elev.outputDir, "./test/stubs/_site");
 });
 

--- a/test/EleventyVirtualTemplatesTest.js
+++ b/test/EleventyVirtualTemplatesTest.js
@@ -6,114 +6,114 @@ import Eleventy from "../src/Eleventy.js";
 import DuplicatePermalinkOutputError from "../src/Errors/DuplicatePermalinkOutputError.js";
 
 test("Virtual templates, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs-virtual-nowrite/virtual.md", `# Hello`)
+	let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual.md", `# Hello`)
 		},
-  });
+	});
 
-  let results = await elev.toJSON();
+	let results = await elev.toJSON();
 
-  t.deepEqual(results.length, 1);
-  t.deepEqual(results[0].content.trim(), `<h1>Hello</h1>`);
-  t.deepEqual(results[0].rawInput, `# Hello`);
+	t.deepEqual(results.length, 1);
+	t.deepEqual(results[0].content.trim(), `<h1>Hello</h1>`);
+	t.deepEqual(results[0].rawInput, `# Hello`);
 });
 
 test("Virtual templates with front matter, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs-virtual-nowrite/virtual.md", `---
+	let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("./virtual.md", `---
 myKey: myValue
 ---
 # {{ myKey }}`)
 		},
-  });
+	});
 
-  let results = await elev.toJSON();
+	let results = await elev.toJSON();
 
-  t.deepEqual(results.length, 1);
-  t.deepEqual(results[0].content.trim(), `<h1>myValue</h1>`);
-  t.deepEqual(results[0].rawInput, `# {{ myKey }}`);
+	t.deepEqual(results.length, 1);
+	t.deepEqual(results[0].content.trim(), `<h1>myValue</h1>`);
+	t.deepEqual(results[0].rawInput, `# {{ myKey }}`);
 });
 
 test("Virtual templates with supplemental data, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs-virtual-nowrite/virtual.md", `# {{ myKey }}`, { myKey: "myValue" })
+	let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual.md", `# {{ myKey }}`, { myKey: "myValue" })
 		},
-  });
+	});
 
-  let results = await elev.toJSON();
+	let results = await elev.toJSON();
 
-  t.deepEqual(results.length, 1);
-  t.deepEqual(results[0].content.trim(), `<h1>myValue</h1>`);
-  t.deepEqual(results[0].rawInput, `# {{ myKey }}`);
+	t.deepEqual(results.length, 1);
+	t.deepEqual(results[0].content.trim(), `<h1>myValue</h1>`);
+	t.deepEqual(results[0].rawInput, `# {{ myKey }}`);
 });
 
 // Supplemental data overrides front matter.
 test("Virtual templates with front matter and supplemental data, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs-virtual-nowrite/virtual.md", `---
+	let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual.md", `---
 myKey1: myValue1
 myKey3: myValueFm
 ---
 # {{ myKey1 }}{{ myKey2 }}{{ myKey3 }}`, { myKey2: "myValue2", myKey3: "myValueData" })
 		},
-  });
+	});
 
-  let results = await elev.toJSON();
+	let results = await elev.toJSON();
 
-  t.deepEqual(results.length, 1);
-  t.deepEqual(results[0].content.trim(), `<h1>myValue1myValue2myValueData</h1>`);
-  t.deepEqual(results[0].rawInput, `# {{ myKey1 }}{{ myKey2 }}{{ myKey3 }}`);
+	t.deepEqual(results.length, 1);
+	t.deepEqual(results[0].content.trim(), `<h1>myValue1myValue2myValueData</h1>`);
+	t.deepEqual(results[0].rawInput, `# {{ myKey1 }}{{ myKey2 }}{{ myKey3 }}`);
 });
 
 test("Virtual template conflicts with file on file system, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs/stubs-virtual-conflict", "./test/stubs/stubs-virtual-conflict/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs/stubs-virtual-conflict/virtual.md", `# Virtual template`)
+	let elev = new Eleventy("./test/stubs/stubs-virtual-conflict", "./test/stubs/stubs-virtual-conflict/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual.md", `# Virtual template`)
 		},
-  });
+	});
 	elev.disableLogger();
 
-  await t.throwsAsync(elev.toJSON(), {
-		message: `A virtual template had the same path as a file on the file system at "./test/stubs/stubs-virtual-conflict/virtual.md"`
+	await t.throwsAsync(elev.toJSON(), {
+		message: `A virtual template had the same path as a file on the file system: "./test/stubs/stubs-virtual-conflict/virtual.md"`
 	});
 });
 
 test("Virtual templates try to output to the same file, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs-virtual-nowrite/virtual-one.md", "", {
+	let elev = new Eleventy("./test/stubs-virtual-nowrite", "./test/stubs-virtual-nowrite/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual-one.md", "", {
 				permalink: "/output.html"
 			})
-			eleventyConfig.addTemplate("./test/stubs-virtual-nowrite/virtual-two.md", "", {
+			eleventyConfig.addTemplate("virtual-two.md", "", {
 				permalink: "/output.html"
 			})
 		},
-  });
+	});
 	elev.disableLogger();
 
-  await t.throwsAsync(elev.toJSON(), {
+	await t.throwsAsync(elev.toJSON(), {
 		instanceOf: DuplicatePermalinkOutputError,
 	});
 });
 
 // Warning: this test writes to the file system
 test("Virtual template writes to file system, issue #1612", async (t) => {
-  let elev = new Eleventy("./test/stubs-virtual", "./test/stubs-virtual/_site", {
-    config: function (eleventyConfig) {
-			eleventyConfig.addTemplate("./test/stubs-virtual/virtual.md", `# Hello`)
+	let elev = new Eleventy("./test/stubs-virtual", "./test/stubs-virtual/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual.md", `# Hello`)
 		},
-  });
-  elev.disableLogger();
+	});
+	elev.disableLogger();
 
-  let [,results] = await elev.write();
+	let [,results] = await elev.write();
 
-  t.deepEqual(results.length, 1);
-  t.deepEqual(results[0].content.trim(), `<h1>Hello</h1>`);
-  t.deepEqual(results[0].rawInput, `# Hello`);
+	t.deepEqual(results.length, 1);
+	t.deepEqual(results[0].content.trim(), `<h1>Hello</h1>`);
+	t.deepEqual(results[0].rawInput, `# Hello`);
 	t.true(fs.existsSync("./test/stubs-virtual/_site/virtual/index.html"));
 
 	rimrafSync("./test/stubs-virtual/_site/");

--- a/test/InputPathToUrlPluginTest.js
+++ b/test/InputPathToUrlPluginTest.js
@@ -51,8 +51,6 @@ test("Using the transform (and the filter too)", async (t) => {
     },
   });
 
-  await elev.initializeConfig();
-
   elev.setIsVerbose(false);
   elev.disableLogger();
 
@@ -73,7 +71,6 @@ test("Using the filter", async (t) => {
 		// FilterPlugin is available in the default config.
     configPath: false,
   });
-  await elev.initializeConfig();
 
   elev.setIsVerbose(false);
   elev.disableLogger();
@@ -98,7 +95,6 @@ test("Using the transform and the base plugin", async (t) => {
       eleventyConfig.addPlugin(HtmlBasePlugin);
     },
   });
-  await elev.initializeConfig();
 
   elev.setIsVerbose(false);
   elev.disableLogger();
@@ -123,7 +119,6 @@ test("Using the transform and the base plugin, reverse order", async (t) => {
 			eleventyConfig.addPlugin(TransformPlugin);
     },
   });
-  await elev.initializeConfig();
 
   elev.setIsVerbose(false);
   elev.disableLogger();

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -7,18 +7,13 @@ import TemplateConfig from "../src/TemplateConfig.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { getRenderedTemplates as getRenderedTmpls, renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 test("No data passed to pagination", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/notpaged.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let paging = new Pagination(tmpl, {}, tmpl.config);
@@ -28,16 +23,10 @@ test("No data passed to pagination", async (t) => {
 });
 
 test("No pagination", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/notpaged.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let data = await tmpl.getData();
@@ -51,16 +40,10 @@ test("No pagination", async (t) => {
 });
 
 test("Empty paged data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/paged-empty.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let data = await tmpl.getData();
@@ -73,16 +56,10 @@ test("Empty paged data", async (t) => {
 });
 
 test("Empty paged data with generatePageOnEmptyData enabled", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/paged-empty-pageonemptydata.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let data = await tmpl.getData();
@@ -95,16 +72,10 @@ test("Empty paged data with generatePageOnEmptyData enabled", async (t) => {
 });
 
 test("Pagination enabled in frontmatter", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/pagedresolve.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let data = await tmpl.getData();
@@ -121,16 +92,10 @@ test("Pagination enabled in frontmatter", async (t) => {
 });
 
 test("Resolve paged data in frontmatter", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/pagedresolve.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let data = await tmpl.getData();
@@ -142,16 +107,10 @@ test("Resolve paged data in frontmatter", async (t) => {
 });
 
 test("Paginate data in frontmatter", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/pagedinlinedata.njk",
     "./test/stubs/",
     "./dist",
-    null,
-    null,
-    eleventyConfig
   );
 
   let data = await tmpl.getData();
@@ -172,8 +131,12 @@ test("Paginate data in frontmatter", async (t) => {
 });
 
 test("Paginate external data file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -395,8 +358,12 @@ test("Template with Pagination", async (t) => {
 });
 
 test("Issue 135", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -542,8 +509,12 @@ test("Page over an object (filtered, string)", async (t) => {
 });
 
 test("Pagination with deep data merge #147", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist",
+    }
+  });
 
   let tmpl = await getNewTemplate(
     "./test/stubs/paged/pagedinlinedata.njk",
@@ -613,8 +584,7 @@ test("Paginate data in frontmatter (reversed)", async (t) => {
 });
 
 test("No circular dependency (does not throw)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   new Pagination(
     null,
@@ -636,8 +606,7 @@ test("No circular dependency (does not throw)", async (t) => {
 
 test("Circular dependency (pagination iterates over tag1 but also supplies pages to tag1)", async (t) => {
   await t.throwsAsync(async () => {
-    let eleventyConfig = new TemplateConfig();
-    await eleventyConfig.init();
+    let eleventyConfig = await getTemplateConfigInstance();
 
     new Pagination(
       null,
@@ -658,8 +627,7 @@ test("Circular dependency (pagination iterates over tag1 but also supplies pages
 });
 
 test("Circular dependency but should not error because it uses eleventyExcludeFromCollections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   new Pagination(
     null,
@@ -728,8 +696,12 @@ test("Pagination `before` Callback with `reverse: true` (test order of operation
 });
 
 test("Pagination new v0.10.0 href/hrefs", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -760,8 +732,12 @@ test("Pagination new v0.10.0 href/hrefs", async (t) => {
 });
 
 test("Pagination new v0.10.0 page/pages", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -820,16 +796,20 @@ test("Pagination make sure pageNumber is numeric for {{ pageNumber + 1 }} Issue 
 });
 
 test("Pagination mutable global data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/paged-global-data-mutable/",
+      output: "dist",
+    }
+  });
 
-  let dataObj = new TemplateData("./test/stubs/paged-global-data-mutable/", eleventyConfig);
+  let dataObj = new TemplateData(undefined, eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
   let tmpl = await getNewTemplate(
     "./test/stubs/paged-global-data-mutable/paged-differing-data-set.njk",
-    "./test/stubs/",
+    "./test/stubs/paged-global-data-mutable/",
     "./dist",
     dataObj,
     null,
@@ -858,8 +838,12 @@ test("Pagination mutable global data", async (t) => {
 });
 
 test("Pagination template/dir data files run once, Issue 919", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs-919",
+      output: "dist",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs-919/", eleventyConfig);
 

--- a/test/PaginationTest.js
+++ b/test/PaginationTest.js
@@ -138,7 +138,7 @@ test("Paginate external data file", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -365,7 +365,7 @@ test("Issue 135", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -703,7 +703,7 @@ test("Pagination new v0.10.0 href/hrefs", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -739,7 +739,7 @@ test("Pagination new v0.10.0 page/pages", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -803,7 +803,7 @@ test("Pagination mutable global data", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData(undefined, eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -845,7 +845,7 @@ test("Pagination template/dir data files run once, Issue 919", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs-919/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   let tmpl = await getNewTemplate(
     "./test/stubs-919/test.njk",

--- a/test/ProjectDirectoriesTest.js
+++ b/test/ProjectDirectoriesTest.js
@@ -1,0 +1,125 @@
+import test from "ava";
+import ProjectDirectories from "../src/Util/ProjectDirectories.js";
+
+test("Implied input", t => {
+	let d = new ProjectDirectories();
+	t.is(d.input, "./");
+});
+
+test("Input matches", t => {
+	let d = new ProjectDirectories();
+	d.setInput("./test/");
+	t.is(d.input, "./test/");
+});
+
+test("Normalized input (has trailing slash)", t => {
+	let d = new ProjectDirectories();
+	d.setInput("test/");
+	t.is(d.input, "./test/");
+});
+
+test("Normalized input (no trailing slash)", t => {
+	let d = new ProjectDirectories();
+	d.setInput("test");
+	t.is(d.input, "./test/");
+});
+
+test("Input must exist", t => {
+	let d = new ProjectDirectories();
+	t.throws(() => d.setInput("does-not-exist"));
+});
+
+test("Input as file", t => {
+	let d = new ProjectDirectories();
+	d.setInput("test/stubs/index.html");
+	t.is(d.input, "./test/stubs/");
+});
+
+test("Input as file (deep)", t => {
+	let d = new ProjectDirectories();
+	d.setInput("test/stubs/img/stub.md");
+	t.is(d.input, "./test/stubs/img/");
+});
+
+test("Input as file (deep with inputDir)", t => {
+	let d = new ProjectDirectories();
+	d.setInput("test/stubs/img/stub.md", "test/stubs");
+	t.is(d.input, "./test/stubs/");
+});
+
+test("Input as file (separate inputDir)", t => {
+	let d = new ProjectDirectories();
+	d.setInput("test/stubs/img/stub.md");
+	d.setInputDir("test/stubs");
+	t.is(d.input, "./test/stubs/");
+});
+
+
+test("Data directory, implied input and default data", t => {
+	let d = new ProjectDirectories();
+	t.is(d.data, "./_data/");
+});
+
+test("Data directory matches, explicit input", t => {
+	let d = new ProjectDirectories();
+	d.setInput("./test/");
+	t.is(d.data, "./test/_data/");
+});
+
+test("Data directory matches, explicit input and data", t => {
+	let d = new ProjectDirectories();
+	d.setInput("./test/");
+	d.setData("mydata");
+	t.is(d.data, "./test/mydata/");
+});
+
+test("Data directory matches, explicit input and data (order reversed)", t => {
+	let d = new ProjectDirectories();
+	d.setData("mydata");
+	d.setInput("./test/");
+	t.is(d.data, "./test/mydata/");
+});
+
+test("Layouts/includes, implied", t => {
+	let d = new ProjectDirectories();
+	t.is(d.layouts, "./_layouts/");
+	t.is(d.includes, "./_includes/");
+});
+
+test("Layouts/includes, explicit", t => {
+	let d = new ProjectDirectories();
+	d.setLayouts("layouts");
+	d.setIncludes("includes");
+	t.is(d.layouts, "./layouts/");
+	t.is(d.includes, "./includes/");
+
+	d.setInput("test");
+	t.is(d.layouts, "./test/layouts/");
+	t.is(d.includes, "./test/includes/");
+
+	d.setLayouts("../layouts");
+	d.setIncludes("../includes");
+	t.is(d.layouts, "./layouts/");
+	t.is(d.includes, "./includes/");
+});
+
+test("Output, implied", t => {
+	let d = new ProjectDirectories();
+	t.is(d.output, "./_site/");
+});
+
+test("Content/template/input paths", t => {
+	let d = new ProjectDirectories();
+	t.is(d.getInputPath("test.md"), "./test.md");
+	t.is(d.getInputPath("./test.md"), "./test.md");
+
+	d.setInput("test");
+	t.is(d.getInputPath("test.md"), "./test/test.md");
+	t.is(d.getInputPath("./test.md"), "./test/test.md");
+});
+
+test("Project file paths", t => {
+	let d = new ProjectDirectories();
+	t.is(d.getProjectPath("eleventy.config.js"), "./eleventy.config.js");
+	t.is(d.getProjectPath("./eleventy.config.js"), "./eleventy.config.js");
+});

--- a/test/TemplateCollectionTest.js
+++ b/test/TemplateCollectionTest.js
@@ -1,10 +1,11 @@
 import test from "ava";
 import multimatch from "multimatch";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import Collection from "../src/TemplateCollection.js";
 import Sortable from "../src/Util/Sortable.js";
+
 import getNewTemplateForTests from "../test/_getNewTemplateForTests.js";
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 function getNewTemplate(filename, input, output, eleventyConfig) {
   return getNewTemplateForTests(filename, input, output, null, null, eleventyConfig);
@@ -31,8 +32,7 @@ async function addTemplate(collection, template) {
 }
 
 test("Basic setup", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -47,8 +47,7 @@ test("Basic setup", async (t) => {
 });
 
 test("sortFunctionDate", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl4 = await getNewTemplateByNumber(4, eleventyConfig);
@@ -67,8 +66,7 @@ test("sortFunctionDate", async (t) => {
 });
 
 test("sortFunctionDateInputPath", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl4 = await getNewTemplateByNumber(4, eleventyConfig);
@@ -87,8 +85,7 @@ test("sortFunctionDateInputPath", async (t) => {
 });
 
 test("getFilteredByTag", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -115,8 +112,7 @@ test("getFilteredByTag", async (t) => {
 });
 
 test("getFilteredByTag (added out of order, sorted)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -144,8 +140,7 @@ test("getFilteredByTag (added out of order, sorted)", async (t) => {
 });
 
 test("getFilteredByTags", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -171,8 +166,7 @@ test("getFilteredByTags", async (t) => {
 });
 
 test("getFilteredByTags (added out of order, sorted)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -201,8 +195,7 @@ test("getFilteredByTags (added out of order, sorted)", async (t) => {
 });
 
 test("getFilteredByGlob", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl6 = await getNewTemplateByNumber(6, eleventyConfig);
@@ -219,8 +212,7 @@ test("getFilteredByGlob", async (t) => {
 });
 
 test("getFilteredByGlob no dash dot", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl6 = await getNewTemplateByNumber(6, eleventyConfig);
@@ -242,8 +234,7 @@ test("getFilteredByGlob no dash dot", async (t) => {
 });
 
 test("partial match on tag string, issue 95", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let cat = await getNewTemplate(
     "./test/stubs/issue-95/cat.md",
@@ -289,8 +280,7 @@ test("multimatch assumptions, issue #127", async (t) => {
 });
 
 test("Sort in place (issue #352)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl4 = await getNewTemplateByNumber(4, eleventyConfig);
@@ -321,8 +311,7 @@ test("Sort in place (issue #352)", async (t) => {
 });
 
 test("getFilteredByTag with excludes", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl8 = await getNewTemplateByNumber(8, eleventyConfig);
   let tmpl9 = await getNewTemplateByNumber(9, eleventyConfig);

--- a/test/TemplateConfigTest.js
+++ b/test/TemplateConfigTest.js
@@ -4,6 +4,8 @@ import md from "markdown-it";
 import TemplateConfig from "../src/TemplateConfig.js";
 import defaultConfig from "../src/defaultConfig.js";
 
+import { getTemplateConfigInstance } from "./_testHelpers.js";
+
 test("Template Config local config overrides base config", async (t) => {
   let templateCfg = new TemplateConfig(defaultConfig, "./test/stubs/config.cjs");
   await templateCfg.init();
@@ -556,4 +558,32 @@ test("Async namespace", async (t) => {
   let cfg = templateCfg.getConfig();
   t.not(Object.keys(cfg.liquidFilters).indexOf("testNamespaceMyFilterName"), -1);
   t.not(Object.keys(cfg.nunjucksFilters).indexOf("testNamespaceMyFilterName"), -1);
+});
+
+test("ProjectDirectories instance exists in user accessible config", async (t) => {
+	let eleventyConfig = await getTemplateConfigInstance();
+  let cfg = eleventyConfig.getConfig();
+
+  t.truthy(cfg.directories);
+  t.is(cfg.directories.input, "./");
+  t.is(cfg.directories.data, "./_data/");
+  t.is(cfg.directories.includes, "./_includes/");
+  t.is(cfg.directories.layouts, undefined);
+  t.is(cfg.directories.output, "./_site/");
+
+	t.throws(() => {
+		cfg.directories.input = "should not work";
+	});
+	t.throws(() => {
+		cfg.directories.data = "should not work";
+	});
+	t.throws(() => {
+		cfg.directories.includes = "should not work";
+	});
+	t.throws(() => {
+		cfg.directories.layouts = "should not work";
+	});
+	t.throws(() => {
+		cfg.directories.output = "should not work";
+	});
 });

--- a/test/TemplateDataTest.js
+++ b/test/TemplateDataTest.js
@@ -3,8 +3,9 @@ import semver from "semver";
 import { createRequire } from "module";
 
 import TemplateData from "../src/Data/TemplateData.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
+
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 const pkg = createRequire(import.meta.url)("../package.json");
 
@@ -20,8 +21,11 @@ async function testGetLocalData(tmplData, templatePath) {
 }
 
 test("Create", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  })
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -32,8 +36,11 @@ test("Create", async (t) => {
 });
 
 test("getGlobalData()", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let config = eleventyConfig.getConfig();
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
@@ -56,8 +63,11 @@ test("getGlobalData()", async (t) => {
 });
 
 test("getGlobalData() use default processing (false)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -68,14 +78,24 @@ test("getGlobalData() use default processing (false)", async (t) => {
 
 test("Data dir does not exist", async (t) => {
   await t.throwsAsync(async () => {
-    let dataObj = new TemplateData("./test/thisdirectorydoesnotexist");
+    let eleventyConfig = await getTemplateConfigInstance({
+      dir: {
+        input: "test/thisdirectorydoesnotexist"
+      }
+    });
+    let dataObj = new TemplateData("./test/thisdirectorydoesnotexist", eleventyConfig);
     await dataObj.getGlobalData();
+  }, {
+    message: "The `input` parameter (directory or file path) must exist on the file system (unless detected as a glob by the `is-glob` package)"
   });
 });
 
 test("Add local data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -98,8 +118,11 @@ test("Add local data", async (t) => {
 });
 
 test("Get local data async JS", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -112,8 +135,11 @@ test("Get local data async JS", async (t) => {
 });
 
 test("addLocalData() doesn’t exist but doesn’t fail (template file does exist)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -132,8 +158,11 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does exis
 });
 
 test("addLocalData() doesn’t exist but doesn’t fail (template file does not exist)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -151,8 +180,11 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does not 
 });
 
 test("Global Dir Directory", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "."
+    }
+  });
 
   let dataObj = new TemplateData("./", eleventyConfig);
 
@@ -160,8 +192,11 @@ test("Global Dir Directory", async (t) => {
 });
 
 test("Global Dir Directory with Constructor Path Arg", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
 
@@ -169,8 +204,11 @@ test("Global Dir Directory with Constructor Path Arg", async (t) => {
 });
 
 test("getAllGlobalData() with other data files", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -198,8 +236,11 @@ test("getAllGlobalData() with other data files", async (t) => {
 });
 
 test("getAllGlobalData() with js object data file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -218,8 +259,11 @@ test("getAllGlobalData() with js object data file", async (t) => {
 });
 
 test("getAllGlobalData() with js function data file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -238,12 +282,13 @@ test("getAllGlobalData() with js function data file", async (t) => {
 });
 
 test("getAllGlobalData() with config globalData", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addGlobalData("example", () => "one");
-  eleventyConfig.userConfig.addGlobalData("example2", async () => "two");
-  eleventyConfig.userConfig.addGlobalData("example3", "static");
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.addGlobalData("example", () => "one");
+    cfg.addGlobalData("example2", async () => "two");
+    cfg.addGlobalData("example3", "static");
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -256,8 +301,11 @@ test("getAllGlobalData() with config globalData", async (t) => {
 });
 
 test("getAllGlobalData() with common js function data file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -276,8 +324,11 @@ test("getAllGlobalData() with common js function data file", async (t) => {
 });
 
 test("getDataValue() without template engine preprocessing", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
 
@@ -292,8 +343,11 @@ test("getDataValue() without template engine preprocessing", async (t) => {
 });
 
 test("getLocalDataPaths", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -314,9 +368,11 @@ test("getLocalDataPaths", async (t) => {
 });
 
 test("getLocalDataPaths (with setDataFileBaseName #1699)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataFileBaseName("index");
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.setDataFileBaseName("index");
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -341,9 +397,11 @@ test("getLocalDataPaths (with setDataFileBaseName #1699)", async (t) => {
 });
 
 test("getLocalDataPaths (with empty setDataFileSuffixes #1699)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataFileSuffixes([]);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.setDataFileSuffixes([]);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -352,9 +410,11 @@ test("getLocalDataPaths (with empty setDataFileSuffixes #1699)", async (t) => {
 });
 
 test("getLocalDataPaths (with setDataFileSuffixes override #1699)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataFileSuffixes([".howdy"]);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.setDataFileSuffixes([".howdy"]);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -373,9 +433,12 @@ test("getLocalDataPaths (with setDataFileSuffixes override #1699)", async (t) =>
 });
 
 test("getLocalDataPaths (with setDataFileSuffixes empty string override #1699)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataFileSuffixes([""]);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.setDataFileSuffixes([""]);
+  });
+
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -384,9 +447,12 @@ test("getLocalDataPaths (with setDataFileSuffixes empty string override #1699)",
 });
 
 test("getLocalDataPaths (with setDataFileSuffixes override with two entries #1699)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataFileSuffixes([".howdy", ""]);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.setDataFileSuffixes([".howdy", ""]);
+  });
+
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -407,11 +473,12 @@ test("getLocalDataPaths (with setDataFileSuffixes override with two entries #169
 });
 
 test("getLocalDataPaths (with setDataFileSuffixes and setDataFileBaseName #1699)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataFileBaseName("index");
-  eleventyConfig.userConfig.setDataFileSuffixes([".howdy", ""]);
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.setDataFileBaseName("index");
+    cfg.setDataFileSuffixes([".howdy", ""]);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -436,8 +503,7 @@ test("getLocalDataPaths (with setDataFileSuffixes and setDataFileBaseName #1699)
 });
 
 test("Deeper getLocalDataPaths", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let dataObj = new TemplateData("./", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -462,8 +528,11 @@ test("Deeper getLocalDataPaths", async (t) => {
 });
 
 test("getLocalDataPaths with an 11ty js template", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.11ty.js");
@@ -483,8 +552,11 @@ test("getLocalDataPaths with an 11ty js template", async (t) => {
 });
 
 test("getLocalDataPaths with inputDir passed in (trailing slash)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -504,8 +576,11 @@ test("getLocalDataPaths with inputDir passed in (trailing slash)", async (t) => 
 });
 
 test("getLocalDataPaths with inputDir passed in (no trailing slash)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -525,8 +600,11 @@ test("getLocalDataPaths with inputDir passed in (no trailing slash)", async (t) 
 });
 
 test("getLocalDataPaths with inputDir passed in (no leading slash)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("test/stubs", eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
@@ -546,8 +624,11 @@ test("getLocalDataPaths with inputDir passed in (no leading slash)", async (t) =
 });
 
 test("getRawImports", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let dataObj = new TemplateData("test/stubs", eleventyConfig);
   let data = await dataObj.getRawImports();
@@ -556,8 +637,11 @@ test("getRawImports", async (t) => {
 });
 
 test("getTemplateDataFileGlob", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs"
+    }
+  });
 
   let tw = new TemplateData("test/stubs", eleventyConfig);
 
@@ -592,15 +676,14 @@ test("TemplateData.cleanupData", (t) => {
 });
 
 test("Parent directory for data (Issue #337)", async (t) => {
-  let eleventyConfig = new TemplateConfig({
+  let eleventyConfig = await getTemplateConfigInstance({
     dir: {
       input: "./test/stubs-337/src/",
       data: "../data/",
-    },
+    }
   });
-  await eleventyConfig.init();
+
   let dataObj = new TemplateData("./test/stubs-337/src/", eleventyConfig);
-  dataObj.setInputDir("./test/stubs-337/src/");
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -611,15 +694,13 @@ test("Parent directory for data (Issue #337)", async (t) => {
 });
 
 test("Dots in datafile path (Issue #1242)", async (t) => {
-  let eleventyConfig = new TemplateConfig({
+  let eleventyConfig = await getTemplateConfigInstance({
     dir: {
       input: "./test/stubs-1242/",
-      data: "_data/",
-    },
+    }
   });
-  await eleventyConfig.init();
+
   let dataObj = new TemplateData("./test/stubs-1242/", eleventyConfig);
-  dataObj.setInputDir("./test/stubs-1242/");
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -633,17 +714,17 @@ test("Dots in datafile path (Issue #1242)", async (t) => {
 });
 
 test("addGlobalData values", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  eleventyConfig.userConfig.addGlobalData("myFunction", () => "fn-value");
-  eleventyConfig.userConfig.addGlobalData("myPromise", () => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, 100, "promise-value");
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "./test/stubs-global-data-config-api/"
+  }, function(cfg) {
+    cfg.addGlobalData("myFunction", () => "fn-value");
+    cfg.addGlobalData("myPromise", () => {
+      return new Promise((resolve) => {
+        setTimeout(resolve, 100, "promise-value");
+      });
     });
+    cfg.addGlobalData("myAsync", async () => Promise.resolve("promise-value"));
   });
-  eleventyConfig.userConfig.addGlobalData("myAsync", async () => Promise.resolve("promise-value"));
-
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs-global-data-config-api/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -656,14 +737,15 @@ test("addGlobalData values", async (t) => {
 
 test("addGlobalData should execute once.", async (t) => {
   let count = 0;
-  let eleventyConfig = new TemplateConfig();
 
-  eleventyConfig.userConfig.addGlobalData("count", () => {
-    count++;
-    return count;
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "./test/stubs-global-data-config-api/"
+  }, function(cfg) {
+    cfg.addGlobalData("count", () => {
+      count++;
+      return count;
+    });
   });
-
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs-global-data-config-api/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -675,12 +757,12 @@ test("addGlobalData should execute once.", async (t) => {
 });
 
 test("addGlobalData complex key", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  eleventyConfig.userConfig.addGlobalData("deep.nested.one", () => "first");
-  eleventyConfig.userConfig.addGlobalData("deep.nested.two", () => "second");
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "./test/stubs-global-data-config-api-nested/"
+  }, function(cfg) {
+    cfg.addGlobalData("deep.nested.one", () => "first");
+    cfg.addGlobalData("deep.nested.two", () => "second");
+  });
 
   let dataObj = new TemplateData("./test/stubs-global-data-config-api-nested/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -692,12 +774,12 @@ test("addGlobalData complex key", async (t) => {
 });
 
 test("eleventy.version and eleventy.generator returned from data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  eleventyConfig.userConfig.addGlobalData("deep.nested.one", () => "first");
-  eleventyConfig.userConfig.addGlobalData("deep.nested.two", () => "second");
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "./test/stubs-empty/"
+  }, function(cfg) {
+    cfg.addGlobalData("deep.nested.one", () => "first");
+    cfg.addGlobalData("deep.nested.two", () => "second");
+  });
 
   let dataObj = new TemplateData("./test/stubs-empty/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -713,8 +795,11 @@ test("eleventy.version and eleventy.generator returned from data", async (t) => 
 });
 
 test("getGlobalData() empty json file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs-empty-json-data/",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs-empty-json-data/", eleventyConfig);
 
@@ -725,8 +810,11 @@ test("getGlobalData() empty json file", async (t) => {
 });
 
 test("ESM data file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "./test/stubs-data-esm/",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs-data-esm/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());

--- a/test/TemplateDataTest.js
+++ b/test/TemplateDataTest.js
@@ -27,7 +27,7 @@ test("Create", async (t) => {
     }
   })
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -43,7 +43,7 @@ test("getGlobalData()", async (t) => {
   });
 
   let config = eleventyConfig.getConfig();
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   t.is(dataObj.getGlobalData().toString(), "[object Promise]");
@@ -69,7 +69,7 @@ test("getGlobalData() use default processing (false)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -83,7 +83,7 @@ test("Data dir does not exist", async (t) => {
         input: "test/thisdirectorydoesnotexist"
       }
     });
-    let dataObj = new TemplateData("./test/thisdirectorydoesnotexist", eleventyConfig);
+    let dataObj = new TemplateData(eleventyConfig);
     await dataObj.getGlobalData();
   }, {
     message: "The `input` parameter (directory or file path) must exist on the file system (unless detected as a glob by the `is-glob` package)"
@@ -97,7 +97,7 @@ test("Add local data", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -124,7 +124,7 @@ test("Get local data async JS", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let withLocalData = await testGetLocalData(dataObj, "./test/stubs/component-async/component.njk");
@@ -141,7 +141,7 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does exis
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -164,7 +164,7 @@ test("addLocalData() doesn’t exist but doesn’t fail (template file does not 
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -186,7 +186,7 @@ test("Global Dir Directory", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), ["./_data/**/*.{json,mjs,cjs,js}"]);
 });
@@ -198,7 +198,7 @@ test("Global Dir Directory with Constructor Path Arg", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), ["./test/stubs/_data/**/*.{json,mjs,cjs,js}"]);
 });
@@ -210,7 +210,7 @@ test("getAllGlobalData() with other data files", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -242,7 +242,7 @@ test("getAllGlobalData() with js object data file", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -265,7 +265,7 @@ test("getAllGlobalData() with js function data file", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -290,7 +290,7 @@ test("getAllGlobalData() with config globalData", async (t) => {
     cfg.addGlobalData("example3", "static");
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -307,7 +307,7 @@ test("getAllGlobalData() with common js function data file", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -330,7 +330,7 @@ test("getDataValue() without template engine preprocessing", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   let data = await dataObj.getDataValue("./test/stubs/_data/testDataLiquid.json", {
     pkg: { name: "pkgname" },
@@ -349,7 +349,7 @@ test("getLocalDataPaths", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -374,7 +374,7 @@ test("getLocalDataPaths (with setDataFileBaseName #1699)", async (t) => {
     cfg.setDataFileBaseName("index");
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -403,7 +403,7 @@ test("getLocalDataPaths (with empty setDataFileSuffixes #1699)", async (t) => {
     cfg.setDataFileSuffixes([]);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, []);
@@ -416,7 +416,7 @@ test("getLocalDataPaths (with setDataFileSuffixes override #1699)", async (t) =>
     cfg.setDataFileSuffixes([".howdy"]);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -440,7 +440,7 @@ test("getLocalDataPaths (with setDataFileSuffixes empty string override #1699)",
   });
 
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, ["./test/stubs/stubs.json", "./test/stubs/component/component.json"]);
@@ -454,7 +454,7 @@ test("getLocalDataPaths (with setDataFileSuffixes override with two entries #169
   });
 
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -480,7 +480,7 @@ test("getLocalDataPaths (with setDataFileSuffixes and setDataFileBaseName #1699)
     cfg.setDataFileSuffixes([".howdy", ""]);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -505,7 +505,7 @@ test("getLocalDataPaths (with setDataFileSuffixes and setDataFileBaseName #1699)
 test("Deeper getLocalDataPaths", async (t) => {
   let eleventyConfig = await getTemplateConfigInstance();
 
-  let dataObj = new TemplateData("./", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -534,7 +534,7 @@ test("getLocalDataPaths with an 11ty js template", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.11ty.js");
 
   t.deepEqual(paths, [
@@ -558,7 +558,7 @@ test("getLocalDataPaths with inputDir passed in (trailing slash)", async (t) => 
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -582,7 +582,7 @@ test("getLocalDataPaths with inputDir passed in (no trailing slash)", async (t) 
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -606,7 +606,7 @@ test("getLocalDataPaths with inputDir passed in (no leading slash)", async (t) =
     }
   });
 
-  let dataObj = new TemplateData("test/stubs", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let paths = await dataObj.getLocalDataPaths("./test/stubs/component/component.liquid");
 
   t.deepEqual(paths, [
@@ -630,7 +630,7 @@ test("getRawImports", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("test/stubs", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let data = await dataObj.getRawImports();
 
   t.is(data.pkg.name, "@11ty/eleventy");
@@ -643,7 +643,7 @@ test("getTemplateDataFileGlob", async (t) => {
     }
   });
 
-  let tw = new TemplateData("test/stubs", eleventyConfig);
+  let tw = new TemplateData(eleventyConfig);
 
   t.deepEqual(await tw.getTemplateDataFileGlob(), [
     "./test/stubs/**/*.{json,11tydata.mjs,11tydata.cjs,11tydata.js}",
@@ -683,7 +683,7 @@ test("Parent directory for data (Issue #337)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs-337/src/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -700,7 +700,7 @@ test("Dots in datafile path (Issue #1242)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs-1242/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -726,7 +726,7 @@ test("addGlobalData values", async (t) => {
     cfg.addGlobalData("myAsync", async () => Promise.resolve("promise-value"));
   });
 
-  let dataObj = new TemplateData("./test/stubs-global-data-config-api/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   let data = await dataObj.getGlobalData();
 
@@ -747,7 +747,7 @@ test("addGlobalData should execute once.", async (t) => {
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs-global-data-config-api/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -764,7 +764,7 @@ test("addGlobalData complex key", async (t) => {
     cfg.addGlobalData("deep.nested.two", () => "second");
   });
 
-  let dataObj = new TemplateData("./test/stubs-global-data-config-api-nested/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   let data = await dataObj.getGlobalData();
 
@@ -781,7 +781,7 @@ test("eleventy.version and eleventy.generator returned from data", async (t) => 
     cfg.addGlobalData("deep.nested.two", () => "second");
   });
 
-  let dataObj = new TemplateData("./test/stubs-empty/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   let data = await dataObj.getGlobalData();
 
@@ -801,7 +801,7 @@ test("getGlobalData() empty json file", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs-empty-json-data/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
@@ -816,7 +816,7 @@ test("ESM data file", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs-data-esm/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();

--- a/test/TemplateDataTest.js
+++ b/test/TemplateDataTest.js
@@ -86,7 +86,7 @@ test("Data dir does not exist", async (t) => {
     let dataObj = new TemplateData(eleventyConfig);
     await dataObj.getGlobalData();
   }, {
-    message: "The `input` parameter (directory or file path) must exist on the file system (unless detected as a glob by the `is-glob` package)"
+    message: "The \"test/thisdirectorydoesnotexist\" `input` parameter (directory or file path) must exist on the file system (unless detected as a glob by the `is-glob` package)"
   });
 });
 
@@ -188,7 +188,7 @@ test("Global Dir Directory", async (t) => {
 
   let dataObj = new TemplateData(eleventyConfig);
 
-  t.deepEqual(await dataObj.getGlobalDataGlob(), ["./_data/**/*.{json,mjs,cjs,js}"]);
+  t.deepEqual(dataObj.getGlobalDataGlob(), ["./_data/**/*.{json,mjs,cjs,js}"]);
 });
 
 test("Global Dir Directory with Constructor Path Arg", async (t) => {
@@ -200,7 +200,7 @@ test("Global Dir Directory with Constructor Path Arg", async (t) => {
 
   let dataObj = new TemplateData(eleventyConfig);
 
-  t.deepEqual(await dataObj.getGlobalDataGlob(), ["./test/stubs/_data/**/*.{json,mjs,cjs,js}"]);
+  t.deepEqual(dataObj.getGlobalDataGlob(), ["./test/stubs/_data/**/*.{json,mjs,cjs,js}"]);
 });
 
 test("getAllGlobalData() with other data files", async (t) => {

--- a/test/TemplateEngineTest.js
+++ b/test/TemplateEngineTest.js
@@ -1,19 +1,16 @@
 import test from "ava";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateEngine from "../src/Engines/TemplateEngine.js";
 
-test("Unsupported engine", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+import { getTemplateConfigInstance } from "./_testHelpers.js"
 
-  let engine = new TemplateEngine("doesnotexist", null, eleventyConfig);
+test("Unsupported engine", async (t) => {
+  let eleventyConfig = await getTemplateConfigInstance();
+  let engine = new TemplateEngine("doesnotexist", eleventyConfig);
   t.is(engine.getName(), "doesnotexist");
 });
 
 test("Supported engine", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
-  t.is(new TemplateEngine("liquid", null, eleventyConfig).getName(), "liquid");
+  let eleventyConfig = await getTemplateConfigInstance();
+  t.is(new TemplateEngine("liquid", eleventyConfig).getName(), "liquid");
 });

--- a/test/TemplateFileSlugTest.js
+++ b/test/TemplateFileSlugTest.js
@@ -2,14 +2,18 @@ import test from "ava";
 
 import TemplateFileSlug from "../src/TemplateFileSlug.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
-import TemplateConfig from "../src/TemplateConfig.js";
+
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 async function getNewSlugInstance(path, inputDir) {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: inputDir
+    }
+  });
 
   let extensionMap = new EleventyExtensionMap([], eleventyConfig);
-  let fs = new TemplateFileSlug(path, inputDir, extensionMap);
+  let fs = new TemplateFileSlug(path, extensionMap, eleventyConfig);
   return fs;
 }
 

--- a/test/TemplateLayoutPathResolverTest.js
+++ b/test/TemplateLayoutPathResolverTest.js
@@ -1,20 +1,24 @@
 import test from "ava";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateLayoutPathResolver from "../src/TemplateLayoutPathResolver.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
+
 async function getResolverInstance(path, inputDir, { eleventyConfig, map } = {}) {
   if (!eleventyConfig) {
-    eleventyConfig = new TemplateConfig();
-    await eleventyConfig.init();
+    eleventyConfig = await getTemplateConfigInstance({
+      dir: {
+        input: inputDir
+      }
+    });
   }
 
   if (!map) {
     map = new EleventyExtensionMap(["liquid", "md", "njk", "html", "11ty.js"], eleventyConfig);
   }
 
-  return new TemplateLayoutPathResolver(path, inputDir, map, eleventyConfig);
+  return new TemplateLayoutPathResolver(path, map, eleventyConfig);
 }
 
 test("Layout", async (t) => {
@@ -28,12 +32,12 @@ test("Layout already has extension", async (t) => {
 });
 
 test("Layout (uses empty string includes folder)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
+  let eleventyConfig = await getTemplateConfigInstance({
     templateFormats: ["liquid"],
     dir: {
-      includes: "",
-    },
+      input: "test/stubs",
+      includes: ""
+    }
   });
 
   let res = await getResolverInstance("includesemptystring", "./test/stubs", {
@@ -44,12 +48,12 @@ test("Layout (uses empty string includes folder)", async (t) => {
 });
 
 test("Layout (uses empty string includes folder) already has extension", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
+  let eleventyConfig = await getTemplateConfigInstance({
     templateFormats: ["liquid"],
     dir: {
-      includes: "",
-    },
+      input: "test/stubs",
+      includes: ""
+    }
   });
 
   let res = await getResolverInstance("includesemptystring.liquid", "./test/stubs", {
@@ -60,13 +64,13 @@ test("Layout (uses empty string includes folder) already has extension", async (
 });
 
 test("Layout (uses layouts folder)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
+  let eleventyConfig = await getTemplateConfigInstance({
     templateFormats: ["liquid"],
     dir: {
+      input: "test/stubs",
       layouts: "_layouts",
       includes: "_includes",
-    },
+    }
   });
 
   let res = await getResolverInstance("layoutsdefault", "./test/stubs", {
@@ -77,13 +81,12 @@ test("Layout (uses layouts folder)", async (t) => {
 });
 
 test("Layout (uses layouts folder) already has extension", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
+  let eleventyConfig = await getTemplateConfigInstance({
     templateFormats: ["liquid"],
     dir: {
+      input: "test/stubs",
       layouts: "_layouts",
-      includes: "_includes",
-    },
+    }
   });
 
   let res = await getResolverInstance("layoutsdefault.liquid", "./test/stubs", {
@@ -94,13 +97,12 @@ test("Layout (uses layouts folder) already has extension", async (t) => {
 });
 
 test("Layout (uses empty string layouts folder)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
+  let eleventyConfig = await getTemplateConfigInstance({
     templateFormats: ["liquid"],
     dir: {
+      input: "test/stubs",
       layouts: "",
-      includes: "_includes",
-    },
+    }
   });
 
   let res = await getResolverInstance("layoutsemptystring", "./test/stubs", {
@@ -111,15 +113,11 @@ test("Layout (uses empty string layouts folder)", async (t) => {
 });
 
 test("Layout (uses empty string layouts folder) no template resolution", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setLayoutResolution(false);
-
-  await eleventyConfig.init({
-    templateFormats: ["liquid"],
-    dir: {
-      layouts: "",
-      includes: "_includes",
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    layouts: ""
+  }, function(cfg) {
+    cfg.setLayoutResolution(false);
   });
 
   let res = await getResolverInstance("layoutsemptystring", "./test/stubs", {
@@ -128,17 +126,18 @@ test("Layout (uses empty string layouts folder) no template resolution", async (
 
   t.throws(() => {
     res.getFileName();
+  }, {
+    message: `You’re trying to use a layout that does not exist: layoutsemptystring`
   });
 });
 
 test("Layout (uses empty string layouts folder) already has extension", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
+  let eleventyConfig = await getTemplateConfigInstance({
     templateFormats: ["liquid"],
     dir: {
+      input: "test/stubs",
       layouts: "",
-      includes: "_includes",
-    },
+    }
   });
 
   let res = await getResolverInstance("layoutsemptystring.liquid", "./test/stubs", {

--- a/test/TemplateLayoutTest.js
+++ b/test/TemplateLayoutTest.js
@@ -7,7 +7,11 @@ import { renderLayoutViaLayout } from "./_getRenderedTemplates.js";
 import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 async function getTemplateLayoutInstance(key, inputDir, map) {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: inputDir,
+		}
+	});
 
   if (!map) {
     map = new EleventyExtensionMap(["liquid", "md", "njk", "html", "11ty.js"], eleventyConfig);

--- a/test/TemplateLayoutTest.js
+++ b/test/TemplateLayoutTest.js
@@ -16,7 +16,7 @@ async function getTemplateLayoutInstance(key, inputDir, map) {
   if (!map) {
     map = new EleventyExtensionMap(["liquid", "md", "njk", "html", "11ty.js"], eleventyConfig);
   }
-  let layout = new TemplateLayout(key, inputDir, map, eleventyConfig);
+  let layout = new TemplateLayout(key, map, eleventyConfig);
   return layout;
 }
 

--- a/test/TemplateLayoutTest.js
+++ b/test/TemplateLayoutTest.js
@@ -1,13 +1,13 @@
 import test from "ava";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateLayout from "../src/TemplateLayout.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
+
 import { renderLayoutViaLayout } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 async function getTemplateLayoutInstance(key, inputDir, map) {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   if (!map) {
     map = new EleventyExtensionMap(["liquid", "md", "njk", "html", "11ty.js"], eleventyConfig);

--- a/test/TemplateMapTest-ComputedData.js
+++ b/test/TemplateMapTest-ComputedData.js
@@ -1,13 +1,17 @@
 import test from "ava";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateData from "../src/Data/TemplateData.js";
 import TemplateMap from "../src/TemplateMap.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 test("Computed data can see tag generated collections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs-computed-collections"
+    }
+  });
 
   let tm = new TemplateMap(eleventyConfig);
 
@@ -54,9 +58,11 @@ test("Computed data can see tag generated collections", async (t) => {
 });
 
 test("Computed data can see paginated data, Issue #1138", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs-computed-pagination"
+    }
+  });
   let tm = new TemplateMap(eleventyConfig);
 
   let dataObj = new TemplateData("./test/stubs-computed-pagination/", eleventyConfig);
@@ -114,8 +120,11 @@ test("Computed data can see paginated data, Issue #1138", async (t) => {
 });
 
 test("Computed data in directory data file consumes data file data, Issue #1137", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs-computed-dirdata"
+    }
+  });
 
   let tm = new TemplateMap(eleventyConfig);
 
@@ -153,8 +162,11 @@ test("Computed data in directory data file consumes data file data, Issue #1137"
 });
 
 test("Computed data can filter collections (and other array methods)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs-computed-collections-filter"
+    }
+  });
 
   let tm = new TemplateMap(eleventyConfig);
 

--- a/test/TemplateMapTest-ComputedData.js
+++ b/test/TemplateMapTest-ComputedData.js
@@ -15,7 +15,7 @@ test("Computed data can see tag generated collections", async (t) => {
 
   let tm = new TemplateMap(eleventyConfig);
 
-  let dataObj = new TemplateData("./test/stubs-computed-collections/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-collections/collections.njk",
     "./test/stubs-computed-collections/",
@@ -27,7 +27,7 @@ test("Computed data can see tag generated collections", async (t) => {
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-collections/", eleventyConfig);
+  let dataObj2 = new TemplateData(eleventyConfig);
   let tmpl2 = await getNewTemplate(
     "./test/stubs-computed-collections/dog.njk",
     "./test/stubs-computed-collections/",
@@ -65,7 +65,7 @@ test("Computed data can see paginated data, Issue #1138", async (t) => {
   });
   let tm = new TemplateMap(eleventyConfig);
 
-  let dataObj = new TemplateData("./test/stubs-computed-pagination/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-pagination/paginated.njk",
     "./test/stubs-computed-pagination/",
@@ -77,7 +77,7 @@ test("Computed data can see paginated data, Issue #1138", async (t) => {
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-pagination/", eleventyConfig);
+  let dataObj2 = new TemplateData(eleventyConfig);
   let tmpl2 = await getNewTemplate(
     "./test/stubs-computed-pagination/child.11ty.cjs",
     "./test/stubs-computed-pagination/",
@@ -128,7 +128,7 @@ test("Computed data in directory data file consumes data file data, Issue #1137"
 
   let tm = new TemplateMap(eleventyConfig);
 
-  let dataObj = new TemplateData("./test/stubs-computed-dirdata/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-dirdata/dir/first.11ty.cjs",
     "./test/stubs-computed-dirdata/",
@@ -140,7 +140,7 @@ test("Computed data in directory data file consumes data file data, Issue #1137"
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-dirdata/", eleventyConfig);
+  let dataObj2 = new TemplateData(eleventyConfig);
   let tmpl2 = await getNewTemplate(
     "./test/stubs-computed-dirdata/dir/second.11ty.cjs",
     "./test/stubs-computed-dirdata/",
@@ -170,7 +170,7 @@ test("Computed data can filter collections (and other array methods)", async (t)
 
   let tm = new TemplateMap(eleventyConfig);
 
-  let dataObj = new TemplateData("./test/stubs-computed-collections-filter/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-collections-filter/collections.njk",
     "./test/stubs-computed-collections-filter/",
@@ -182,7 +182,7 @@ test("Computed data can filter collections (and other array methods)", async (t)
 
   await tm.add(tmpl);
 
-  let dataObj2 = new TemplateData("./test/stubs-computed-collections-filter/", eleventyConfig);
+  let dataObj2 = new TemplateData(eleventyConfig);
   let tmpl2 = await getNewTemplate(
     "./test/stubs-computed-collections-filter/dog.njk",
     "./test/stubs-computed-collections-filter/",

--- a/test/TemplateMapTest.js
+++ b/test/TemplateMapTest.js
@@ -243,7 +243,12 @@ This page is bars
 });
 
 test("Issue #115 with layout, mixing pagination and collections", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		}
+	});
 
   let tmplFoos = await getNewTemplate(
     "./test/stubs/issue-115/template-foos.liquid",
@@ -309,7 +314,12 @@ This page is bars
 });
 
 test("TemplateMap adds collections data and has page data values using .cache()", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		}
+	});
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -328,7 +338,12 @@ test("TemplateMap adds collections data and has page data values using .cache()"
 });
 
 test("TemplateMap adds collections data and has page data values using ._testGetCollectionsData()", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		}
+	});
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -352,7 +367,10 @@ test("TemplateMap adds collections data and has page data values using ._testGet
 
 test("Url should be available in user config collections API calls", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         return collection.getAll();
@@ -385,7 +403,10 @@ test("Url should be available in user config collections API calls", async (t) =
 
 test("Url should be available in user config collections API calls (test in callback)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getAll();
@@ -432,7 +453,10 @@ test("Should be able to paginate a tag generated collection", async (t) => {
 
 test("Should be able to paginate a user config collection", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getFilteredByTag("dog");
@@ -463,7 +487,10 @@ test("Should be able to paginate a user config collection", async (t) => {
 
 test("Should be able to paginate a user config collection (uses rendered permalink)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getFilteredByTag("dog");
@@ -502,7 +529,10 @@ test("Should be able to paginate a user config collection (uses rendered permali
 
 test("Should be able to paginate a user config collection (paged template is also tagged)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getFilteredByTag("dog");
@@ -538,7 +568,10 @@ test("Should be able to paginate a user config collection (paged template is als
 
 test("Should be able to paginate a user config collection (paged template is also tagged, add all pages to collections)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getFilteredByTag("dog");
@@ -575,7 +608,10 @@ test("Should be able to paginate a user config collection (paged template is als
 
 test("Should be able to paginate a user config collection (paged template is also tagged, uses custom rendered permalink)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getFilteredByTag("dog");
@@ -609,7 +645,10 @@ test("Should be able to paginate a user config collection (paged template is als
 
 test("Should be able to paginate a user config collection (paged template is also tagged, uses custom rendered permalink, add all pages to collections)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         let all = collection.getFilteredByTag("dog");
@@ -643,7 +682,12 @@ test("Should be able to paginate a user config collection (paged template is als
 });
 
 test("TemplateMap render and templateContent are the same (templateContent doesn’t have layout but makes proper use of layout front matter data)", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		}
+	});
 
   let tm = new TemplateMap(eleventyConfig);
   let tmplLayout = await getNewTemplate(
@@ -746,7 +790,10 @@ test("Should be able to paginate a tag generated collection when aliased (and it
 
 test("Issue #253: Paginated template with a tag should put multiple pages into a collection", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", function (collection) {
         // TODO test user config collections (no actual tests against this collection yet)
@@ -863,7 +910,12 @@ test("Dependency Map should have include orphan user config collections (in the 
 });
 
 test("Template pages should not have layouts when added to collections", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		}
+	});
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -881,7 +933,12 @@ test("Template pages should not have layouts when added to collections", async (
 });
 
 test("Paginated template pages should not have layouts when added to collections", async (t) => {
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/stubs",
+			output: "test/stubs/_site",
+		}
+	});
 
   let tm = new TemplateMap(eleventyConfig);
 
@@ -1107,7 +1164,12 @@ test("Paginate over collections.all WITH a paginate over collections (tag pages)
 
 test("Test a transform with a layout (via templateMap)", async (t) => {
   t.plan(7);
-  let eleventyConfig = await getTemplateConfigInstance();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "./test/stubs-475/",
+			output: "./test/stubs-475/_site",
+		}
+	});
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -1144,7 +1206,10 @@ test("Test a transform with a layout (via templateMap)", async (t) => {
 
 test("Async user collection addCollection method", async (t) => {
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs/",
+    	output: "./test/stubs/_site",
+		},
     function(cfg) {
       cfg.addCollection("userCollection", async function (collection) {
         return new Promise((resolve) => {
@@ -1327,7 +1392,10 @@ test("eleventy.layouts Event", async (t) => {
   t.plan(1);
 
   let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
-    {},
+    {
+			input: "./test/stubs-layouts-event/",
+			output: "./test/stubs-layouts-event/_site",
+		},
     function(cfg) {
       cfg.on("eleventy.layouts", (layoutMap) => {
         t.deepEqual(layoutMap, {

--- a/test/TemplateMapTest.js
+++ b/test/TemplateMapTest.js
@@ -5,9 +5,10 @@ import TemplateCollection from "../src/TemplateCollection.js";
 import UsingCircularTemplateContentReferenceError from "../src/Errors/UsingCircularTemplateContentReferenceError.js";
 import TemplateContentUnrenderedTemplateError from "../src/Errors/TemplateContentUnrenderedTemplateError.js";
 import { normalizeNewLines } from "./Util/normalizeNewLines.js";
-import TemplateConfig from "../src/TemplateConfig.js";
+
 import getNewTemplateForTests from "./_getNewTemplateForTests.js";
 import { getRenderedTemplates as getRenderedTmpls, renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 function getNewTemplate(filename, input, output, eleventyConfig) {
   return getNewTemplateForTests(filename, input, output, null, null, eleventyConfig);
@@ -24,9 +25,9 @@ function getNewTemplateByNumber(num, eleventyConfig) {
 
 async function testRenderWithoutLayouts(template, data) {
   let ret = await template.renderPageEntryWithoutLayout({
-		rawInput: await template.getPreRender(),
-		data,
-	});
+    rawInput: await template.getPreRender(),
+    data,
+  });
   return ret;
 }
 
@@ -38,8 +39,7 @@ async function addTemplate(collection, template) {
 }
 
 test("TemplateMap has collections added", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
 
@@ -53,8 +53,7 @@ test("TemplateMap has collections added", async (t) => {
 });
 
 test("TemplateMap compared to Collection API", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl4 = await getNewTemplateByNumber(4, eleventyConfig);
@@ -80,8 +79,7 @@ test("TemplateMap compared to Collection API", async (t) => {
 });
 
 test("populating the collection twice should clear the previous values (--watch was making it cumulative)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -97,8 +95,7 @@ test("populating the collection twice should clear the previous values (--watch 
 });
 
 test("TemplateMap adds collections data and has templateContent values", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -133,8 +130,7 @@ test("TemplateMap adds collections data and has templateContent values", async (
 });
 
 test("TemplateMap circular references (map without templateContent)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl3 = await getNewTemplateByNumber(3, eleventyConfig);
 
@@ -156,8 +152,7 @@ test("TemplateMap circular references (map without templateContent)", async (t) 
 });
 
 test("TemplateMap circular references (map.templateContent)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -182,8 +177,7 @@ test("TemplateMap circular references (map.templateContent)", async (t) => {
 });
 
 test("Issue #115, mixing pagination and collections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmplFoos = await getNewTemplate(
     "./test/stubs/issue-115/template-foos.liquid",
@@ -249,8 +243,7 @@ This page is bars
 });
 
 test("Issue #115 with layout, mixing pagination and collections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmplFoos = await getNewTemplate(
     "./test/stubs/issue-115/template-foos.liquid",
@@ -316,8 +309,7 @@ This page is bars
 });
 
 test("TemplateMap adds collections data and has page data values using .cache()", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -336,8 +328,7 @@ test("TemplateMap adds collections data and has page data values using .cache()"
 });
 
 test("TemplateMap adds collections data and has page data values using ._testGetCollectionsData()", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -360,11 +351,14 @@ test("TemplateMap adds collections data and has page data values using ._testGet
 });
 
 test("Url should be available in user config collections API calls", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    return collection.getAll();
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        return collection.getAll();
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -390,17 +384,20 @@ test("Url should be available in user config collections API calls", async (t) =
 });
 
 test("Url should be available in user config collections API calls (test in callback)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getAll();
-    t.is(all[0].url, "/templateMapCollection/test1/");
-    t.is(all[0].outputPath, "./test/stubs/_site/templateMapCollection/test1/index.html");
-    t.is(all[1].url, "/templateMapCollection/test2/");
-    t.is(all[1].outputPath, "./test/stubs/_site/templateMapCollection/test2/index.html");
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getAll();
+        t.is(all[0].url, "/templateMapCollection/test1/");
+        t.is(all[0].outputPath, "./test/stubs/_site/templateMapCollection/test1/index.html");
+        t.is(all[1].url, "/templateMapCollection/test2/");
+        t.is(all[1].outputPath, "./test/stubs/_site/templateMapCollection/test2/index.html");
 
-    return all;
-  });
-  await eleventyConfig.init();
+        return all;
+      });
+    }
+  );
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
@@ -411,8 +408,7 @@ test("Url should be available in user config collections API calls (test in call
 });
 
 test("Should be able to paginate a tag generated collection", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -435,12 +431,15 @@ test("Should be able to paginate a tag generated collection", async (t) => {
 });
 
 test("Should be able to paginate a user config collection", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getFilteredByTag("dog");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getFilteredByTag("dog");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -463,14 +462,17 @@ test("Should be able to paginate a user config collection", async (t) => {
 });
 
 test("Should be able to paginate a user config collection (uses rendered permalink)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getFilteredByTag("dog");
-    t.is(all[0].url, "/templateMapCollection/test1/");
-    t.is(all[0].outputPath, "./test/stubs/_site/templateMapCollection/test1/index.html");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getFilteredByTag("dog");
+        t.is(all[0].url, "/templateMapCollection/test1/");
+        t.is(all[0].outputPath, "./test/stubs/_site/templateMapCollection/test1/index.html");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -499,12 +501,15 @@ test("Should be able to paginate a user config collection (uses rendered permali
 });
 
 test("Should be able to paginate a user config collection (paged template is also tagged)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getFilteredByTag("dog");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getFilteredByTag("dog");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -532,12 +537,15 @@ test("Should be able to paginate a user config collection (paged template is als
 });
 
 test("Should be able to paginate a user config collection (paged template is also tagged, add all pages to collections)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getFilteredByTag("dog");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getFilteredByTag("dog");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -566,12 +574,15 @@ test("Should be able to paginate a user config collection (paged template is als
 });
 
 test("Should be able to paginate a user config collection (paged template is also tagged, uses custom rendered permalink)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getFilteredByTag("dog");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getFilteredByTag("dog");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -597,12 +608,15 @@ test("Should be able to paginate a user config collection (paged template is als
 });
 
 test("Should be able to paginate a user config collection (paged template is also tagged, uses custom rendered permalink, add all pages to collections)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    let all = collection.getFilteredByTag("dog");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        let all = collection.getFilteredByTag("dog");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -629,8 +643,7 @@ test("Should be able to paginate a user config collection (paged template is als
 });
 
 test("TemplateMap render and templateContent are the same (templateContent doesn’t have layout but makes proper use of layout front matter data)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmplLayout = await getNewTemplate(
@@ -649,8 +662,7 @@ test("TemplateMap render and templateContent are the same (templateContent doesn
 });
 
 test("Should be able to paginate a tag generated collection (and it has templateContent)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -695,8 +707,7 @@ test("Should be able to paginate a tag generated collection (and it has template
 });
 
 test("Should be able to paginate a tag generated collection when aliased (and it has templateContent)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -734,13 +745,16 @@ test("Should be able to paginate a tag generated collection when aliased (and it
 });
 
 test("Issue #253: Paginated template with a tag should put multiple pages into a collection", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    // TODO test user config collections (no actual tests against this collection yet)
-    let all = collection.getFilteredByTag("dog");
-    return all;
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        // TODO test user config collections (no actual tests against this collection yet)
+        let all = collection.getFilteredByTag("dog");
+        return all;
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -769,25 +783,31 @@ test("Issue #253: Paginated template with a tag should put multiple pages into a
 });
 
 test("getUserConfigCollectionNames", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    return collection.getAll();
-  });
-  eleventyConfig.userConfig.addCollection("otherUserCollection", function (collection) {
-    return collection.getAll();
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        return collection.getAll();
+      });
+      cfg.addCollection("otherUserCollection", function (collection) {
+        return collection.getAll();
+      });
+    }
+  );
 
   let tm = new TemplateMap(eleventyConfig);
   t.deepEqual(tm.getUserConfigCollectionNames(), ["userCollection", "otherUserCollection"]);
 });
 
 test("isUserConfigCollectionName", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    return collection.getAll();
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        return collection.getAll();
+      });
+    }
+  );
 
   let tm = new TemplateMap(eleventyConfig);
 
@@ -796,8 +816,7 @@ test("isUserConfigCollectionName", async (t) => {
 });
 
 test("Dependency Map should have nodes that have no dependencies and no dependents", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl5 = await getNewTemplateByNumber(5, eleventyConfig);
@@ -816,11 +835,14 @@ test("Dependency Map should have nodes that have no dependencies and no dependen
 });
 
 test("Dependency Map should have include orphan user config collections (in the correct order)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", function (collection) {
-    return collection.getAll();
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", function (collection) {
+        return collection.getAll();
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl5 = await getNewTemplateByNumber(5, eleventyConfig);
@@ -841,8 +863,7 @@ test("Dependency Map should have include orphan user config collections (in the 
 });
 
 test("Template pages should not have layouts when added to collections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -860,8 +881,7 @@ test("Template pages should not have layouts when added to collections", async (
 });
 
 test("Paginated template pages should not have layouts when added to collections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
 
@@ -882,8 +902,7 @@ test("Paginated template pages should not have layouts when added to collections
 });
 
 test("Tag pages. Allow pagination over all collections a la `data: collections`", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -917,8 +936,7 @@ test("Tag pages. Allow pagination over all collections a la `data: collections`"
 });
 
 test("Tag pages (all pages added to collections). Allow pagination over all collections a la `data: collections`", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -952,8 +970,7 @@ test("Tag pages (all pages added to collections). Allow pagination over all coll
 });
 
 test("eleventyExcludeFromCollections", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
 
@@ -980,8 +997,7 @@ test("eleventyExcludeFromCollections", async (t) => {
 });
 
 test("eleventyExcludeFromCollections and permalink: false", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
 
@@ -1008,8 +1024,7 @@ test("eleventyExcludeFromCollections and permalink: false", async (t) => {
 });
 
 test("Paginate over collections.all", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -1060,8 +1075,7 @@ test("Paginate over collections.all", async (t) => {
 });
 
 test("Paginate over collections.all WITH a paginate over collections (tag pages)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
   let tmpl2 = await getNewTemplateByNumber(2, eleventyConfig);
@@ -1093,8 +1107,7 @@ test("Paginate over collections.all WITH a paginate over collections (tag pages)
 
 test("Test a transform with a layout (via templateMap)", async (t) => {
   t.plan(7);
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -1130,15 +1143,18 @@ test("Test a transform with a layout (via templateMap)", async (t) => {
 });
 
 test("Async user collection addCollection method", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addCollection("userCollection", async function (collection) {
-    return new Promise((resolve) => {
-      setTimeout(function () {
-        resolve(collection.getAll());
-      }, 50);
-    });
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addCollection("userCollection", async function (collection) {
+        return new Promise((resolve) => {
+          setTimeout(function () {
+            resolve(collection.getAll());
+          }, 50);
+        });
+      });
+    }
+  );
 
   let tmpl1 = await getNewTemplateByNumber(1, eleventyConfig);
 
@@ -1152,8 +1168,7 @@ test("Async user collection addCollection method", async (t) => {
 });
 
 test("Duplicate permalinks in template map", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplate(
     "./test/stubs/permalink-conflicts/test1.md",
@@ -1177,8 +1192,7 @@ test("Duplicate permalinks in template map", async (t) => {
 });
 
 test("No duplicate permalinks in template map, using false", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplate(
     "./test/stubs/permalink-conflicts-false/test1.md",
@@ -1201,8 +1215,7 @@ test("No duplicate permalinks in template map, using false", async (t) => {
 });
 
 test("Duplicate permalinks in template map, no leading slash", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tmpl1 = await getNewTemplate(
     "./test/stubs/permalink-conflicts/test1.md",
@@ -1227,8 +1240,7 @@ test("Duplicate permalinks in template map, no leading slash", async (t) => {
 });
 
 test("TemplateMap circular references (map.templateContent) using eleventyExcludeFromCollections and collections.all", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmplExcluded = await getNewTemplate(
@@ -1266,8 +1278,7 @@ test("TemplateMap circular references (map.templateContent) using eleventyExclud
 });
 
 test("permalink object with build", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmplLayout = await getNewTemplate(
@@ -1286,8 +1297,7 @@ test("permalink object with build", async (t) => {
 });
 
 test("permalink object without build (defaults to `read` mode)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -1316,22 +1326,25 @@ test("permalink object without build (defaults to `read` mode)", async (t) => {
 test("eleventy.layouts Event", async (t) => {
   t.plan(1);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.on("eleventy.layouts", (layoutMap) => {
-    t.deepEqual(layoutMap, {
-      "./test/stubs-layouts-event/_includes/first.liquid": ["./test/stubs-layouts-event/page.md"],
-      "./test/stubs-layouts-event/_includes/second.liquid": [
-        "./test/stubs-layouts-event/page.md",
-        "./test/stubs-layouts-event/_includes/first.liquid",
-      ],
-      "./test/stubs-layouts-event/_includes/third.liquid": [
-        "./test/stubs-layouts-event/page.md",
-        "./test/stubs-layouts-event/_includes/first.liquid",
-        "./test/stubs-layouts-event/_includes/second.liquid",
-      ],
-    });
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.on("eleventy.layouts", (layoutMap) => {
+        t.deepEqual(layoutMap, {
+          "./test/stubs-layouts-event/_includes/first.liquid": ["./test/stubs-layouts-event/page.md"],
+          "./test/stubs-layouts-event/_includes/second.liquid": [
+            "./test/stubs-layouts-event/page.md",
+            "./test/stubs-layouts-event/_includes/first.liquid",
+          ],
+          "./test/stubs-layouts-event/_includes/third.liquid": [
+            "./test/stubs-layouts-event/page.md",
+            "./test/stubs-layouts-event/_includes/first.liquid",
+            "./test/stubs-layouts-event/_includes/second.liquid",
+          ],
+        });
+      });
+    }
+  );
 
   let tm = new TemplateMap(eleventyConfig);
   let tmpl = await getNewTemplate(

--- a/test/TemplatePassthroughManagerTest.js
+++ b/test/TemplatePassthroughManagerTest.js
@@ -7,6 +7,8 @@ import TemplateConfig from "../src/TemplateConfig.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
 import EleventyFiles from "../src/EleventyFiles.js";
 
+import { getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
+
 test("Get paths from Config", async (t) => {
   let eleventyConfig = new TemplateConfig();
   eleventyConfig.userConfig.passthroughCopies = {
@@ -177,13 +179,17 @@ test("getAllNormalizedPaths with globs", async (t) => {
 
 test("Look for uniqueness on template passthrough paths #1677", async (t) => {
   let formats = [];
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.passthroughCopies = {
-    "./test/stubs/template-passthrough-duplicates/**/*.png": {
-      outputPath: "./",
-    },
-  };
-  await eleventyConfig.init();
+
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+		input: "test/stubs/template-passthrough-duplicates",
+		output: "test/stubs/template-passthrough-duplicates/_site"
+	}, function(cfg) {
+		cfg.passthroughCopies = {
+			"./test/stubs/template-passthrough-duplicates/**/*.png": {
+				outputPath: "./",
+			},
+		};
+	});
 
   let files = new EleventyFiles(
     "test/stubs/template-passthrough-duplicates",
@@ -198,7 +204,6 @@ test("Look for uniqueness on template passthrough paths #1677", async (t) => {
   await t.throwsAsync(async function () {
     await mgr.copyAll();
   });
-
 
   rimrafSync("test/stubs/template-passthrough-duplicates/_site/");
 });

--- a/test/TemplatePassthroughManagerTest.js
+++ b/test/TemplatePassthroughManagerTest.js
@@ -191,12 +191,7 @@ test("Look for uniqueness on template passthrough paths #1677", async (t) => {
 		};
 	});
 
-  let files = new EleventyFiles(
-    "test/stubs/template-passthrough-duplicates",
-    "test/stubs/template-passthrough-duplicates/_site",
-    formats,
-    eleventyConfig
-  );
+  let files = new EleventyFiles(formats, eleventyConfig);
   files.setFileSystemSearch(new FileSystemSearch());
   files.init();
 

--- a/test/TemplatePassthroughTest.js
+++ b/test/TemplatePassthroughTest.js
@@ -290,5 +290,5 @@ test("Bug with incremental dir copying to a directory output, issue #2278 #1038"
     "."
   );
 
-  t.is(await pass1.getOutputPath(), "test/stubs");
+  t.is(await pass1.getOutputPath(), "./test/stubs/");
 });

--- a/test/TemplateRenderCustomTest.js
+++ b/test/TemplateRenderCustomTest.js
@@ -20,7 +20,7 @@ async function getNewTemplateRender(name, inputDir, eleventyConfig, extensionMap
     extensionMap = new EleventyExtensionMap([], eleventyConfig);
   }
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = extensionMap;
   await tr.init();
 

--- a/test/TemplateRenderCustomTest.js
+++ b/test/TemplateRenderCustomTest.js
@@ -5,15 +5,15 @@ import * as sass from "sass";
 
 import TemplateRender from "../src/TemplateRender.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
-import TemplateConfig from "../src/TemplateConfig.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 
 async function getNewTemplateRender(name, inputDir, eleventyConfig, extensionMap) {
   if (!eleventyConfig) {
-    eleventyConfig = new TemplateConfig();
-    await eleventyConfig.init();
+    eleventyConfig = await getTemplateConfigInstance();
   }
 
   if (!extensionMap) {
@@ -28,18 +28,20 @@ async function getNewTemplateRender(name, inputDir, eleventyConfig, extensionMap
 }
 
 test("Custom plaintext Render", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("txt", {
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
-  });
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("txt", {
+        compile: function (str, inputPath) {
+          // plaintext
+          return function (data) {
+            return str;
+          };
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("txt", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate("<p>Paragraph</p>");
@@ -48,18 +50,19 @@ test("Custom plaintext Render", async (t) => {
 });
 
 test("Custom Markdown Render with `compile` override", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("md", {
-    compile: function (str, inputPath) {
-      return function (data) {
-        return `<not-markdown>${str.trim()}</not-markdown>`;
-      };
-    },
-  });
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("md", {
+        compile: function (str, inputPath) {
+          return function (data) {
+            return `<not-markdown>${str.trim()}</not-markdown>`;
+          };
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -69,17 +72,18 @@ test("Custom Markdown Render with `compile` override", async (t) => {
 });
 
 test("Custom Markdown Render without `compile` override", async (t) => {
-  let eleventyConfig = new TemplateConfig();
   let initCalled = false;
-
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("md", {
-    init: function () {
-      initCalled = true;
-    },
-  });
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("md", {
+        init: function () {
+          initCalled = true;
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -90,19 +94,20 @@ test("Custom Markdown Render without `compile` override", async (t) => {
 });
 
 test("Custom Markdown Render with `compile` override + call to default compiler", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("md", {
-    compile: function (str, inputPath) {
-      return async function (data) {
-        const result = await this.defaultRenderer(data);
-        return `<custom-wrapper>${result.trim()}</custom-wrapper>`;
-      };
-    },
-  });
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("md", {
+        compile: function (str, inputPath) {
+          return async function (data) {
+            const result = await this.defaultRenderer(data);
+            return `<custom-wrapper>${result.trim()}</custom-wrapper>`;
+          };
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -112,23 +117,26 @@ test("Custom Markdown Render with `compile` override + call to default compiler"
 });
 
 test("Custom Vue Render", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("vue", {
-    compile: function (str) {
-      return async function (data) {
-        const app = createSSRApp({
-          template: str,
-          data: function () {
-            return data;
-          },
-        });
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("vue", {
+        compile: function (str) {
+          return async function (data) {
+            const app = createSSRApp({
+              template: str,
+              data: function () {
+                return data;
+              },
+            });
 
-        return renderToString(app);
-      };
-    },
-  });
-  await eleventyConfig.init();
+            return renderToString(app);
+          };
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("vue", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate('<p v-html="test">Paragraph</p>');
@@ -136,38 +144,39 @@ test("Custom Vue Render", async (t) => {
 });
 
 test("Custom Sass Render", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("sass", {
-    compile: function (str, inputPath) {
-      // TODO declare data variables as SASS variables?
-      return async function (data) {
-        return new Promise(function (resolve, reject) {
-          sass.render(
-            {
-              data: str,
-              includePaths: [tr.inputDir, tr.includesDir],
-              style: "expanded",
-              indentType: "space",
-              // TODO
-              // sourcemap: "file",
-              outFile: "test_this_is_to_not_write_a_file.css",
-            },
-            function (error, result) {
-              if (error) {
-                reject(error);
-              } else {
-                resolve(result.css.toString("utf8"));
-              }
-            },
-          );
-        });
-      };
-    },
-  });
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("sass", {
+        compile: function (str, inputPath) {
+          // TODO declare data variables as SASS variables?
+          return async function (data) {
+            return new Promise(function (resolve, reject) {
+              sass.render(
+                {
+                  data: str,
+                  includePaths: [tr.inputDir, tr.includesDir],
+                  style: "expanded",
+                  indentType: "space",
+                  // TODO
+                  // sourcemap: "file",
+                  outFile: "test_this_is_to_not_write_a_file.css",
+                },
+                function (error, result) {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(result.css.toString("utf8"));
+                  }
+                },
+              );
+            });
+          };
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("sass", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate("$color: blue; p { color: $color; }");
@@ -187,8 +196,6 @@ serverPrefetch: function() {
 test("JavaScript functions should not be mutable but not *that* mutable", async (t) => {
   t.plan(3);
 
-  let eleventyConfig = new TemplateConfig();
-
   let instance = {
     dataForCascade: function () {
       // was mutating this.config.javascriptFunctions!
@@ -197,24 +204,27 @@ test("JavaScript functions should not be mutable but not *that* mutable", async 
     },
   };
 
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("js1", {
-    getData: ["dataForCascade"],
-    getInstanceFromInputPath: function (inputPath) {
-      t.truthy(true);
-      return instance;
-    },
-    compile: function (str, inputPath) {
-      t.falsy(this.config.javascriptFunctions.shouldnotmutatethething);
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("js1", {
+        getData: ["dataForCascade"],
+        getInstanceFromInputPath: function (inputPath) {
+          t.truthy(true);
+          return instance;
+        },
+        compile: function (str, inputPath) {
+          t.falsy(this.config.javascriptFunctions.shouldnotmutatethething);
 
-      // plaintext
-      return (data) => {
-        return str;
-      };
-    },
-  });
-
-  await eleventyConfig.init();
+          // plaintext
+          return (data) => {
+            return str;
+          };
+        },
+      });
+    }
+  );
 
   let tmpl = await getNewTemplate(
     "./test/stubs-custom-extension/test.js1",
@@ -229,15 +239,17 @@ test("JavaScript functions should not be mutable but not *that* mutable", async 
 });
 
 test("Return undefined in compile to ignore #2267", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-
-  // addExtension() API
-  eleventyConfig.userConfig.addExtension("txt", {
-    compile: function (str, inputPath) {
-      return;
-    },
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      // addExtension() API
+      cfg.addExtension("txt", {
+        compile: function (str, inputPath) {
+          return;
+        },
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("txt", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate("<p>Paragraph</p>");
@@ -245,11 +257,14 @@ test("Return undefined in compile to ignore #2267", async (t) => {
 });
 
 test("Simple alias to Markdown Render", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addExtension("mdx", {
-    key: "md",
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addExtension("mdx", {
+        key: "md",
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("mdx", null, eleventyConfig);
 
@@ -260,11 +275,14 @@ test("Simple alias to Markdown Render", async (t) => {
 
 // NOTE: Breaking change in 3.0 `import` does not allow aliasing to non-.js file names
 test.skip("Breaking Change (3.0): Simple alias to JavaScript Render", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addExtension("11ty.custom", {
-    key: "11ty.js",
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addExtension("11ty.custom", {
+        key: "11ty.js",
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("./test/stubs/string.11ty.custom", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate();
@@ -273,12 +291,15 @@ test.skip("Breaking Change (3.0): Simple alias to JavaScript Render", async (t) 
 
 // NOTE: Breaking change in 3.0 `import` does not allow aliasing to non-.js file names
 test.skip("Breaking Change (3.0): Override to JavaScript Render", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addExtension("11ty.custom", {
-    key: "11ty.js",
-    init: function () {},
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addExtension("11ty.custom", {
+        key: "11ty.js",
+        init: function () {},
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("./test/stubs/string.11ty.custom", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate();
@@ -288,11 +309,14 @@ test.skip("Breaking Change (3.0): Override to JavaScript Render", async (t) => {
 // NOTE: Breaking change in 3.0 `import` does not allow aliasing to non-.js file names
 test.skip("Breaking Change (3.0): Two simple aliases to JavaScript Render", async (t) => {
   t.plan(2);
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addExtension(["11ty.custom", "11ty.possum"], {
-    key: "11ty.js", // esm
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addExtension(["11ty.custom", "11ty.possum"], {
+        key: "11ty.js", // esm
+      });
+    }
+  );
 
   let map = new EleventyExtensionMap([], eleventyConfig); // reuse this
 
@@ -311,15 +335,17 @@ test.skip("Breaking Change (3.0): Two simple aliases to JavaScript Render", asyn
 });
 
 test("Double override (not aliases) throws an error", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addExtension(["11ty.custom", "11ty.possum"], {
-    key: "11ty.js",
-    init: function () {
-      t.true(true);
-    },
-  });
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addExtension(["11ty.custom", "11ty.possum"], {
+        key: "11ty.js",
+        init: function () {
+          t.true(true);
+        },
+      });
+    }
+  );
 
   let map = new EleventyExtensionMap([], eleventyConfig); // reuse this
 

--- a/test/TemplateRenderHTMLTest.js
+++ b/test/TemplateRenderHTMLTest.js
@@ -1,11 +1,15 @@
 import test from "ava";
 import TemplateRender from "../src/TemplateRender.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 
+import { getTemplateConfigInstance } from "./_testHelpers.js";
+
 async function getNewTemplateRender(name, inputDir) {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: inputDir
+		}
+	});
 
   let tr = new TemplateRender(name, inputDir, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);

--- a/test/TemplateRenderHTMLTest.js
+++ b/test/TemplateRenderHTMLTest.js
@@ -11,7 +11,7 @@ async function getNewTemplateRender(name, inputDir) {
 		}
 	});
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
   return tr;

--- a/test/TemplateRenderJavaScriptTest.js
+++ b/test/TemplateRenderJavaScriptTest.js
@@ -1,12 +1,16 @@
 import test from "ava";
 
 import TemplateRender from "../src/TemplateRender.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 
+import { getTemplateConfigInstance } from "./_testHelpers.js";
+
 async function getNewTemplateRender(name, inputDir, extendedConfig) {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init(extendedConfig);
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: inputDir
+		}
+	}, null, extendedConfig);
 
   let tr = new TemplateRender(name, inputDir, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);

--- a/test/TemplateRenderJavaScriptTest.js
+++ b/test/TemplateRenderJavaScriptTest.js
@@ -12,7 +12,7 @@ async function getNewTemplateRender(name, inputDir, extendedConfig) {
 		}
 	}, null, extendedConfig);
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
 

--- a/test/TemplateRenderLiquidTest.js
+++ b/test/TemplateRenderLiquidTest.js
@@ -13,7 +13,7 @@ async function getNewTemplateRender(name, inputDir, userConfig = {}) {
 		}
 	}, null, userConfig);
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
   return tr;

--- a/test/TemplateRenderLiquidTest.js
+++ b/test/TemplateRenderLiquidTest.js
@@ -2,15 +2,16 @@ import test from "ava";
 import { Liquid, Drop } from "liquidjs";
 
 import TemplateRender from "../src/TemplateRender.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 
+import { getTemplateConfigInstance } from "./_testHelpers.js";
+
 async function getNewTemplateRender(name, inputDir, userConfig = {}) {
-  let eleventyConfig = new TemplateConfig();
-  for (let key in userConfig) {
-    eleventyConfig.userConfig[key] = userConfig[key];
-  }
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: inputDir
+		}
+	}, null, userConfig);
 
   let tr = new TemplateRender(name, inputDir, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);

--- a/test/TemplateRenderMarkdownPluginTest.js
+++ b/test/TemplateRenderMarkdownPluginTest.js
@@ -2,12 +2,12 @@ import test from "ava";
 import md from "markdown-it";
 
 import TemplateRender from "../src/TemplateRender.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 
+import { getTemplateConfigInstance } from "./_testHelpers.js";
+
 async function getNewTemplateRender(name, inputDir) {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tr = new TemplateRender(name, inputDir, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);

--- a/test/TemplateRenderMarkdownPluginTest.js
+++ b/test/TemplateRenderMarkdownPluginTest.js
@@ -9,7 +9,7 @@ import { getTemplateConfigInstance } from "./_testHelpers.js";
 async function getNewTemplateRender(name, inputDir) {
   let eleventyConfig = await getTemplateConfigInstance();
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
   return tr;

--- a/test/TemplateRenderMarkdownTest.js
+++ b/test/TemplateRenderMarkdownTest.js
@@ -4,16 +4,20 @@ import { full as mdEmoji } from 'markdown-it-emoji'
 import eleventySyntaxHighlightPlugin from "@11ty/eleventy-plugin-syntaxhighlight";
 
 import TemplateRender from "../src/TemplateRender.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import Liquid from "../src/Engines/Liquid.js";
 import Nunjucks from "../src/Engines/Nunjucks.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
+
 import { normalizeNewLines } from "./Util/normalizeNewLines.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 async function getNewTemplateRender(name, inputDir, eleventyConfig) {
   if (!eleventyConfig) {
-    eleventyConfig = new TemplateConfig();
-    await eleventyConfig.init();
+    eleventyConfig = await getTemplateConfigInstance({
+      dir: {
+        input: inputDir
+      }
+    });
   }
 
   let tr = new TemplateRender(name, inputDir, eleventyConfig);
@@ -137,10 +141,12 @@ This is some code.
 });
 
 test("Markdown Render: use prism highlighter (no language)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.addPlugin(eleventySyntaxHighlightPlugin);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addPlugin(eleventySyntaxHighlightPlugin);
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -162,10 +168,12 @@ This is some code.
 });
 
 test("Markdown Render: use prism highlighter", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.addPlugin(eleventySyntaxHighlightPlugin);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addPlugin(eleventySyntaxHighlightPlugin);
+    }
+  );
 
   let tr = await getNewTemplateRender("md");
 
@@ -187,10 +195,12 @@ var key = "value";
 });
 
 test("Markdown Render: use prism highlighter (no space before language)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.addPlugin(eleventySyntaxHighlightPlugin);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addPlugin(eleventySyntaxHighlightPlugin);
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -212,10 +222,12 @@ var key = "value";
 });
 
 test("Markdown Render: use prism highlighter, line highlighting", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.addPlugin(eleventySyntaxHighlightPlugin);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addPlugin(eleventySyntaxHighlightPlugin);
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
   let markdownHighlight = eleventyConfig.getConfig().markdownHighlighter;
@@ -236,11 +248,12 @@ var key = "value";
 });
 
 test("Markdown Render: use prism highlighter, line highlighting with fallback `text` language.", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.addPlugin(eleventySyntaxHighlightPlugin);
-
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.addPlugin(eleventySyntaxHighlightPlugin);
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -263,8 +276,7 @@ var key = "value";
 });
 
 test("Markdown Render: use Markdown inside of a Liquid shortcode (Issue #536)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance();
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -289,9 +301,7 @@ test("Markdown Render: use Markdown inside of a Liquid shortcode (Issue #536)", 
 });
 
 test("Markdown Render: use Markdown inside of a Nunjucks shortcode (Issue #536)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
+  let eleventyConfig = await getTemplateConfigInstance();
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
   let nunjucksEngine = new Nunjucks("njk", tr.getDirs(), eleventyConfig);
   nunjucksEngine.addShortcode("testShortcode", function () {
@@ -314,9 +324,7 @@ test("Markdown Render: use Markdown inside of a Nunjucks shortcode (Issue #536)"
 });
 
 test("Markdown Render: use Markdown inside of a Liquid paired shortcode (Issue #536)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
+  let eleventyConfig = await getTemplateConfigInstance();
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
   let liquidEngine = new Liquid("liquid", tr.getIncludesDir(), eleventyConfig);
@@ -340,9 +348,7 @@ test("Markdown Render: use Markdown inside of a Liquid paired shortcode (Issue #
 });
 
 test("Markdown Render: use Markdown inside of a Nunjucks paired shortcode (Issue #536)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
-
+  let eleventyConfig = await getTemplateConfigInstance();
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
   let nunjucksEngine = new Nunjucks("njk", tr.getDirs(), eleventyConfig);
@@ -383,10 +389,12 @@ test("Markdown Render: setLibrary does not have disabled indented code blocks ei
 });
 
 test("Markdown Render: use amendLibrary to re-enable indented code blocks. Issue #2438", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.amendLibrary("md", (lib) => lib.enable("code"));
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.amendLibrary("md", (lib) => lib.enable("code"));
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -400,10 +408,12 @@ test("Markdown Render: use amendLibrary to re-enable indented code blocks. Issue
 });
 
 test("Markdown Render: amendLibrary works with setLibrary to re-enable indented code blocks. Issue #2438", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.amendLibrary("md", (lib) => lib.enable("code"));
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.amendLibrary("md", (lib) => lib.enable("code"));
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -422,17 +432,19 @@ test("Markdown Render: amendLibrary works with setLibrary to re-enable indented 
 test("Markdown Render: multiple amendLibrary calls. Issue #2438", async (t) => {
   t.plan(3);
 
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.amendLibrary("md", (lib) => {
-    t.true(true);
-    lib.enable("code");
-  });
-  userConfig.amendLibrary("md", (lib) => {
-    t.true(true);
-    lib.disable("code");
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.amendLibrary("md", (lib) => {
+        t.true(true);
+        lib.enable("code");
+      });
+      cfg.amendLibrary("md", (lib) => {
+        t.true(true);
+        lib.disable("code");
+      });
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
@@ -442,10 +454,12 @@ test("Markdown Render: multiple amendLibrary calls. Issue #2438", async (t) => {
 });
 
 test("Markdown Render: use amendLibrary to add a Plugin", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  let userConfig = eleventyConfig.userConfig;
-  userConfig.amendLibrary("md", (mdLib) => mdLib.use(mdEmoji));
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {},
+    function(cfg) {
+      cfg.amendLibrary("md", (mdLib) => mdLib.use(mdEmoji));
+    }
+  );
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
   let fn = await tr.getCompiledTemplate(":)");

--- a/test/TemplateRenderMarkdownTest.js
+++ b/test/TemplateRenderMarkdownTest.js
@@ -280,7 +280,7 @@ test("Markdown Render: use Markdown inside of a Liquid shortcode (Issue #536)", 
 
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
-  let liquidEngine = new Liquid("liquid", tr.getDirs(), eleventyConfig);
+  let liquidEngine = new Liquid("liquid", eleventyConfig);
   liquidEngine.addShortcode("testShortcode", function () {
     return "## My Other Title";
   });
@@ -303,7 +303,7 @@ test("Markdown Render: use Markdown inside of a Liquid shortcode (Issue #536)", 
 test("Markdown Render: use Markdown inside of a Nunjucks shortcode (Issue #536)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstance();
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
-  let nunjucksEngine = new Nunjucks("njk", tr.getDirs(), eleventyConfig);
+  let nunjucksEngine = new Nunjucks("njk", eleventyConfig);
   nunjucksEngine.addShortcode("testShortcode", function () {
     return "## My Other Title";
   });
@@ -327,7 +327,7 @@ test("Markdown Render: use Markdown inside of a Liquid paired shortcode (Issue #
   let eleventyConfig = await getTemplateConfigInstance();
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
-  let liquidEngine = new Liquid("liquid", tr.getIncludesDir(), eleventyConfig);
+  let liquidEngine = new Liquid("liquid", eleventyConfig);
   liquidEngine.addPairedShortcode("testShortcode", function (content) {
     return content;
   });
@@ -351,7 +351,7 @@ test("Markdown Render: use Markdown inside of a Nunjucks paired shortcode (Issue
   let eleventyConfig = await getTemplateConfigInstance();
   let tr = await getNewTemplateRender("md", null, eleventyConfig);
 
-  let nunjucksEngine = new Nunjucks("njk", tr.getDirs(), eleventyConfig);
+  let nunjucksEngine = new Nunjucks("njk", eleventyConfig);
   nunjucksEngine.addPairedShortcode("testShortcode", function (content) {
     return content;
   });

--- a/test/TemplateRenderMarkdownTest.js
+++ b/test/TemplateRenderMarkdownTest.js
@@ -20,7 +20,7 @@ async function getNewTemplateRender(name, inputDir, eleventyConfig) {
     });
   }
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
   return tr;

--- a/test/TemplateRenderNunjucksTest.js
+++ b/test/TemplateRenderNunjucksTest.js
@@ -16,7 +16,7 @@ async function getNewTemplateRender(name, inputDir, eleventyConfig) {
     });
   }
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
   return tr;

--- a/test/TemplateRenderPluginTest.js
+++ b/test/TemplateRenderPluginTest.js
@@ -7,6 +7,7 @@ import {
   RenderManager,
 } from "../src/Plugins/RenderPlugin.js";
 import Eleventy from "../src/Eleventy.js";
+
 import { normalizeNewLines } from "./Util/normalizeNewLines.js";
 
 async function getTestOutput(input, configCallback = function () {}) {

--- a/test/TemplateRenderTest.js
+++ b/test/TemplateRenderTest.js
@@ -1,12 +1,16 @@
 import test from "ava";
 
 import TemplateRender from "../src/TemplateRender.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 
+import { getTemplateConfigInstance } from "./_testHelpers.js";
+
 async function getNewTemplateRender(name, inputDir) {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: inputDir
+		}
+	});
 
   let tr = new TemplateRender(name, inputDir, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
@@ -23,7 +27,7 @@ test("Basic", async (t) => {
 
 test("Includes Dir", async (t) => {
   let tr = await getNewTemplateRender("liquid", "./test/stubs");
-  t.is(tr.getIncludesDir(), "test/stubs/_includes");
+  t.is(tr.getIncludesDir(), "./test/stubs/_includes/");
 });
 
 test("Invalid override", async (t) => {

--- a/test/TemplateRenderTest.js
+++ b/test/TemplateRenderTest.js
@@ -12,7 +12,7 @@ async function getNewTemplateRender(name, inputDir) {
 		}
 	});
 
-  let tr = new TemplateRender(name, inputDir, eleventyConfig);
+  let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);
   await tr.init();
   return tr;

--- a/test/TemplateRenderTest.js
+++ b/test/TemplateRenderTest.js
@@ -7,10 +7,10 @@ import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 async function getNewTemplateRender(name, inputDir) {
   let eleventyConfig = await getTemplateConfigInstance({
-		dir: {
-			input: inputDir
-		}
-	});
+    dir: {
+      input: inputDir
+    }
+  });
 
   let tr = new TemplateRender(name, eleventyConfig);
   tr.extensionMap = new EleventyExtensionMap([], eleventyConfig);

--- a/test/TemplateTest-CompileOptions.js
+++ b/test/TemplateTest-CompileOptions.js
@@ -1,34 +1,38 @@
 import test from "ava";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateData from "../src/Data/TemplateData.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 test("Custom extension (.txt) with custom permalink compile function", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-      // pass in your own custom permalink function.
-      permalink: async function (permalinkString, inputPath) {
-        t.is(permalinkString, "custom-extension.lit");
-        t.is(inputPath, "./test/stubs/custom-extension.txt");
-        return async function () {
-          return "HAHA_THIS_ALWAYS_GOES_HERE.txt";
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+        // pass in your own custom permalink function.
+        permalink: async function (permalinkString, inputPath) {
+          t.is(permalinkString, "custom-extension.lit");
+          t.is(inputPath, "./test/stubs/custom-extension.txt");
+          return async function () {
+            return "HAHA_THIS_ALWAYS_GOES_HERE.txt";
+          };
+        },
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
         };
       },
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -49,22 +53,25 @@ test("Custom extension (.txt) with custom permalink compile function", async (t)
 });
 
 test("Custom extension with and compileOptions.permalink = false", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-      permalink: false,
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+        permalink: false,
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -85,22 +92,25 @@ test("Custom extension with and compileOptions.permalink = false", async (t) => 
 });
 
 test("Custom extension with and opt-out of permalink compilation", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-      permalink: "raw",
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+        permalink: "raw",
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -121,30 +131,33 @@ test("Custom extension with and opt-out of permalink compilation", async (t) => 
 });
 
 test("Custom extension (.txt) with custom permalink compile function but no permalink in the data cascade", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-      // pass in your own custom permalink function.
-      permalink: async function (permalinkString, inputPath) {
-        t.is(permalinkString, undefined);
-        t.is(inputPath, "./test/stubs/custom-extension-no-permalink.txt");
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+        // pass in your own custom permalink function.
+        permalink: async function (permalinkString, inputPath) {
+          t.is(permalinkString, undefined);
+          t.is(inputPath, "./test/stubs/custom-extension-no-permalink.txt");
 
-        return async function () {
-          return "HAHA_THIS_ALWAYS_GOES_HERE.txt";
+          return async function () {
+            return "HAHA_THIS_ALWAYS_GOES_HERE.txt";
+          };
+        },
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
         };
       },
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -165,28 +178,31 @@ test("Custom extension (.txt) with custom permalink compile function but no perm
 });
 
 test("Custom extension (.txt) with custom permalink compile function (that returns a string not a function) but no permalink in the data cascade", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-      permalink: async function (permalinkString, inputPath) {
-        t.is(permalinkString, undefined);
-        t.is(inputPath, "./test/stubs/custom-extension-no-permalink.txt");
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+        permalink: async function (permalinkString, inputPath) {
+          t.is(permalinkString, undefined);
+          t.is(inputPath, "./test/stubs/custom-extension-no-permalink.txt");
 
-        // unique part of this test: this is a string, not a function
-        return "HAHA_THIS_ALWAYS_GOES_HERE.txt";
+          // unique part of this test: this is a string, not a function
+          return "HAHA_THIS_ALWAYS_GOES_HERE.txt";
+        },
       },
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -207,28 +223,31 @@ test("Custom extension (.txt) with custom permalink compile function (that retur
 });
 
 test("Custom extension (.txt) with custom permalink compile function that returns false", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-      permalink: async function (permalinkString, inputPath) {
-        t.is(permalinkString, undefined);
-        t.is(inputPath, "./test/stubs/custom-extension-no-permalink.txt");
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+        permalink: async function (permalinkString, inputPath) {
+          t.is(permalinkString, undefined);
+          t.is(inputPath, "./test/stubs/custom-extension-no-permalink.txt");
 
-        // unique part of this test: this returns false
-        return false;
+          // unique part of this test: this returns false
+          return false;
+        },
       },
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -249,21 +268,24 @@ test("Custom extension (.txt) with custom permalink compile function that return
 });
 
 test("Custom extension (.txt) that returns undefined from compile", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    compile: function (str, inputPath) {
-      t.is(str, "Sample content");
-      return function (data) {
-        return undefined;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+      },
+      compile: function (str, inputPath) {
+        t.is(str, "Sample content");
+        return function (data) {
+          return undefined;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(

--- a/test/TemplateTest-CompileOptions.js
+++ b/test/TemplateTest-CompileOptions.js
@@ -48,7 +48,7 @@ test("Custom extension (.txt) with custom permalink compile function", async (t)
   t.is(await renderTemplate(tmpl, data), "Sample content");
   let testObj = await tmpl.getOutputLocations(data);
   t.is(testObj.href, "/HAHA_THIS_ALWAYS_GOES_HERE.txt");
-  t.is(testObj.path, "dist/HAHA_THIS_ALWAYS_GOES_HERE.txt");
+  t.is(testObj.path, "./dist/HAHA_THIS_ALWAYS_GOES_HERE.txt");
   t.is(testObj.rawPath, "HAHA_THIS_ALWAYS_GOES_HERE.txt");
 });
 
@@ -126,7 +126,7 @@ test("Custom extension with and opt-out of permalink compilation", async (t) => 
   t.is(await renderTemplate(tmpl, data), "Sample content");
   let testObj = await tmpl.getOutputLocations(data);
   t.is(testObj.href, "/custom-extension.lit");
-  t.is(testObj.path, "dist/custom-extension.lit");
+  t.is(testObj.path, "./dist/custom-extension.lit");
   t.is(testObj.rawPath, "custom-extension.lit");
 });
 
@@ -173,7 +173,7 @@ test("Custom extension (.txt) with custom permalink compile function but no perm
   t.is(await renderTemplate(tmpl, data), "Sample content");
   let testObj = await tmpl.getOutputLocations(data);
   t.is(testObj.href, "/HAHA_THIS_ALWAYS_GOES_HERE.txt");
-  t.is(testObj.path, "dist/HAHA_THIS_ALWAYS_GOES_HERE.txt");
+  t.is(testObj.path, "./dist/HAHA_THIS_ALWAYS_GOES_HERE.txt");
   t.is(testObj.rawPath, "HAHA_THIS_ALWAYS_GOES_HERE.txt");
 });
 
@@ -218,7 +218,7 @@ test("Custom extension (.txt) with custom permalink compile function (that retur
   t.is(await renderTemplate(tmpl, data), "Sample content");
   let testObj = await tmpl.getOutputLocations(data);
   t.is(testObj.href, "/HAHA_THIS_ALWAYS_GOES_HERE.txt");
-  t.is(testObj.path, "dist/HAHA_THIS_ALWAYS_GOES_HERE.txt");
+  t.is(testObj.path, "./dist/HAHA_THIS_ALWAYS_GOES_HERE.txt");
   t.is(testObj.rawPath, "HAHA_THIS_ALWAYS_GOES_HERE.txt");
 });
 

--- a/test/TemplateTest-CompileOptions.js
+++ b/test/TemplateTest-CompileOptions.js
@@ -34,7 +34,7 @@ test("Custom extension (.txt) with custom permalink compile function", async (t)
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -73,7 +73,7 @@ test("Custom extension with and compileOptions.permalink = false", async (t) => 
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -112,7 +112,7 @@ test("Custom extension with and opt-out of permalink compilation", async (t) => 
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -159,7 +159,7 @@ test("Custom extension (.txt) with custom permalink compile function but no perm
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension-no-permalink.txt",
     "./test/stubs/",
@@ -204,7 +204,7 @@ test("Custom extension (.txt) with custom permalink compile function (that retur
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension-no-permalink.txt",
     "./test/stubs/",
@@ -249,7 +249,7 @@ test("Custom extension (.txt) with custom permalink compile function that return
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension-no-permalink.txt",
     "./test/stubs/",
@@ -287,7 +287,7 @@ test("Custom extension (.txt) that returns undefined from compile", async (t) =>
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension-no-permalink.txt",
     "./test/stubs/",

--- a/test/TemplateTest-ComputedData.js
+++ b/test/TemplateTest-ComputedData.js
@@ -1,9 +1,10 @@
 import test from "ava";
 
 import TemplateData from "../src/Data/TemplateData.js";
-import TemplateConfig from "../src/TemplateConfig.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 async function getRenderedData(tmpl, pageNumber = 0) {
   let data = await tmpl.getData();
@@ -121,8 +122,12 @@ test("eleventyComputed true primitive", async (t) => {
 });
 
 test("eleventyComputed relies on global data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist",
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -141,9 +146,12 @@ test("eleventyComputed relies on global data", async (t) => {
 });
 
 test("eleventyComputed intermixes with global data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.setDataDeepMerge(true);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs-computed-global",
+    output: "dist",
+  }, function(cfg) {
+    cfg.setDataDeepMerge(true);
+  });
 
   let dataObj = new TemplateData("./test/stubs-computed-global/", eleventyConfig);
 
@@ -171,15 +179,18 @@ test("eleventyComputed intermixes with global data", async (t) => {
 });
 
 test("eleventyComputed using symbol parsing on template strings (nunjucks)", async (t) => {
-  let eleventyConfig = await new TemplateConfig();
-  eleventyConfig.userConfig.addNunjucksFilter("fail", function (str) {
-    // Filter expects a certain String format, don’t use the (((11ty))) string hack
-    if (!str || str.length !== 1) {
-      throw new Error("Expect a one character string");
-    }
-    return `${str}`;
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs-computed-symbolparse",
+    output: "dist",
+  }, function(cfg) {
+    cfg.addNunjucksFilter("fail", function (str) {
+      // Filter expects a certain String format, don’t use the (((11ty))) string hack
+      if (!str || str.length !== 1) {
+        throw new Error("Expect a one character string");
+      }
+      return `${str}`;
+    });
   });
-  await eleventyConfig.init();
 
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-symbolparse/test.njk",
@@ -197,15 +208,18 @@ test("eleventyComputed using symbol parsing on template strings (nunjucks)", asy
 });
 
 test("eleventyComputed using symbol parsing on template strings (liquid)", async (t) => {
-  let eleventyConfig = await new TemplateConfig();
-  eleventyConfig.userConfig.addLiquidFilter("fail", function (str) {
-    // Filter expects a certain String format, don’t use the (((11ty))) string hack
-    if (!str || str.length !== 1) {
-      throw new Error("Expect a one character string: " + str);
-    }
-    return `${str}`;
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs-computed-symbolparse",
+    output: "dist",
+  }, function(cfg) {
+    cfg.addLiquidFilter("fail", function (str) {
+      // Filter expects a certain String format, don’t use the (((11ty))) string hack
+      if (!str || str.length !== 1) {
+        throw new Error("Expect a one character string: " + str);
+      }
+      return `${str}`;
+    });
   });
-  await eleventyConfig.init();
 
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-symbolparse/test.liquid",

--- a/test/TemplateTest-ComputedData.js
+++ b/test/TemplateTest-ComputedData.js
@@ -129,7 +129,7 @@ test("eleventyComputed relies on global data", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/eleventyComputed/use-global-data.njk",
     "./test/stubs/",
@@ -153,7 +153,7 @@ test("eleventyComputed intermixes with global data", async (t) => {
     cfg.setDataDeepMerge(true);
   });
 
-  let dataObj = new TemplateData("./test/stubs-computed-global/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   let tmpl = await getNewTemplate(
     "./test/stubs-computed-global/intermix.njk",

--- a/test/TemplateTest-CustomExtensions.js
+++ b/test/TemplateTest-CustomExtensions.js
@@ -1,28 +1,31 @@
 import test from "ava";
 import { marked } from "marked";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateData from "../src/Data/TemplateData.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 test("Using getData: false without getInstanceFromInputPath works ok", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: false,
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+      },
+      getData: false,
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
+  })
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -39,22 +42,24 @@ test("Using getData: false without getInstanceFromInputPath works ok", async (t)
 });
 
 test("Using getData: true without getInstanceFromInputPath should error", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: true,
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
-  });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+      },
+      getData: true,
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
+  })
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -68,26 +73,30 @@ test("Using getData: true without getInstanceFromInputPath should error", async 
 
   await t.throwsAsync(async () => {
     await tmpl.getData();
+  }, {
+    message: "getInstanceFromInputPath callback missing from txt template engine plugin."
   });
 });
 
 test("Using getData: [] without getInstanceFromInputPath should error", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: [],
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+      },
+      getData: [],
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -101,6 +110,8 @@ test("Using getData: [] without getInstanceFromInputPath should error", async (t
 
   await t.throwsAsync(async () => {
     await tmpl.getData();
+  }, {
+    message: "getInstanceFromInputPath callback missing from txt template engine plugin."
   });
 });
 
@@ -109,27 +120,29 @@ test("Using getData: true and getInstanceFromInputPath to get data from instance
     topLevelData: true,
   };
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: true,
-    getInstanceFromInputPath: function () {
-      return {
-        data: globalData,
-      };
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+      },
+      getData: true,
+      getInstanceFromInputPath: function () {
+        return {
+          data: globalData,
+        };
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -150,28 +163,30 @@ test("Using eleventyDataKey to get a different key data from instance", async (t
     topLevelData: true,
   };
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: [],
-    getInstanceFromInputPath: function () {
-      return {
-        eleventyDataKey: ["otherProp"],
-        otherProp: globalData,
-      };
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "txt",
+      key: "txt",
+      compileOptions: {
+        cache: false,
+      },
+      getData: [],
+      getInstanceFromInputPath: function () {
+        return {
+          eleventyDataKey: ["otherProp"],
+          otherProp: globalData,
+        };
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -188,15 +203,17 @@ test("Using eleventyDataKey to get a different key data from instance", async (t
 });
 
 test("Uses default renderer (no compile function) when you override an existing extension", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "liquid",
-    key: "liquid",
-    compileOptions: {
-      cache: false,
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+    cfg.extensionMap.add({
+      extension: "liquid",
+      key: "liquid",
+      compileOptions: {
+        cache: false,
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -215,22 +232,24 @@ test("Uses default renderer (no compile function) when you override an existing 
 test("Access to default renderer when you override an existing extension", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "liquid",
-    key: "liquid",
-    compileOptions: {
-      cache: false,
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        t.true(true);
-        return this.defaultRenderer();
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "liquid",
+			key: "liquid",
+			compileOptions: {
+				cache: false,
+			},
+			compile: function (str, inputPath) {
+				// plaintext
+				return function (data) {
+					t.true(true);
+					return this.defaultRenderer();
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -249,23 +268,25 @@ test("Access to default renderer when you override an existing extension", async
 test("Overridden liquid gets used from a markdown template", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "liquid",
-    key: "liquid",
-    compileOptions: {
-      cache: false,
-    },
-    compile: function (str, inputPath) {
-      t.true(true);
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "liquid",
+			key: "liquid",
+			compileOptions: {
+				cache: false,
+			},
+			compile: function (str, inputPath) {
+				t.true(true);
 
-      // plaintext
-      return function (data) {
-        return this.defaultRenderer();
-      };
-    },
+				// plaintext
+				return function (data) {
+					return this.defaultRenderer();
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -284,23 +305,25 @@ test("Overridden liquid gets used from a markdown template", async (t) => {
 test("Use marked for markdown", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "md",
-    key: "md",
-    compileOptions: {
-      cache: false,
-    },
-    compile: function (str, inputPath) {
-      let html = marked.parse(str);
-      // plaintext
-      return function (data) {
-        t.true(true);
-        return html;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "md",
+			key: "md",
+			compileOptions: {
+				cache: false,
+			},
+			compile: function (str, inputPath) {
+				let html = marked.parse(str);
+				// plaintext
+				return function (data) {
+					t.true(true);
+					return html;
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -319,21 +342,23 @@ test("Use marked for markdown", async (t) => {
 test("Use defaultRenderer for markdown", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "md",
-    key: "md",
-    compileOptions: {
-      cache: false,
-    },
-    compile: function (str, inputPath) {
-      return function (data) {
-        t.true(true);
-        return this.defaultRenderer(data);
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "md",
+			key: "md",
+			compileOptions: {
+				cache: false,
+			},
+			compile: function (str, inputPath) {
+				return function (data) {
+					t.true(true);
+					return this.defaultRenderer(data);
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -352,20 +377,22 @@ test("Use defaultRenderer for markdown", async (t) => {
 test("Front matter in a custom extension", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    compile: function (str, inputPath) {
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "txt",
+			key: "txt",
+			compileOptions: {
+				cache: false,
+			},
+			compile: function (str, inputPath) {
+				return function (data) {
+					return str;
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -385,22 +412,24 @@ test("Front matter in a custom extension", async (t) => {
 test("Access to default renderer when you override an existing extension (async compile function, arrow render function)", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "liquid",
-    key: "liquid",
-    compileOptions: {
-      cache: false,
-    },
-    compile: async function (str, inputPath) {
-      // plaintext
-      return async (data) => {
-        t.true(true);
-        return this.defaultRenderer();
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "liquid",
+			key: "liquid",
+			compileOptions: {
+				cache: false,
+			},
+			compile: async function (str, inputPath) {
+				// plaintext
+				return async (data) => {
+					t.true(true);
+					return this.defaultRenderer();
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -419,22 +448,24 @@ test("Access to default renderer when you override an existing extension (async 
 test("Access to default renderer when you override an existing extension (async compile function, async render function)", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "liquid",
-    key: "liquid",
-    compileOptions: {
-      cache: false,
-    },
-    compile: async function (str, inputPath) {
-      // plaintext
-      return async function (data) {
-        t.true(true);
-        return this.defaultRenderer();
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "liquid",
+			key: "liquid",
+			compileOptions: {
+				cache: false,
+			},
+			compile: async function (str, inputPath) {
+				// plaintext
+				return async function (data) {
+					t.true(true);
+					return this.defaultRenderer();
+				};
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -451,19 +482,21 @@ test("Access to default renderer when you override an existing extension (async 
 });
 
 test("Return undefined in compile to ignore #2267", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: false,
-    compile: function (str, inputPath) {
-      return;
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "txt",
+			key: "txt",
+			compileOptions: {
+				cache: false,
+			},
+			getData: false,
+			compile: function (str, inputPath) {
+				return;
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -480,19 +513,21 @@ test("Return undefined in compile to ignore #2267", async (t) => {
 });
 
 test("Return undefined in compile to ignore (async compile function) #2350", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.extensionMap.add({
-    extension: "txt",
-    key: "txt",
-    compileOptions: {
-      cache: false,
-    },
-    getData: false,
-    compile: async function (str, inputPath) {
-      return;
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs"
+  }, function(cfg) {
+		cfg.extensionMap.add({
+			extension: "txt",
+			key: "txt",
+			compileOptions: {
+				cache: false,
+			},
+			getData: false,
+			compile: async function (str, inputPath) {
+				return;
+			},
+		});
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(

--- a/test/TemplateTest-CustomExtensions.js
+++ b/test/TemplateTest-CustomExtensions.js
@@ -27,7 +27,7 @@ test("Using getData: false without getInstanceFromInputPath works ok", async (t)
     });
   })
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -61,7 +61,7 @@ test("Using getData: true without getInstanceFromInputPath should error", async 
     });
   })
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -98,7 +98,7 @@ test("Using getData: [] without getInstanceFromInputPath should error", async (t
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -144,7 +144,7 @@ test("Using getData: true and getInstanceFromInputPath to get data from instance
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -188,7 +188,7 @@ test("Using eleventyDataKey to get a different key data from instance", async (t
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -215,7 +215,7 @@ test("Uses default renderer (no compile function) when you override an existing 
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default.liquid",
     "./test/stubs/",
@@ -251,7 +251,7 @@ test("Access to default renderer when you override an existing extension", async
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default.liquid",
     "./test/stubs/",
@@ -288,7 +288,7 @@ test("Overridden liquid gets used from a markdown template", async (t) => {
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default.md",
     "./test/stubs/",
@@ -325,7 +325,7 @@ test("Use marked for markdown", async (t) => {
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default-no-liquid.md",
     "./test/stubs/",
@@ -360,7 +360,7 @@ test("Use defaultRenderer for markdown", async (t) => {
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default.md",
     "./test/stubs/",
@@ -394,7 +394,7 @@ test("Front matter in a custom extension", async (t) => {
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default-frontmatter.txt",
     "./test/stubs/",
@@ -431,7 +431,7 @@ test("Access to default renderer when you override an existing extension (async 
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default.liquid",
     "./test/stubs/",
@@ -467,7 +467,7 @@ test("Access to default renderer when you override an existing extension (async 
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/default.liquid",
     "./test/stubs/",
@@ -498,7 +498,7 @@ test("Return undefined in compile to ignore #2267", async (t) => {
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",
@@ -529,7 +529,7 @@ test("Return undefined in compile to ignore (async compile function) #2350", asy
 		});
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/custom-extension.txt",
     "./test/stubs/",

--- a/test/TemplateTest-DataCascade.js
+++ b/test/TemplateTest-DataCascade.js
@@ -14,7 +14,7 @@ test("Layout front matter does not override template data files", async (t) => {
 		}
 	});
 
-  let dataObj = new TemplateData("./test/stubs-data-cascade/layout-data-files/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-data-cascade/layout-data-files/test.njk",
     "./test/stubs-data-cascade/layout-data-files/",
@@ -36,7 +36,7 @@ test("Layout front matter should not override global data (sanity check, Issue 9
 		}
 	});
 
-  let dataObj = new TemplateData("./test/stubs-data-cascade/global-versus-layout/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-data-cascade/global-versus-layout/test.njk",
     "./test/stubs-data-cascade/global-versus-layout/",
@@ -58,10 +58,7 @@ test("Template data files should be more specific in data cascade than Layout fr
 		}
 	});
 
-  let dataObj = new TemplateData(
-    "./test/stubs-data-cascade/layout-versus-tmpldatafile/",
-    eleventyConfig
-  );
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-data-cascade/layout-versus-tmpldatafile/test.njk",
     "./test/stubs-data-cascade/layout-versus-tmpldatafile/",
@@ -83,10 +80,7 @@ test("Directory data files should be more specific in data cascade than Layout f
 		}
 	});
 
-  let dataObj = new TemplateData(
-    "./test/stubs-data-cascade/layout-versus-dirdatafile/src/",
-    eleventyConfig
-  );
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs-data-cascade/layout-versus-dirdatafile/src/test.njk",
     "./test/stubs-data-cascade/layout-versus-dirdatafile/src/",

--- a/test/TemplateTest-DataCascade.js
+++ b/test/TemplateTest-DataCascade.js
@@ -1,13 +1,18 @@
 import test from "ava";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateData from "../src/Data/TemplateData.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 // Prior to and including 0.10.0 this mismatched the documentation)! (Issue #915)
 test("Layout front matter does not override template data files", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/stubs-data-cascade/layout-data-files",
+			output: "dist"
+		}
+	});
 
   let dataObj = new TemplateData("./test/stubs-data-cascade/layout-data-files/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -24,8 +29,12 @@ test("Layout front matter does not override template data files", async (t) => {
 });
 
 test("Layout front matter should not override global data (sanity check, Issue 915)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/stubs-data-cascade/global-versus-layout",
+			output: "dist"
+		}
+	});
 
   let dataObj = new TemplateData("./test/stubs-data-cascade/global-versus-layout/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -42,8 +51,12 @@ test("Layout front matter should not override global data (sanity check, Issue 9
 });
 
 test("Template data files should be more specific in data cascade than Layout front matter (breaking change in 1.0, issue 915)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/stubs-data-cascade/layout-versus-tmpldatafile",
+			output: "dist"
+		}
+	});
 
   let dataObj = new TemplateData(
     "./test/stubs-data-cascade/layout-versus-tmpldatafile/",
@@ -63,8 +76,12 @@ test("Template data files should be more specific in data cascade than Layout fr
 });
 
 test("Directory data files should be more specific in data cascade than Layout front matter (breaking change in 1.0, issue 915)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/stubs-data-cascade/layout-versus-dirdatafile/src/",
+			output: "dist"
+		}
+	});
 
   let dataObj = new TemplateData(
     "./test/stubs-data-cascade/layout-versus-dirdatafile/src/",

--- a/test/TemplateTest-JavaScript.js
+++ b/test/TemplateTest-JavaScript.js
@@ -1,9 +1,9 @@
 import test from "ava";
 import semver from "semver";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { getRenderedTemplates as getRenderedTmpls } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 test("JavaScript template type (function)", async (t) => {
   let tmpl = await getNewTemplate("./test/stubs/function.11ty.cjs", "./test/stubs/", "./dist");
@@ -90,13 +90,13 @@ test("JavaScript template type (class with async data method)", async (t) => {
 });
 
 test("JavaScript template type (class with data getter and a javascriptFunction)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
-    javascriptFunctions: {
-      upper: function (val) {
-        return new String(val).toUpperCase();
-      },
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.addJavaScriptFunction("upper", function (val) {
+      return new String(val).toUpperCase();
+    });
   });
 
   let tmpl = await getNewTemplate(
@@ -116,13 +116,13 @@ test("JavaScript template type (class with data getter and a javascriptFunction)
 });
 
 test("JavaScript template type (class with data method and a javascriptFunction)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init({
-    javascriptFunctions: {
-      upper: function (val) {
-        return new String(val).toUpperCase();
-      },
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist",
+  }, function(cfg) {
+    cfg.addJavaScriptFunction("upper", function (val) {
+      return new String(val).toUpperCase();
+    });
   });
 
   let tmpl = await getNewTemplate(

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -196,7 +196,7 @@ test("One Layout (using new content var)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/templateWithLayoutKey.liquid",
     "./test/stubs/",
@@ -230,7 +230,7 @@ test("One Layout (using content)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/templateWithLayoutContent.liquid",
     "./test/stubs/",
@@ -264,7 +264,7 @@ test("One Layout (layouts disabled)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/templateWithLayoutContent.liquid",
     "./test/stubs/",
@@ -296,7 +296,7 @@ test("One Layout (liquid test)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/templateWithLayout.liquid",
     "./test/stubs/",
@@ -330,7 +330,7 @@ test("Two Layouts", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/templateTwoLayouts.liquid",
     "./test/stubs/",
@@ -366,7 +366,7 @@ test("Liquid template", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/formatTest.liquid",
     "./test/stubs/",
@@ -419,7 +419,7 @@ test("Layout from template-data-file that has a permalink (fileslug) Issue #121"
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/permalink-data-layout/test.njk",
     "./test/stubs/",
@@ -449,7 +449,7 @@ test("Local template data file import (without a global data json)", async (t) =
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -485,7 +485,7 @@ test("Local template data file import (two subdirectories deep)", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -528,7 +528,7 @@ test("Posts inherits local JSON, layouts", async (t) => {
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -582,7 +582,7 @@ test("Template and folder name are the same, make sure data imports work ok", as
     }
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1129,7 +1129,7 @@ test("Data Cascade (Deep merge)", async (t) => {
     // cfg.setDataDeepMerge(true);
   });
 
-  let dataObj = new TemplateData("./test/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1167,7 +1167,7 @@ test("Data Cascade (Shallow merge)", async (t) => {
     cfg.setDataDeepMerge(false);
   });
 
-  let dataObj = new TemplateData("./test/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1205,7 +1205,7 @@ test("Data Cascade Tag Merge (Deep merge)", async (t) => {
     // cfg.setDataDeepMerge(true);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1231,7 +1231,7 @@ test("Data Cascade Tag Merge (Deep Merge - Deduplication)", async (t) => {
     // cfg.setDataDeepMerge(true);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1257,7 +1257,7 @@ test("Data Cascade Tag Merge (Shallow merge)", async (t) => {
     cfg.setDataDeepMerge(false);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1283,7 +1283,7 @@ test('Local data inherits tags string ([tags] vs "tags") Shallow Merge', async (
     cfg.setDataDeepMerge(false);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1309,7 +1309,7 @@ test('Local data inherits tags string ([tags] vs "tags") Deep Merge', async (t) 
     // cfg.setDataDeepMerge(true);
   });
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
 
@@ -1906,7 +1906,7 @@ test("Error messaging, returning literals (not objects) from custom data extensi
     });
   });
 
-  let dataObj = new TemplateData("./test/stubs-1691/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
 
   let tmpl = await getNewTemplate(
     "./test/stubs-1691/template.njk",

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -3,7 +3,6 @@ import fs from "fs";
 import pretty from "pretty";
 import TOML from "@iarna/toml";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateData from "../src/Data/TemplateData.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
@@ -11,8 +10,10 @@ import EleventyErrorUtil from "../src/Errors/EleventyErrorUtil.js";
 import TemplateContentPrematureUseError from "../src/Errors/TemplateContentPrematureUseError.js";
 import { normalizeNewLines } from "./Util/normalizeNewLines.js";
 import eventBus from "../src/EventBus.js";
+
 import getNewTemplate from "./_getNewTemplateForTests.js";
 import { getRenderedTemplates as getRenderedTmpls, renderLayout, renderTemplate } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 const fsp = fs.promises;
 
@@ -188,8 +189,12 @@ test("Test that getData() works", async (t) => {
 });
 
 test("One Layout (using new content var)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -218,8 +223,12 @@ test("One Layout (using new content var)", async (t) => {
 });
 
 test("One Layout (using content)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -248,8 +257,12 @@ test("One Layout (using content)", async (t) => {
 });
 
 test("One Layout (layouts disabled)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -267,17 +280,21 @@ test("One Layout (layouts disabled)", async (t) => {
   t.is(data[tmpl.config.keys.layout], "defaultLayoutLayoutContent");
 
   t.is(cleanHtml(await tmpl.renderPageEntryWithoutLayout({
-		rawInput: await tmpl.getPreRender(),
-		data: data
-	})), "<p>Hello.</p>");
+    rawInput: await tmpl.getPreRender(),
+    data: data
+  })), "<p>Hello.</p>");
 
   t.is(data.keymain, "valuemain");
   t.is(data.keylayout, "valuelayout");
 });
 
 test("One Layout (liquid test)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -306,8 +323,12 @@ test("One Layout (liquid test)", async (t) => {
 });
 
 test("Two Layouts", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -338,8 +359,12 @@ test("Two Layouts", async (t) => {
 });
 
 test("Liquid template", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -387,8 +412,12 @@ test("Permalink output directory from layout (fileslug)", async (t) => {
 });
 
 test("Layout from template-data-file that has a permalink (fileslug) Issue #121", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -413,8 +442,12 @@ test("Fileslug in an 11ty.js template Issue #588", async (t) => {
 });
 
 test("Local template data file import (without a global data json)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -445,8 +478,12 @@ test("Local template data file import (without a global data json)", async (t) =
 });
 
 test("Local template data file import (two subdirectories deep)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -484,8 +521,12 @@ test("Local template data file import (two subdirectories deep)", async (t) => {
 });
 
 test("Posts inherits local JSON, layouts", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -534,8 +575,12 @@ test("Posts inherits local JSON, layouts", async (t) => {
 });
 
 test("Template and folder name are the same, make sure data imports work ok", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "dist"
+    }
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1076,10 +1121,13 @@ test("Front matter date with quotes (njk), issue #258", async (t) => {
 });
 
 test("Data Cascade (Deep merge)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // Default changed in 1.0
-  // eleventyConfig.userConfig.setDataDeepMerge(true);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test",
+    output: "dist"
+  }, function(cfg) {
+    // Default changed in 1.0
+    // cfg.setDataDeepMerge(true);
+  });
 
   let dataObj = new TemplateData("./test/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1087,7 +1135,7 @@ test("Data Cascade (Deep merge)", async (t) => {
 
   let tmpl = await getNewTemplate(
     "./test/stubs/data-cascade/template.njk",
-    "./test/stubs/",
+    "./test/",
     "./dist",
     dataObj,
     null,
@@ -1111,10 +1159,13 @@ test("Data Cascade (Deep merge)", async (t) => {
 });
 
 test("Data Cascade (Shallow merge)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // Default changed in 1.0
-  eleventyConfig.userConfig.setDataDeepMerge(false);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test",
+    output: "dist",
+  }, function(cfg) {
+    // Default changed in 1.0
+    cfg.setDataDeepMerge(false);
+  });
 
   let dataObj = new TemplateData("./test/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1122,7 +1173,7 @@ test("Data Cascade (Shallow merge)", async (t) => {
 
   let tmpl = await getNewTemplate(
     "./test/stubs/data-cascade/template.njk",
-    "./test/stubs/",
+    "./test/",
     "./dist",
     dataObj,
     null,
@@ -1146,10 +1197,13 @@ test("Data Cascade (Shallow merge)", async (t) => {
 });
 
 test("Data Cascade Tag Merge (Deep merge)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // Default changed in 1.0
-  // eleventyConfig.userConfig.setDataDeepMerge(true);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist"
+  }, function(cfg) {
+    // Default changed in 1.0
+    // cfg.setDataDeepMerge(true);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1169,10 +1223,13 @@ test("Data Cascade Tag Merge (Deep merge)", async (t) => {
 });
 
 test("Data Cascade Tag Merge (Deep Merge - Deduplication)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // Default changed in 1.0
-  // eleventyConfig.userConfig.setDataDeepMerge(true);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist"
+  }, function(cfg) {
+    // Default changed in 1.0
+    // cfg.setDataDeepMerge(true);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1192,10 +1249,13 @@ test("Data Cascade Tag Merge (Deep Merge - Deduplication)", async (t) => {
 });
 
 test("Data Cascade Tag Merge (Shallow merge)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // Default changed in 1.0
-  eleventyConfig.userConfig.setDataDeepMerge(false);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist"
+  }, function(cfg) {
+    // Default changed in 1.0
+    cfg.setDataDeepMerge(false);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1215,10 +1275,13 @@ test("Data Cascade Tag Merge (Shallow merge)", async (t) => {
 });
 
 test('Local data inherits tags string ([tags] vs "tags") Shallow Merge', async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  // Default changed in 1.0
-  eleventyConfig.userConfig.setDataDeepMerge(false);
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist"
+  }, function(cfg) {
+    // Default changed in 1.0
+    cfg.setDataDeepMerge(false);
+  });
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -1238,11 +1301,14 @@ test('Local data inherits tags string ([tags] vs "tags") Shallow Merge', async (
 });
 
 test('Local data inherits tags string ([tags] vs "tags") Deep Merge', async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist"
+  }, function(cfg) {
+    // Default changed in 1.0
+    // cfg.setDataDeepMerge(true);
+  });
 
-  // Default changed in 1.0
-  // eleventyConfig.userConfig.setDataDeepMerge(true);
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
   await dataObj.getGlobalData();
@@ -1584,8 +1650,13 @@ test("Get Layout Chain", async (t) => {
 });
 
 test("Engine Singletons", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/engine-singletons",
+      output: "dist"
+    }
+  });
+
   let map = new EleventyExtensionMap(["njk"], eleventyConfig);
   let tmpl1 = await getNewTemplate(
     "./test/stubs/engine-singletons/first.njk",
@@ -1651,20 +1722,23 @@ test("Make sure layout cache takes new changes during watch (liquid)", async (t)
 });
 
 test("Add Extension via Configuration (txt file)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addExtension("txt", {
-    isIncrementalMatch: function (incrementalFilePath) {
-      // do some kind of check
-      return this.inputPath === incrementalFilePath;
-    },
-    compile: function (str, inputPath) {
-      // plaintext
-      return function (data) {
-        return str;
-      };
-    },
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs",
+    output: "dist"
+  }, function(cfg) {
+    cfg.addExtension("txt", {
+      isIncrementalMatch: function (incrementalFilePath) {
+        // do some kind of check
+        return this.inputPath === incrementalFilePath;
+      },
+      compile: function (str, inputPath) {
+        // plaintext
+        return function (data) {
+          return str;
+        };
+      },
+    });
   });
-  await eleventyConfig.init();
 
   let map = new EleventyExtensionMap([], eleventyConfig);
   let tmpl = await getNewTemplate(
@@ -1823,11 +1897,14 @@ test("page.templateSyntax works with templateEngineOverride", async (t) => {
 
 // Inspired by https://github.com/11ty/eleventy/pull/1691
 test("Error messaging, returning literals (not objects) from custom data extension", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("txt", {
-    parser: (s) => s,
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs-1691",
+    output: "dist"
+  }, function(cfg) {
+    cfg.addDataExtension("txt", {
+      parser: (s) => s,
+    });
   });
-  await eleventyConfig.init();
 
   let dataObj = new TemplateData("./test/stubs-1691/", eleventyConfig);
 

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -63,9 +63,8 @@ test("getTemplateSubFolder, output is a subdir of input", async (t) => {
 
 test("output path maps to an html file", async (t) => {
   let tmpl = await getNewTemplate("./test/stubs/template.liquid", "./test/stubs/", "./dist");
-  t.is(tmpl.parsed.dir, "./test/stubs");
-  t.is(tmpl.inputDir, "./test/stubs");
-  t.is(tmpl.outputDir, "./dist");
+  t.is(tmpl.inputDir, "./test/stubs/");
+  t.is(tmpl.outputDir, "./dist/");
   t.is(tmpl.getTemplateSubfolder(), "");
 
   let data = await tmpl.getData();

--- a/test/TemplateTest_Permalink.js
+++ b/test/TemplateTest_Permalink.js
@@ -1,9 +1,10 @@
 import test from "ava";
 import fs from "fs";
 
-import TemplateConfig from "../src/TemplateConfig.js";
 import TemplateData from "../src/Data/TemplateData.js";
 import getNewTemplate from "./_getNewTemplateForTests.js";
+
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 async function writeMapEntries(mapEntries) {
   let promises = [];
@@ -155,8 +156,12 @@ test.skip("Permalink with dates on file name regex!", async (t) => {
 });
 
 test("Reuse permalink in directory specific data file", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/stubs",
+			output: "dist"
+		}
+	});
 
   let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
   let tmpl = await getNewTemplate(

--- a/test/TemplateTest_Permalink.js
+++ b/test/TemplateTest_Permalink.js
@@ -163,7 +163,7 @@ test("Reuse permalink in directory specific data file", async (t) => {
 		}
 	});
 
-  let dataObj = new TemplateData("./test/stubs/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let tmpl = await getNewTemplate(
     "./test/stubs/reuse-permalink/test1.liquid",
     "./test/stubs/",

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -7,14 +7,19 @@ import path from "path";
 import EleventyFiles from "../src/EleventyFiles.js";
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
 import TemplateWriter from "../src/TemplateWriter.js";
-import TemplateConfig from "../src/TemplateConfig.js";
+
 import { normalizeNewLines } from "./Util/normalizeNewLines.js";
 import { getRenderedTemplates as getRenderedTmpls } from "./_getRenderedTemplates.js";
+import { getTemplateConfigInstance, getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
 
 // TODO make sure if output is a subdir of input dir that they don’t conflict.
 test("Output is a subdir of input", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/writeTest",
+      output: "test/stubs/writeTest/_writeTestSite"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/writeTest",
@@ -43,8 +48,12 @@ test("Output is a subdir of input", async (t) => {
 });
 
 test("_createTemplateMap", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/writeTest",
+      output: "test/stubs/writeTest/_writeTestSite"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/writeTest",
@@ -66,8 +75,12 @@ test("_createTemplateMap", async (t) => {
 });
 
 test("_createTemplateMap (no leading dot slash)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/writeTest",
+      output: "test/stubs/writeTest/_writeTestSite"
+    }
+  });
 
   let tw = new TemplateWriter(
     "test/stubs/writeTest",
@@ -83,8 +96,12 @@ test("_createTemplateMap (no leading dot slash)", async (t) => {
 });
 
 test("_testGetCollectionsData", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection",
@@ -104,8 +121,12 @@ test("_testGetCollectionsData", async (t) => {
 
 // TODO remove this (used by other test things)
 test("_testGetAllTags", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection",
@@ -123,8 +144,12 @@ test("_testGetAllTags", async (t) => {
 });
 
 test("Collection of files sorted by date", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/dates",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/dates",
@@ -141,8 +166,12 @@ test("Collection of files sorted by date", async (t) => {
 });
 
 test("__testGetCollectionsData with custom collection (ascending)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection2",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
@@ -167,8 +196,12 @@ test("__testGetCollectionsData with custom collection (ascending)", async (t) =>
 });
 
 test("__testGetCollectionsData with custom collection (descending)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection2",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
@@ -193,8 +226,12 @@ test("__testGetCollectionsData with custom collection (descending)", async (t) =
 });
 
 test("__testGetCollectionsData with custom collection (filter only to markdown input)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection2",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
@@ -220,8 +257,12 @@ test("__testGetCollectionsData with custom collection (filter only to markdown i
 });
 
 test("Pagination with a Collection", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/paged/collection",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/paged/collection",
@@ -250,8 +291,12 @@ test("Pagination with a Collection", async (t) => {
 });
 
 test("Pagination with a Collection from another Paged Template", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/paged/cfg-collection-tag-cfg-collection",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/paged/cfg-collection-tag-cfg-collection",
@@ -282,8 +327,12 @@ test("Pagination with a Collection from another Paged Template", async (t) => {
 });
 
 test("Pagination with a Collection (apply all pages to collections)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/paged/collection-apply-to-all",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/paged/collection-apply-to-all",
@@ -333,8 +382,12 @@ test("Pagination with a Collection (apply all pages to collections)", async (t) 
 });
 
 test("Use a collection inside of a template", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection-template",
+      output: "test/stubs/collection-template/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection-template",
@@ -378,8 +431,12 @@ Template 1 dog`,
 });
 
 test("Use a collection inside of a layout", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection-layout",
+      output: "test/stubs/collection-layout/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection-layout",
@@ -421,8 +478,12 @@ Layout 1 dog`,
 });
 
 test("Glob Watcher Files with Passthroughs", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "test/stubs",
@@ -437,8 +498,12 @@ test("Glob Watcher Files with Passthroughs", async (t) => {
 test("Pagination and TemplateContent", async (t) => {
   rimrafSync("./test/stubs/pagination-templatecontent/_site/");
 
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/pagination-templatecontent",
+      output: "test/stubs/pagination-templatecontent/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/pagination-templatecontent",
@@ -462,8 +527,12 @@ test("Pagination and TemplateContent", async (t) => {
 });
 
 test("Custom collection returns array", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection2",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
@@ -488,8 +557,12 @@ test("Custom collection returns array", async (t) => {
 });
 
 test("Custom collection returns a string", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection2",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
@@ -510,8 +583,12 @@ test("Custom collection returns a string", async (t) => {
 });
 
 test("Custom collection returns an object", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection2",
+      output: "test/stubs/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection2",
@@ -532,8 +609,12 @@ test("Custom collection returns an object", async (t) => {
 });
 
 test("fileSlug should exist in a collection", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/collection-slug",
+      output: "test/stubs/collection-slug/_site"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/collection-slug",
@@ -558,8 +639,12 @@ test("fileSlug should exist in a collection", async (t) => {
 });
 
 test("Write Test 11ty.js", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/writeTestJS",
+      output: "test/stubs/_writeTestJSSite"
+    }
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/writeTestJS",
@@ -586,7 +671,13 @@ test("Write Test 11ty.js", async (t) => {
 });
 
 test.skip("Markdown with alias", async (t) => {
-  let eleventyConfig = new TemplateConfig();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/writeTestMarkdown",
+      output: "test/stubs/_writeTestMarkdownSite"
+    }
+  });
+
   let map = new EleventyExtensionMap(["md"], eleventyConfig);
   map.config = {
     templateExtensionAliases: {
@@ -630,7 +721,13 @@ test.skip("Markdown with alias", async (t) => {
 });
 
 test.skip("JavaScript with alias", async (t) => {
-  let eleventyConfig = new TemplateConfig();
+  let eleventyConfig = await getTemplateConfigInstance({
+    dir: {
+      input: "test/stubs/writeTestJS",
+      output: "test/stubs/_writeTestJSSite"
+    }
+  });
+
   let map = new EleventyExtensionMap(["11ty.js"], eleventyConfig);
   map.config = {
     templateExtensionAliases: {
@@ -673,22 +770,36 @@ test.skip("JavaScript with alias", async (t) => {
 test("Passthrough file output", async (t) => {
   rimrafSync("./test/stubs/template-passthrough/_site/");
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.passthroughCopies = {
-    "./test/stubs/template-passthrough/static": {
-      outputPath: true,
-    },
-    "./test/stubs/template-passthrough/static/": {
-      outputPath: "./",
-    },
-    "./test/stubs/template-passthrough/static/**/*": {
-      outputPath: "./all/",
-    },
-    "./test/stubs/template-passthrough/static/**/*.js": {
-      outputPath: "./js/",
-    },
-  };
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({
+    input: "test/stubs/template-passthrough",
+    output: "test/stubs/template-passthrough/_site"
+  }, function(cfg){
+    cfg.addPassthroughCopy("./test/stubs/template-passthrough/static");
+    cfg.addPassthroughCopy({
+			"./test/stubs/template-passthrough/static/": "./",
+    });
+    cfg.addPassthroughCopy({
+			"./test/stubs/template-passthrough/static/**/*": "./all/",
+    });
+    cfg.addPassthroughCopy({
+			"./test/stubs/template-passthrough/static/**/*.js": "./js/",
+    });
+
+    // cfg.passthroughCopies = {
+    //   "./test/stubs/template-passthrough/static": {
+    //     outputPath: true,
+    //   },
+    //   "./test/stubs/template-passthrough/static/": {
+    //     outputPath: "./",
+    //   },
+    //   "./test/stubs/template-passthrough/static/**/*": {
+    //     outputPath: "./all/",
+    //   },
+    //   "./test/stubs/template-passthrough/static/**/*.js": {
+    //     outputPath: "./js/",
+    //   },
+    // };
+  });
 
   let tw = new TemplateWriter(
     "./test/stubs/template-passthrough/",

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -34,7 +34,7 @@ test("Output is a subdir of input", async (t) => {
   t.true(files.length > 0);
 
   let { template: tmpl } = tw._createTemplate(files[0]);
-  t.is(tmpl.inputDir, "./test/stubs/writeTest");
+  t.is(tmpl.inputDir, "./test/stubs/writeTest/");
 
   let data = await tmpl.getData();
   t.is(await tmpl.getOutputPath(data), "./test/stubs/writeTest/_writeTestSite/test/index.html");

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -22,8 +22,6 @@ test("Output is a subdir of input", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/writeTest",
-    "./test/stubs/writeTest/_writeTestSite",
     ["liquid", "md"],
     null,
     eleventyConfig,
@@ -56,8 +54,6 @@ test("_createTemplateMap", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/writeTest",
-    "./test/stubs/_writeTestSite",
     ["liquid", "md"],
     null,
     eleventyConfig,
@@ -78,13 +74,11 @@ test("_createTemplateMap (no leading dot slash)", async (t) => {
   let eleventyConfig = await getTemplateConfigInstance({
     dir: {
       input: "test/stubs/writeTest",
-      output: "test/stubs/writeTest/_writeTestSite"
+      output: "test/stubs/_writeTestSite"
     }
   });
 
   let tw = new TemplateWriter(
-    "test/stubs/writeTest",
-    "test/stubs/_writeTestSite",
     ["liquid", "md"],
     null,
     eleventyConfig,
@@ -104,8 +98,6 @@ test("_testGetCollectionsData", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -129,8 +121,6 @@ test("_testGetAllTags", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -152,8 +142,6 @@ test("Collection of files sorted by date", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/dates",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -174,8 +162,6 @@ test("__testGetCollectionsData with custom collection (ascending)", async (t) =>
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection2",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -204,8 +190,6 @@ test("__testGetCollectionsData with custom collection (descending)", async (t) =
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection2",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -234,8 +218,6 @@ test("__testGetCollectionsData with custom collection (filter only to markdown i
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection2",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -265,8 +247,6 @@ test("Pagination with a Collection", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/paged/collection",
-    "./test/stubs/_site",
     ["njk"],
     null,
     eleventyConfig,
@@ -299,8 +279,6 @@ test("Pagination with a Collection from another Paged Template", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/paged/cfg-collection-tag-cfg-collection",
-    "./test/stubs/_site",
     ["njk"],
     null,
     eleventyConfig,
@@ -335,8 +313,6 @@ test("Pagination with a Collection (apply all pages to collections)", async (t) 
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/paged/collection-apply-to-all",
-    "./test/stubs/_site",
     ["njk"],
     null,
     eleventyConfig,
@@ -390,8 +366,6 @@ test("Use a collection inside of a template", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection-template",
-    "./test/stubs/collection-template/_site",
     ["liquid"],
     null,
     eleventyConfig,
@@ -439,8 +413,6 @@ test("Use a collection inside of a layout", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection-layout",
-    "./test/stubs/collection-layout/_site",
     ["liquid"],
     null,
     eleventyConfig,
@@ -486,8 +458,6 @@ test("Glob Watcher Files with Passthroughs", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "test/stubs",
-    "test/stubs/_site",
     ["njk", "png"],
     null,
     eleventyConfig,
@@ -506,8 +476,6 @@ test("Pagination and TemplateContent", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/pagination-templatecontent",
-    "./test/stubs/pagination-templatecontent/_site",
     ["njk", "md"],
     null,
     eleventyConfig,
@@ -535,8 +503,6 @@ test("Custom collection returns array", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection2",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -565,8 +531,6 @@ test("Custom collection returns a string", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection2",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -591,8 +555,6 @@ test("Custom collection returns an object", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection2",
-    "./test/stubs/_site",
     ["md"],
     null,
     eleventyConfig,
@@ -617,8 +579,6 @@ test("fileSlug should exist in a collection", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/collection-slug",
-    "./test/stubs/collection-slug/_site",
     ["njk"],
     null,
     eleventyConfig,
@@ -647,8 +607,6 @@ test("Write Test 11ty.js", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite",
     ["11ty.js"],
     null,
     eleventyConfig,
@@ -703,8 +661,6 @@ test.skip("Markdown with alias", async (t) => {
   t.true(files.indexOf("./test/stubs/writeTestMarkdown/sample2.markdown") > -1);
 
   let tw = new TemplateWriter(
-    "./test/stubs/writeTestMarkdown",
-    "./test/stubs/_writeTestMarkdownSite",
     ["md"],
     null,
     eleventyConfig,
@@ -755,8 +711,6 @@ test.skip("JavaScript with alias", async (t) => {
   );
 
   let tw = new TemplateWriter(
-    "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite",
     ["11ty.js"],
     null,
     eleventyConfig,
@@ -802,8 +756,6 @@ test("Passthrough file output", async (t) => {
   });
 
   let tw = new TemplateWriter(
-    "./test/stubs/template-passthrough/",
-    "./test/stubs/template-passthrough/_site",
     ["njk", "md"],
     null,
     eleventyConfig,

--- a/test/TemplateWriterTest.js
+++ b/test/TemplateWriterTest.js
@@ -26,12 +26,7 @@ test("Output is a subdir of input", async (t) => {
     null,
     eleventyConfig,
   );
-  let evf = new EleventyFiles(
-    "./test/stubs/writeTest",
-    "./test/stubs/writeTest/_writeTestSite",
-    ["liquid", "md"],
-    eleventyConfig,
-  );
+  let evf = new EleventyFiles(["liquid", "md"], eleventyConfig);
   evf.init();
 
   let files = await fastglob(evf.getFileGlobs());
@@ -612,8 +607,6 @@ test("Write Test 11ty.js", async (t) => {
     eleventyConfig,
   );
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite",
     ["11ty.js"],
     eleventyConfig,
   );
@@ -644,8 +637,6 @@ test.skip("Markdown with alias", async (t) => {
   };
 
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestMarkdown",
-    "./test/stubs/_writeTestMarkdownSite",
     ["md"],
     eleventyConfig,
   );
@@ -692,8 +683,6 @@ test.skip("JavaScript with alias", async (t) => {
   };
 
   let evf = new EleventyFiles(
-    "./test/stubs/writeTestJS",
-    "./test/stubs/_writeTestJSSite",
     ["11ty.js"],
     eleventyConfig,
   );

--- a/test/UserDataExtensionsTest.js
+++ b/test/UserDataExtensionsTest.js
@@ -6,11 +6,18 @@ import TemplateConfig from "../src/TemplateConfig.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
 import TemplateData from "../src/Data/TemplateData.js";
 
+import { getTemplateConfigInstanceCustomCallback } from "./_testHelpers.js";
+
 test("Local data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
-  eleventyConfig.userConfig.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-630"
+    },
+    function(cfg) {
+      cfg.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
+      cfg.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -39,10 +46,15 @@ test("Local data", async (t) => {
 });
 
 test("Local files", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
-  eleventyConfig.userConfig.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-630"
+    },
+    function(cfg) {
+      cfg.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
+      cfg.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
   let files = await dataObj.getLocalDataPaths("./test/stubs-630/component-yaml/component.njk");
@@ -78,10 +90,15 @@ test("Local files", async (t) => {
 });
 
 test("Global data", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
-  eleventyConfig.userConfig.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-630"
+    },
+    function(cfg) {
+      cfg.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
+      cfg.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -114,10 +131,15 @@ test("Global data", async (t) => {
 });
 
 test("Global data merging and priority", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
-  eleventyConfig.userConfig.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-630"
+    },
+    function(cfg) {
+      cfg.addDataExtension("yaml", { parser: (s) => yaml.load(s) });
+      cfg.addDataExtension("nosj", { parser: (s) => JSON.parse(s) });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -141,16 +163,21 @@ test("Global data merging and priority", async (t) => {
 test("Binary data files, encoding: null", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("jpg", {
-    parser: (s) => {
-      t.true(Buffer.isBuffer(s));
-      // s is a Buffer, just return the length as a sample
-      return s.length;
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-2378"
     },
-    encoding: null,
-  });
-  await eleventyConfig.init();
+    function(cfg) {
+      cfg.addDataExtension("jpg", {
+        parser: (s) => {
+          t.true(Buffer.isBuffer(s));
+          // s is a Buffer, just return the length as a sample
+          return s.length;
+        },
+        encoding: null,
+      });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-2378/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -162,16 +189,21 @@ test("Binary data files, encoding: null", async (t) => {
 test("Binary data files, read: false", async (t) => {
   t.plan(2);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("jpg", {
-    parser: (s) => {
-      t.true(fs.existsSync(s));
-      // s is a Buffer, just return the length as a sample
-      return s;
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-2378"
     },
-    read: false,
-  });
-  await eleventyConfig.init();
+    function(cfg) {
+      cfg.addDataExtension("jpg", {
+        parser: (s) => {
+          t.true(fs.existsSync(s));
+          // s is a Buffer, just return the length as a sample
+          return s;
+        },
+        read: false,
+      });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-2378/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -183,16 +215,21 @@ test("Binary data files, read: false", async (t) => {
 test("Binary data files, encoding: null (multiple data extensions)", async (t) => {
   t.plan(4);
 
-  let eleventyConfig = new TemplateConfig();
-  eleventyConfig.userConfig.addDataExtension("jpg, png", {
-    parser: function (s) {
-      t.true(Buffer.isBuffer(s));
-      // s is a Buffer, just return the length as a sample
-      return s.length;
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback(
+    {
+      input: "test/stubs-2378"
     },
-    encoding: null,
-  });
-  await eleventyConfig.init();
+    function(cfg) {
+      cfg.addDataExtension("jpg, png", {
+        parser: function (s) {
+          t.true(Buffer.isBuffer(s));
+          // s is a Buffer, just return the length as a sample
+          return s.length;
+        },
+        encoding: null,
+      });
+    }
+  );
 
   let dataObj = new TemplateData("./test/stubs-2378/", eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
@@ -206,5 +243,7 @@ test("Missing `parser` property to addDataExtension object throws error", async 
   let eleventyConfig = new TemplateConfig();
   t.throws(() => {
     eleventyConfig.userConfig.addDataExtension("jpg", {});
+  }, {
+    message: "Expected `parser` property in second argument object to `eleventyConfig.addDataExtension`"
   });
 });

--- a/test/UserDataExtensionsTest.js
+++ b/test/UserDataExtensionsTest.js
@@ -103,7 +103,7 @@ test("Global data", async (t) => {
   let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
-  t.deepEqual(await dataObj.getGlobalDataGlob(), [
+  t.deepEqual(dataObj.getGlobalDataGlob(), [
     "./test/stubs-630/_data/**/*.{nosj,yaml,json,mjs,cjs,js}",
   ]);
 

--- a/test/UserDataExtensionsTest.js
+++ b/test/UserDataExtensionsTest.js
@@ -19,7 +19,7 @@ test("Local data", async (t) => {
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -56,7 +56,7 @@ test("Local files", async (t) => {
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   let files = await dataObj.getLocalDataPaths("./test/stubs-630/component-yaml/component.njk");
   t.deepEqual(files, [
     "./test/stubs-630/stubs-630.yaml",
@@ -100,7 +100,7 @@ test("Global data", async (t) => {
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   t.deepEqual(await dataObj.getGlobalDataGlob(), [
@@ -141,7 +141,7 @@ test("Global data merging and priority", async (t) => {
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-630/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -179,7 +179,7 @@ test("Binary data files, encoding: null", async (t) => {
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-2378/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -205,7 +205,7 @@ test("Binary data files, read: false", async (t) => {
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-2378/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();
@@ -231,7 +231,7 @@ test("Binary data files, encoding: null (multiple data extensions)", async (t) =
     }
   );
 
-  let dataObj = new TemplateData("./test/stubs-2378/", eleventyConfig);
+  let dataObj = new TemplateData(eleventyConfig);
   dataObj.setFileSystemSearch(new FileSystemSearch());
 
   let data = await dataObj.getGlobalData();

--- a/test/_getNewTemplateForTests.js
+++ b/test/_getNewTemplateForTests.js
@@ -1,7 +1,8 @@
 import EleventyExtensionMap from "../src/EleventyExtensionMap.js";
-import TemplateConfig from "../src/TemplateConfig.js";
 import Template from "../src/Template.js";
 import FileSystemSearch from "../src/FileSystemSearch.js";
+
+import { getTemplateConfigInstance } from "./_testHelpers.js";
 
 export default async function getNewTemplate(
   path,
@@ -12,8 +13,12 @@ export default async function getNewTemplate(
   eleventyConfig = null
 ) {
   if (!eleventyConfig) {
-    eleventyConfig = new TemplateConfig();
-    await eleventyConfig.init();
+    eleventyConfig = await getTemplateConfigInstance({
+      dir: {
+        input: inputDir,
+        output: outputDir,
+      }
+    });
   }
 
   if (!map) {
@@ -23,6 +28,7 @@ export default async function getNewTemplate(
     templateData.setFileSystemSearch(new FileSystemSearch());
   }
   let tmpl = new Template(path, inputDir, outputDir, templateData, map, eleventyConfig);
+
   await tmpl.getTemplateRender();
 
   return tmpl;

--- a/test/_getNewTemplateForTests.js
+++ b/test/_getNewTemplateForTests.js
@@ -27,7 +27,7 @@ export default async function getNewTemplate(
   if (templateData) {
     templateData.setFileSystemSearch(new FileSystemSearch());
   }
-  let tmpl = new Template(path, inputDir, outputDir, templateData, map, eleventyConfig);
+  let tmpl = new Template(path, templateData, map, eleventyConfig);
 
   await tmpl.getTemplateRender();
 

--- a/test/_issues/975/975-test.js
+++ b/test/_issues/975/975-test.js
@@ -1,16 +1,20 @@
 import test from "ava";
 
 import TemplateMap from "../../../src/TemplateMap.js";
-import TemplateConfig from "../../../src/TemplateConfig.js";
 import getNewTemplateForTests from "../../_getNewTemplateForTests.js";
+import { getTemplateConfigInstance } from "../../_testHelpers.js";
 
 function getNewTemplate(filename, input, output, eleventyConfig) {
   return getNewTemplateForTests(filename, input, output, null, null, eleventyConfig);
 }
 
 test("Get ordered list of templates", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+  let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/_issues/975/",
+			output: "test/_issues/975/_site",
+		}
+	});
 
   let tm = new TemplateMap(eleventyConfig);
 
@@ -52,8 +56,12 @@ test("Get ordered list of templates", async (t) => {
 });
 
 test("Get ordered list of templates (reverse add)", async (t) => {
-  let eleventyConfig = new TemplateConfig();
-  await eleventyConfig.init();
+	let eleventyConfig = await getTemplateConfigInstance({
+		dir: {
+			input: "test/_issues/975/",
+			output: "test/_issues/975/_site",
+		}
+	});
 
   let tm = new TemplateMap(eleventyConfig);
 

--- a/test/_testHelpers.js
+++ b/test/_testHelpers.js
@@ -1,0 +1,50 @@
+import { isPlainObject } from "@11ty/eleventy-utils";
+import TemplateConfig from "../src/TemplateConfig.js";
+import ProjectDirectories from "../src/Util/ProjectDirectories.js";
+
+async function getTemplateConfigInstance(configObj, dirs, configObjOverride = undefined) {
+	let eleventyConfig;
+	if(configObj instanceof TemplateConfig) {
+		eleventyConfig = configObj;
+		configObj = undefined;
+
+		if(!(dirs instanceof ProjectDirectories)) {
+			throw new Error("Testing error: second argument to getTemplateConfigInstance must be a ProjectDirectories instance when the first argument is a TemplateConfig instance.")
+		}
+	} else {
+		eleventyConfig = new TemplateConfig();
+	}
+
+	if(!(dirs instanceof ProjectDirectories)) {
+		dirs = new ProjectDirectories();
+		if(isPlainObject(configObj) && !configObj.dir) {
+			throw new Error("Testing error: missing `dir` property on config object literal passed in.")
+		}
+		dirs.setViaConfigObject(configObj?.dir || {});
+	}
+
+	eleventyConfig.setDirectories(dirs);
+
+	await eleventyConfig.init(configObjOverride || configObj); // overrides
+
+	return eleventyConfig;
+}
+
+async function getTemplateConfigInstanceCustomCallback(dirObject, configCallback) {
+	let tmplCfg = new TemplateConfig();
+
+	configCallback(tmplCfg.userConfig);
+
+	let dirs = new ProjectDirectories();
+	dirs.setViaConfigObject(dirObject);
+
+	let eleventyConfig = await getTemplateConfigInstance(tmplCfg, dirs, {
+		dir: dirObject
+	});
+	return eleventyConfig;
+}
+
+export {
+	getTemplateConfigInstance,
+	getTemplateConfigInstanceCustomCallback,
+};


### PR DESCRIPTION
Preparation for #67 and #1503 and #2307.
Assisting on #1612 (making paths relative to input dir).

The biggest practical change here is that you’ll be able to reference Eleventy’s full resolved `directories` in plugins and configuration files. This will include values set via command line arguments #2729.

## When returning `dir` in your config:

Use `addPlugin` to get the correct values (plugins run in a second stage).

```js
export default function(eleventyConfig) {
  // Plugins run in a second stage, so we have access to the return object data below
  eleventyConfig.addPlugin(eleventyConfig => {
    // These values always have a trailing slash (if directory); always posix-style forward-slash paths
    eleventyConfig.directories.input; // has "./content/"
    eleventyConfig.directories.output; // has "./_site/"

    // includes, data, layouts directories (input dir relative) are normalized to project root relative.
    eleventyConfig.directories.includes; // has "./content/_includes/
    eleventyConfig.directories.layouts; // is falsy (not specified)
    eleventyConfig.directories.data; // has "./content/_data/"
  });

  return {
    dir: {
      input: "content",
      includes: "_includes",
      data: "_data",
      output: "_site",
    }
  }
};
```

If you don’t use `addPlugin`, you’ll get the wrong values. To be fixed in #1503.

```js
export default function(eleventyConfig) {
  // WARNING: this will be wrong if you return an object in your config file
  eleventyConfig.directories.input; // has "./"

  return {
    dir: {
      input: "content",
      includes: "_includes",
      data: "_data",
      output: "_site",
    }
  }
};
```

## Command Line

However, if you pass `--input` or `--output` directories in on the command line, the values will be correct, e.g. `npx @11ty/eleventy --input=content`:

```js
export default function(eleventyConfig) {
  eleventyConfig.directories.input; // has "./content/"
};
```