### PR TITLE
Store the result of this.benchmarks.aggregate.get("Passthrough Copy File") in a variable

### DIFF
--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -241,17 +241,18 @@ class TemplatePassthrough {
 
 		let fileCopyCount = 0;
 		let map = {};
+		let b = this.benchmarks.aggregate.get("Passthrough Copy File");
 		// returns a promise
 		return copy(src, dest, copyOptions)
 			.on(copy.events.COPY_FILE_START, (copyOp) => {
 				// Access to individual files at `copyOp.src`
 				debug("Copying individual file %o", copyOp.src);
 				map[copyOp.src] = copyOp.dest;
-				this.benchmarks.aggregate.get("Passthrough Copy File").before();
+				b.before();
 			})
 			.on(copy.events.COPY_FILE_COMPLETE, (/*copyOp*/) => {
 				fileCopyCount++;
-				this.benchmarks.aggregate.get("Passthrough Copy File").after();
+				b.after();
 			})
 			.then(() => {
 				return {


### PR DESCRIPTION
This is to ensure the same object is used for .before() and .after() calls, which makes this code work better with https://github.com/fqueze/11ty-fx-profiler/ that replaces the eleventyConfig.benchmarkManager implementation with another one that produces profiles the Firefox Profiler can understand.