### PR TITLE
Write templates synchronously

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -25,7 +25,6 @@ import EleventyBaseError from "./Errors/EleventyBaseError.js";
 import ReservedData from "./Util/ReservedData.js";
 
 const { set: lodashSet, get: lodashGet } = lodash;
-const writeFile = util.promisify(fs.writeFile);
 const fsStat = util.promisify(fs.stat);
 
 const debug = debugUtil("Eleventy:Template");
@@ -748,7 +747,9 @@ class Template extends TemplateContent {
 		let templateBenchmark = this.bench.get("Template Write");
 		templateBenchmark.before();
 
-		await writeFile(outputPath, finalContent);
+		// Note: This deliberately uses the synchronous version to avoid
+		// unbounded concurrency: https://github.com/11ty/eleventy/issues/3271
+		fs.writeFileSync(outputPath, finalContent);
 
 		templateBenchmark.after();
 		this.writeCount++;


### PR DESCRIPTION
I’m not sure how to implement a queue to resolve #3271 but here’s my proposed workaround. This does block everything while writing a template (hopefully a small window).

Closes #3271
Closes #2627