### PR TITLE
Fix type of HtmlTransformer plugins attribute

### DIFF
--- a/src/Util/HtmlTransformer.js
+++ b/src/Util/HtmlTransformer.js
@@ -7,7 +7,7 @@ class HtmlTransformer {
 		// execution order is important (not order of addition/object key order)
 		this.callbacks = {};
 		this.posthtmlProcessOptions = {};
-		this.plugins = [];
+		this.plugins = {};
 	}
 
 	get aggregateBench() {


### PR DESCRIPTION
While plugins should be ordered, this attribute seems to be used as a map from an extension to that list of plugins rather than the list itself; as indicated in the `getPlugins()` method.

In my site I don't do any configuration of this, just using the defaults. While trying to update to Eleventy 3 I was running into errors

> Problem writing Eleventy templates:
> 1. Having trouble writing to "./public/css/base.css", "./public/css/base.css.map" from "./pages/styles.11ty.js" (via EleventyTemplateError)
> 2. Transform `@11ty/eleventy/html-transformer` encountered an error when transforming ./pages/styles.11ty.js. (via EleventyTransformError)
> 3. plugins is not iterable (via TypeError)
>
> Original error stack trace: TypeError: plugins is not iterable
>     at HtmlTransformer._getPosthtmlInstance (file:///home/ats/vc/personal/web/node_modules/.pnpm/github.com+11ty+eleventy@c39e8961a2ab7e311696d415fc4238e8fe4d4d80/node_modules/@11ty/eleventy/src/Util/HtmlTransformer.js:39:39)
>     at HtmlTransformer.transformContent (file:///home/ats/vc/personal/web/node_modules/.pnpm/github.com+11ty+eleventy@c39e8961a2ab7e311696d415fc4238e8fe4d4d80/node_modules/@11ty/eleventy/src/Util/HtmlTransformer.js:142:42)
>     at Object.<anonymous> (file:///home/ats/vc/personal/web/node_modules/.pnpm/github.com+11ty+eleventy@c39e8961a2ab7e311696d415fc4238e8fe4d4d80/node_modules/@11ty/eleventy/src/defaultConfig.js:125:13)
>     at Object.fn (file:///home/ats/vc/personal/web/node_modules/.pnpm/github.com+11ty+eleventy@c39e8961a2ab7e311696d415fc4238e8fe4d4d80/node_modules/@11ty/eleventy/src/Benchmark/BenchmarkGroup.js:37:23)
>     at TransformsUtil.runAll (file:///home/ats/vc/personal/web/node_modules/.pnpm/github.com+11ty+eleventy@c39e8961a2ab7e311696d415fc4238e8fe4d4d80/node_modules/@11ty/eleventy/src/Util/TransformsUtil.js:36:30)

The main problem seemed to be writing `./public/css/base.css.map`. When getPlugins was called for that it was finding the `map` method for Array which it could not iterate over.