### PR TITLE
Render templates in parallel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
 		"node-retrieve-globals": "^6.0.0",
 		"normalize-path": "^3.0.0",
 		"nunjucks": "^3.2.4",
+		"p-map": "^7.0.2",
 		"please-upgrade-node": "^3.2.0",
 		"posthtml": "^0.16.6",
 		"recursive-copy": "^2.0.14",


### PR DESCRIPTION
For Eleventy sites with templates using shortcodes that do a lot of computation, rendering the template is the part of the build that takes the longest. This part is done sequentially.

This PR makes it happen in parallel, limiting the concurrency to the core count.

Example profiles, using the 11ty-website site as an example for benchmarking:
- when _site doesn't exist (causing eleventy-img to re-resize all images used by templates)
  - with concurrency limited to 1 (matching current behavior) : https://share.firefox.dev/44vKeml (3.7s to render templates)
  - with concurrency using all cores (10 on my laptop) : https://share.firefox.dev/4bjJnas (2.2s to render templates)
- when _site is already fully populated:
  - with concurrency limited to 1 (matching current behavior) : https://share.firefox.dev/3UwaE2T (1s to render templates)
  - with concurrency using all cores (10 on my laptop) : https://share.firefox.dev/3Qxz3Ui (1s to render templates)

I zoomed all profiles to the time range when templates are rendered.

The saving is larger for [my own website](https://github.com/fqueze/combien-consomme.fr/), going from [10s](https://share.firefox.dev/4bmBfWJ) to [3.4s](https://share.firefox.dev/3wlBlz8) to render my templates.

Rendering in parallel helps mostly for cases where the templates trigger async code that can perform some of its work off main thread. This is the case for resizing images with eleventy-img. This would also enable using workers to move heavy JS computations of shortcodes off of the main thread (without this PR, moving work to a worker is pointless as the main thread is blocked waiting for the result).