### PR TITLE
Restore Node 22.5 to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        # Restore "22" after 22.5.1 ships https://github.com/actions/node-versions/pull/182
-        node: ["18", "20", "22.4"]
+        node: ["18", "20", "22"]
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Was waiting on https://github.com/actions/node-versions/pull/182 which shipped.