### PR TITLE
docs: Add JSDoc for all events

### DIFF
--- a/src/Data/TemplateData.js
+++ b/src/Data/TemplateData.js
@@ -275,6 +275,9 @@ class TemplateData {
 		return folders;
 	}
 
+	/**
+	 * @fires "eleventy.globalDataFiles"
+	 */
 	async getAllGlobalData() {
 		let globalData = {};
 		let files = TemplatePath.addLeadingDotSlashArray(await this.getGlobalDataFiles());
@@ -373,6 +376,9 @@ class TemplateData {
 	}
 
 	/* Template and Directory data files */
+	/**
+	 * @fires "eleventy.dataFiles"
+	 */
 	async combineLocalData(localDataPaths) {
 		let localData = {};
 		if (!Array.isArray(localDataPaths)) {

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -406,9 +406,14 @@ class Eleventy {
 	/**
 	 * Starts Eleventy.
 	 *
+	 * @fires "eleventy.config"
+	 * @fires "eleventy.env"
+	 * @fires "eleventy.extensionmap"
+	 * @fires "eleventy.directories"
+	 *
 	 * @async
-	 * @method
-	 * @returns {} - tbd.
+	 * @param {object} [options={}]
+	 * @void
 	 */
 	async init(options = {}) {
 		options = Object.assign({ viaConfigReset: false }, options);
@@ -769,6 +774,9 @@ Arguments:
 	/**
 	 * tbd.
 	 *
+	 * @fires "eleventy.templateModified"
+	 * @fires "eleventy.resourceModified"
+	 *
 	 * @private
 	 * @method
 	 * @param {String} changedFilePath - File that triggered a re-run (added or modified)
@@ -832,6 +840,9 @@ Arguments:
 
 	/**
 	 * tbd.
+	 *
+	 * @fires "eleventy.beforeWatch"
+	 * @fires "eleventy.reset"
 	 *
 	 * @private
 	 * @method
@@ -1064,6 +1075,10 @@ Arguments:
 	/**
 	 * Start the watching of files
 	 *
+	 * @listens "change"
+	 * @listens "add"
+	 * @listens "unlink"
+	 *
 	 * @async
 	 * @method
 	 */
@@ -1207,6 +1222,9 @@ Arguments:
 
 	/**
 	 * tbd.
+	 *
+	 * @fires "eleventy.before"
+	 * @fires "eleventy.after"
 	 *
 	 * @async
 	 * @method

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -170,6 +170,9 @@ class EleventyFiles {
 		return this._templateData;
 	}
 
+	/**
+	 * @fires "eleventy.ignores"
+	 */
 	setupGlobs() {
 		this.fileIgnores = this.getIgnores();
 		this.extraIgnores = this._getIncludesAndDataDirs();

--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -62,6 +62,10 @@ class EleventyServe {
 		return this._eleventyConfig;
 	}
 
+
+	/**
+	 * @listens "eleventy.passthrough"
+	 */
 	set eleventyConfig(config) {
 		this._eleventyConfig = config;
 		if (checkPassthroughCopyBehavior(this._eleventyConfig.userConfig, "serve")) {

--- a/src/EleventyWatchTargets.js
+++ b/src/EleventyWatchTargets.js
@@ -131,6 +131,11 @@ class EleventyWatchTargets {
 		this.writer = templateWriter;
 	}
 
+	/**
+	 * @fires "eleventy.importCacheReset"
+	 *
+	 * @param {string[]} filePathArray
+	 */
 	clearImportCacheFor(filePathArray) {
 		let paths = new Set();
 		for (const filePath of filePathArray) {

--- a/src/Engines/Custom.js
+++ b/src/Engines/Custom.js
@@ -3,6 +3,8 @@ import getJavaScriptData from "../Util/GetJavaScriptData.js";
 import eventBus from "../EventBus.js";
 
 let lastModifiedFile = undefined;
+
+/** @listens "eleventy.resourceModified" */
 eventBus.on("eleventy.resourceModified", (path) => {
 	lastModifiedFile = path;
 });

--- a/src/Engines/Nunjucks.js
+++ b/src/Engines/Nunjucks.js
@@ -20,6 +20,9 @@ class Nunjucks extends TemplateEngine {
 		this.cacheable = true;
 	}
 
+	/**
+	 * @fires "eleventy.engine.njk"
+	 */
 	_setEnv(override) {
 		if (override) {
 			this.njkEnv = override;
@@ -61,6 +64,9 @@ class Nunjucks extends TemplateEngine {
 		});
 	}
 
+	/**
+	 * @listens "eleventy.resourceModified"
+	 */
 	setLibrary(override) {
 		this._setEnv(override);
 

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -14,6 +14,9 @@ class GlobalDependencyMap {
 		this._map = undefined;
 	}
 
+	/**
+	 * @listens "eleventy.layouts" (once)
+	 */
 	setConfig(config) {
 		if (this.config) {
 			return;

--- a/src/Plugins/I18nPlugin.js
+++ b/src/Plugins/I18nPlugin.js
@@ -154,6 +154,10 @@ function getLocaleUrlsMap(urlToInputPath, extensionMap, options = {}) {
 	return urlMap;
 }
 
+/**
+ * @listens "eleventy.extensionmap"
+ * @listens "eleventy.contentMap"
+ */
 function EleventyPlugin(eleventyConfig, opts = {}) {
 	let options = DeepCopy(
 		{

--- a/src/Plugins/InputPathToUrl.js
+++ b/src/Plugins/InputPathToUrl.js
@@ -22,6 +22,9 @@ function normalizeInputPath(inputPath, inputDir, contentMap) {
 	return inputPath;
 }
 
+/**
+ * @listens "eleventy.contentMap"
+ */
 function FilterPlugin(eleventyConfig) {
 	let contentMap;
 	eleventyConfig.on("eleventy.contentMap", function ({ inputPathToUrl }) {
@@ -45,6 +48,9 @@ function FilterPlugin(eleventyConfig) {
 	});
 }
 
+/**
+ * @listens "eleventy.contentMap"
+ */
 function TransformPlugin(eleventyConfig, defaultOptions = {}) {
 	let opts = Object.assign(
 		{

--- a/src/Plugins/RenderPlugin.js
+++ b/src/Plugins/RenderPlugin.js
@@ -129,8 +129,12 @@ async function renderShortcodeFn(fn, data) {
  * string (or file) inside of another template. {@link https://www.11ty.dev/docs/plugins/render/}
  *
  * @since 1.0.0
+ *
  * @param {module:11ty/eleventy/UserConfig} eleventyConfig - User-land configuration instance.
  * @param {Object} options - Plugin options
+ *
+ * @listens "eleventy.config"
+ * @listens "eleventy.extensionmap"
  */
 function EleventyPlugin(eleventyConfig, options = {}) {
 	/**

--- a/src/TemplateCache.js
+++ b/src/TemplateCache.js
@@ -86,6 +86,7 @@ class TemplateCache {
 
 let layoutCache = new TemplateCache();
 
+/** @listens "eleventy.resourceModified" */
 eventBus.on("eleventy.resourceModified", (path, usedBy, metadata = {}) => {
 	// https://github.com/11ty/eleventy-plugin-bundle/issues/10
 	if (metadata.viaConfigReset) {

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -151,6 +151,7 @@ class TemplateConfig {
 
 	/**
 	 * Resets the configuration.
+	 * @fires "eleventy.compileCacheReset"
 	 */
 	async reset() {
 		debugDev("Resetting configuration: TemplateConfig and UserConfig.");
@@ -380,6 +381,8 @@ class TemplateConfig {
 
 	/**
 	 * Merges different config files together.
+	 *
+	 * @fires "eleventy.beforeConfig"
 	 *
 	 * @param {String} projectConfigPath - Path to project config.
 	 * @returns {{}} merged - The merged config file.

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -661,6 +661,8 @@ class TemplateContent {
 
 TemplateContent._inputCache = new Map();
 TemplateContent._compileCache = new Map();
+
+/** @listens "eleventy.resourceModified" */
 eventBus.on("eleventy.resourceModified", (path) => {
 	// delete from input cache
 	TemplateContent.deleteFromInputCache(path);
@@ -673,7 +675,12 @@ eventBus.on("eleventy.resourceModified", (path) => {
 	}
 });
 
-// Used when the configuration file reset https://github.com/11ty/eleventy/issues/2147
+/**
+ * Used when the configuration file reset.
+ * @see https://github.com/11ty/eleventy/issues/2147
+ *
+ * @listens "eleventy.compileCacheReset"
+ */
 eventBus.on("eleventy.compileCacheReset", (/*path*/) => {
 	TemplateContent._compileCache = new Map();
 });

--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -430,6 +430,10 @@ class TemplateMap {
 		}
 	}
 
+	/**
+	 * @fires "eleventy.contentMap"
+	 * @fires "eleventy.layouts"
+	 */
 	async cache() {
 		debug("Caching collections objects.");
 		this.collectionsData = {};

--- a/src/TemplatePassthrough.js
+++ b/src/TemplatePassthrough.js
@@ -221,10 +221,14 @@ class TemplatePassthrough {
 		return paths;
 	}
 
-	/* Types:
+	/**
+	 * Types:
 	 * 1. via glob, individual files found
 	 * 2. directory, triggers an event for each file
 	 * 3. individual file
+	 *
+	 * @listens copy.events.COPY_FILE_START
+	 * @listens copy.events.COPY_FILE_COMPLETE
 	 */
 	async copy(src, dest, copyOptions) {
 		if (

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -278,6 +278,7 @@ class TemplatePassthroughManager {
 	// Performance note: these can actually take a fair bit of time, but aren’t a
 	// bottleneck to eleventy. The copies are performed asynchronously and don’t affect eleventy
 	// write times in a significant way.
+	/** @fires "eleventy.passthrough" */
 	async copyAll(templateExtensionPaths) {
 		debug("TemplatePassthrough copy started.");
 		let normalizedPaths = this.getAllNormalizedPaths(templateExtensionPaths);

--- a/src/Util/Require.js
+++ b/src/Util/Require.js
@@ -34,6 +34,8 @@ async function loadContents(path, options = {}) {
 }
 
 let lastModifiedPaths = new Map();
+
+/** @listens "eleventy.importCacheReset" */
 eventBus.on("eleventy.importCacheReset", (fileQueue) => {
 	for (let filePath of fileQueue) {
 		let absolutePath = TemplatePath.absolutePath(filePath);


### PR DESCRIPTION
The official JSDoc events is confusing and poorly documented, so this is really just “tagging” where event are listened for, and where they are emitted.

…That said, I think it’s a good start towards documenting the public API of Eleventy’s internals. JSDocs like this—even when they exist only in the source—will be particularly helpful for plugin authors who want to explore what they are able to do, and how they might do it.