### PR TITLE
Fix wildcard in extensions argument in `.addPreprocessor()`

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -655,7 +655,7 @@ class Template extends TemplateContent {
 			}
 
 			filters = filters.map((extension) => {
-				if (extension.startsWith(".")) {
+				if (extension.startsWith(".") || extension === "*") {
 					return extension;
 				}
 


### PR DESCRIPTION
The second argument in `.addPreprocessor()` seems to be designed to allow `"*"` to match all templating languages, but gets mapped to `".*"` before the actual comparison to `"*"` happens. As such, it is impossible to match all file types.