### PR TITLE
refactor(loops): Clean up some loops

### DIFF
--- a/src/Benchmark/BenchmarkGroup.js
+++ b/src/Benchmark/BenchmarkGroup.js
@@ -98,8 +98,7 @@ class BenchmarkGroup {
 	}
 
 	finish(label, totalTimeSpent) {
-		for (var type in this.benchmarks) {
-			let bench = this.benchmarks[type];
+		for (let [type, bench] of Object.entries(this.benchmarks)) {
 			let isAbsoluteMinimumComparison = this.minimumThresholdMs > 0;
 			let totalForBenchmark = bench.getTotal();
 			let percent = Math.round((totalForBenchmark * 100) / totalTimeSpent);

--- a/src/Benchmark/BenchmarkManager.js
+++ b/src/Benchmark/BenchmarkManager.js
@@ -14,8 +14,8 @@ class BenchmarkManager {
 	reset() {
 		this.start = this.getNewTimestamp();
 
-		for (var j in this.benchmarkGroups) {
-			this.benchmarkGroups[j].reset();
+		for (let group of Object.keys(this.benchmarkGroups)) {
+			this.benchmarkGroups[group].reset();
 		}
 	}
 
@@ -64,8 +64,8 @@ class BenchmarkManager {
 
 	finish() {
 		let totalTimeSpentBenchmarking = this.getNewTimestamp() - this.start;
-		for (var j in this.benchmarkGroups) {
-			this.benchmarkGroups[j].finish(j, totalTimeSpentBenchmarking);
+		for (let group of Object.keys(this.benchmarkGroups)) {
+			this.benchmarkGroups[group].finish(group, totalTimeSpentBenchmarking);
 		}
 	}
 }

--- a/src/EleventyExtensionMap.js
+++ b/src/EleventyExtensionMap.js
@@ -74,12 +74,10 @@ class EleventyExtensionMap {
 	// on paths found from the file system glob search.
 	// TODO: Method name might just need to be renamed to something more accurate.
 	isFullTemplateFilePath(path) {
-		for (let extension of this.validTemplateLanguageKeys) {
-			if (path.endsWith(`.${extension}`)) {
-				return true;
-			}
-		}
-		return false;
+		return this.validTemplateLanguageKeys.some(
+			(extension) => path.endsWith(`.${extension}`)
+		)
+
 	}
 
 	getCustomExtensionEntry(extension) {

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -89,15 +89,12 @@ class EleventyFiles {
 	}
 
 	get passthroughGlobs() {
-		let paths = new Set();
-		// stuff added in addPassthroughCopy()
-		for (let path of this.passthroughManager.getConfigPathGlobs()) {
-			paths.add(path);
-		}
-		// non-template language extensions
-		for (let path of this.extensionMap.getPassthroughCopyGlobs(this.inputDir)) {
-			paths.add(path);
-		}
+		let paths = new Set([
+			// stuff added in addPassthroughCopy()
+			...this.passthroughManager.getConfigPathGlobs(),
+			// non-template language extensions
+			...this.extensionMap.getPassthroughCopyGlobs(this.inputDir),
+		]);
 		return Array.from(paths);
 	}
 
@@ -184,13 +181,10 @@ class EleventyFiles {
 	}
 
 	getIgnoreGlobs() {
-		let uniqueIgnores = new Set();
-		for (let ignore of this.fileIgnores) {
-			uniqueIgnores.add(ignore);
-		}
-		for (let ignore of this.extraIgnores) {
-			uniqueIgnores.add(ignore);
-		}
+		let uniqueIgnores = new Set([
+			...this.fileIgnores,
+			...this.extraIgnores,
+		]);
 		// Placing the config ignores last here is important to the tests
 		for (let ignore of this.config.ignores) {
 			uniqueIgnores.add(TemplateGlob.normalizePath(this.localPathRoot || ".", ignore));
@@ -267,11 +261,9 @@ class EleventyFiles {
 	}
 
 	getIgnores() {
-		let files = new Set();
-
-		for (let ignore of EleventyFiles.getFileIgnores(this.getIgnoreFiles())) {
-			files.add(ignore);
-		}
+		let files = new Set(
+			EleventyFiles.getFileIgnores(this.getIgnoreFiles())
+		);
 
 		// testing API
 		if (this.eleventyIgnoreContent !== false) {
@@ -431,14 +423,7 @@ class EleventyFiles {
 		if (!filePath) {
 			return false;
 		}
-
-		for (let path of paths) {
-			if (path === filePath) {
-				return true;
-			}
-		}
-
-		return false;
+		return paths.some((path) => path === filePath)
 	}
 
 	/* For `eleventy --watch` */

--- a/src/EleventyWatch.js
+++ b/src/EleventyWatch.js
@@ -78,12 +78,9 @@ class EleventyWatch {
 	}
 
 	hasQueuedFiles(files) {
-		for (const file of files) {
-			if (this.hasQueuedFile(file)) {
-				return true;
-			}
-		}
-		return false;
+		return files.some(
+			(file) => this.hasQueuedFile(file)
+		)
 	}
 
 	get pendingQueue() {

--- a/src/Template.js
+++ b/src/Template.js
@@ -211,7 +211,7 @@ class Template extends TemplateContent {
 				let results = await Promise.all(promises);
 
 				permalinkValue = {};
-				for (let j = 0, k = keys.length; j < k; j++) {
+				for (let j = 0; j < keys.length; j++) {
 					let key = keys[j];
 					permalinkValue[key] = results[j];
 					debug(

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -193,7 +193,7 @@ class TemplateLayout extends TemplateContent {
 
 				// The parent already includes the rest of the layout chain
 				let upstreamFns = await layoutTemplate.getCompiledLayoutFunctions();
-				for (let j = 0, k = upstreamFns.length; j < k; j++) {
+				for (let j = 0; j < upstreamFns.length; j++) {
 					fns.push(upstreamFns[j]);
 				}
 			}

--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -653,13 +653,13 @@ class TemplateMap {
 	}
 
 	populateCollectionsWithContent() {
-		for (let collectionName in this.collectionsData) {
+		for (let collectionData of Object.values(this.collectionsData)) {
 			// skip custom collections set in configuration files that have arbitrary types
-			if (!Array.isArray(this.collectionsData[collectionName])) {
+			if (!Array.isArray(collectionData)) {
 				continue;
 			}
 
-			for (let item of this.collectionsData[collectionName]) {
+			for (let item of collectionData) {
 				// skip custom collections set in configuration files that have arbitrary types
 				if (!isPlainObject(item) || !("inputPath" in item)) {
 					continue;

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -95,13 +95,9 @@ class TemplatePassthroughManager {
 	}
 
 	getNonTemplatePaths(paths) {
-		let matches = [];
-		for (let path of paths) {
-			if (!this.extensionMap.hasEngine(path)) {
-				matches.push(path);
-			}
-		}
-
+		let matches = paths.filter((path) => {
+			return !this.extensionMap.hasEngine(path);
+		});
 		return matches;
 	}
 

--- a/src/Util/Objects/ProxyWrap.js
+++ b/src/Util/Objects/ProxyWrap.js
@@ -29,10 +29,7 @@ function wrapObject(target, fallback) {
 			return Reflect.has(fallback, prop);
 		},
 		ownKeys(target) {
-			let s = new Set();
-			for (let k of Reflect.ownKeys(target)) {
-				s.add(k);
-			}
+			let s = new Set(Reflect.ownKeys(target));
 			if (isPlainObject(fallback)) {
 				for (let k of Reflect.ownKeys(fallback)) {
 					s.add(k);


### PR DESCRIPTION
Lots of small tweaks. Usually to make loops easier to read, and sometimes to replace a loop with something that is (hopefully) [easier][1] or [faster][2] to read.

[1]: #diff-b3d72ae97ebb8b890a1bfb1d216e058beae0efddf87ec4bb75fcedb26e0f98e3
[2]: #diff-8b8317c75f11cacab005f253a162744e6cf3530292234efec197702d27540680R92