### PR TITLE
replace `index.d.ts` with jsdoc `@typedef`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 	},
 	"main": "src/Eleventy.js",
 	"type": "module",
-	"types": "src/index.d.ts",
 	"bin": {
 		"eleventy": "cmd.cjs"
 	},

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -1402,3 +1402,7 @@ export {
 	 */
 	BundlePlugin,
 };
+
+/**
+ * @typedef {import('./UserConfig.js').default} UserConfig
+ */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,0 @@
-import UserConfig from "./UserConfig";
-
-export { UserConfig };


### PR DESCRIPTION
This basically reverts the changes from #3291 (and #2091), in favor of the approach from #3060. 

A new JSDoc `@typedef` comment ensures that `UserConfig` types are available (fixes #3097), *and* that everything exported from `Eleventy.js` has proper types (fixes #2935).