### PR TITLE
`addPreprocessor` support for `11ty.js` and Custom templates (via `useJavaScriptImport` property)

### DIFF
--- a/src/Engines/JavaScript.js
+++ b/src/Engines/JavaScript.js
@@ -123,6 +123,15 @@ class JavaScript extends TemplateEngine {
 		return false;
 	}
 
+	/**
+	 * Use the module loader directly
+	 *
+	 * @override
+	 */
+	useJavaScriptImport() {
+		return true;
+	}
+
 	async getExtraDataFromFile(inputPath) {
 		let inst = await this.getInstanceFromInputPath(inputPath);
 		return getJavaScriptData(inst, inputPath);

--- a/src/Engines/TemplateEngine.js
+++ b/src/Engines/TemplateEngine.js
@@ -111,6 +111,10 @@ class TemplateEngine {
 		return fn(data);
 	}
 
+	useJavaScriptImport() {
+		return false;
+	}
+
 	// JavaScript files defer to the module loader rather than read the files to strings
 	needsToReadFileContents() {
 		return true;

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -184,6 +184,13 @@ class TemplateContent {
 		let content = await this.inputContent;
 
 		if (content || content === "") {
+			if (this.engine.useJavaScriptImport()) {
+				return {
+					data: {},
+					content,
+				};
+			}
+
 			let options = this.config.frontMatterParsingOptions || {};
 			let fm;
 			try {
@@ -266,6 +273,14 @@ class TemplateContent {
 
 	async getInputContent() {
 		let tr = await this.getTemplateRender();
+
+		if (
+			tr.engine.useJavaScriptImport() &&
+			typeof tr.engine.getInstanceFromInputPath === "function"
+		) {
+			return tr.engine.getInstanceFromInputPath(this.inputPath);
+		}
+
 		if (!tr.engine.needsToReadFileContents()) {
 			return "";
 		}

--- a/src/TemplateContent.js
+++ b/src/TemplateContent.js
@@ -274,6 +274,12 @@ class TemplateContent {
 	async getInputContent() {
 		let tr = await this.getTemplateRender();
 
+		let virtualTemplateDefinition = this.getVirtualTemplateDefinition();
+		if (virtualTemplateDefinition) {
+			let { content } = virtualTemplateDefinition;
+			return content;
+		}
+
 		if (
 			tr.engine.useJavaScriptImport() &&
 			typeof tr.engine.getInstanceFromInputPath === "function"
@@ -283,12 +289,6 @@ class TemplateContent {
 
 		if (!tr.engine.needsToReadFileContents()) {
 			return "";
-		}
-
-		let virtualTemplateDefinition = this.getVirtualTemplateDefinition();
-		if (virtualTemplateDefinition) {
-			let { content } = virtualTemplateDefinition;
-			return content;
 		}
 
 		let templateBenchmark = this.bench.get("Template Read");

--- a/test/EleventyTest-Preprocessors.js
+++ b/test/EleventyTest-Preprocessors.js
@@ -109,8 +109,8 @@ test("addPreprocessor with 11ty.js, Issue #3433", async (t) => {
   let elev = new Eleventy("./test/stubs-virtual/", undefined, {
     config: eleventyConfig => {
       eleventyConfig.addPreprocessor("testing", "11ty.js", (data, content) => {
-        t.is( typeof content.render, "function" );
-        t.is(content.render(), "Hello!");
+        t.is( typeof content, "function" );
+        t.is(content(), "Hello!");
 
         return {
           render: function() {
@@ -119,7 +119,7 @@ test("addPreprocessor with 11ty.js, Issue #3433", async (t) => {
         };
       });
 
-      eleventyConfig.addTemplate("template.11ty.js", function render() {
+      eleventyConfig.addTemplate("template.11ty.js", function() {
         return "Hello!"
       });
     }
@@ -143,8 +143,8 @@ test("addPreprocessor and addExtension, Issue #3433", async (t) => {
       });
 
       eleventyConfig.addPreprocessor("testing", "11ty.test", (data, content) => {
-        t.is( typeof content.render, "function" );
-        t.is(content.render(), "Hello!");
+        t.is( typeof content, "function" );
+        t.is(content(), "Hello!");
 
         return {
           render: function() {
@@ -153,7 +153,7 @@ test("addPreprocessor and addExtension, Issue #3433", async (t) => {
         };
       });
 
-      eleventyConfig.addTemplate("template.11ty.test", function render() {
+      eleventyConfig.addTemplate("template.11ty.test", function() {
         return "Hello!"
       });
     }
@@ -179,8 +179,8 @@ test("addPreprocessor and addExtension with custom `compile` (defaultRenderer), 
       });
 
       eleventyConfig.addPreprocessor("testing", "11ty.test", (data, content) => {
-        t.is( typeof content.render, "function" );
-        t.is(content.render(), "Hello!");
+        t.is( typeof content, "function" );
+        t.is(content(), "Hello!");
 
         return {
           render: function() {
@@ -189,7 +189,7 @@ test("addPreprocessor and addExtension with custom `compile` (defaultRenderer), 
         };
       });
 
-      eleventyConfig.addTemplate("template.11ty.test", function render() {
+      eleventyConfig.addTemplate("template.11ty.test", function() {
         return "Hello!"
       });
     }
@@ -217,8 +217,8 @@ test("addPreprocessor and addExtension with custom `compile` (re-use render func
       });
 
       eleventyConfig.addPreprocessor("testing", "11ty.test", (data, content) => {
-        t.is( typeof content.render, "function" );
-        t.is(content.render(), "Hello!");
+        t.is( typeof content, "function" );
+        t.is(content(), "Hello!");
 
         return {
           render: function() {
@@ -227,7 +227,7 @@ test("addPreprocessor and addExtension with custom `compile` (re-use render func
         };
       });
 
-      eleventyConfig.addTemplate("template.11ty.test", function render() {
+      eleventyConfig.addTemplate("template.11ty.test", function() {
         return "Hello!"
       });
     }
@@ -260,8 +260,8 @@ test("addPreprocessor and addExtension with custom `compile` (new render functio
 
       eleventyConfig.addPreprocessor("testing", "11ty.test", (data, content) => {
         // check template content directly
-        t.is( typeof content.render, "function" );
-        t.is(content.render(), "Original template content");
+        t.is( typeof content, "function" );
+        t.is(content(), "Original template content");
 
         return {
           render: function() {
@@ -270,7 +270,7 @@ test("addPreprocessor and addExtension with custom `compile` (new render functio
         };
       });
 
-      eleventyConfig.addTemplate("template.11ty.test", function render() {
+      eleventyConfig.addTemplate("template.11ty.test", function() {
         return "Original template content"
       });
     }

--- a/test/EleventyTest-Preprocessors.js
+++ b/test/EleventyTest-Preprocessors.js
@@ -101,3 +101,36 @@ test("#188: Content preprocessing (wildcard)", async (t) => {
   t.is(results.length, 1);
   t.is(results[0].content, `Hello Before`);
 });
+
+test("addPreprocessor and addExtension, Issue #3433", async (t) => {
+  t.plan(5);
+
+  let elev = new Eleventy("./test/stubs-virtual/", undefined, {
+    config: eleventyConfig => {
+      eleventyConfig.addTemplateFormats("11ty.test");
+      eleventyConfig.addExtension("11ty.test", {
+        key: "11ty.js",
+      });
+
+      eleventyConfig.addPreprocessor("testing", "11ty.test", (data, content) => {
+        t.is( typeof content.render, "function" );
+        t.is(content.render(), "Hello!");
+
+        return {
+          render: function() {
+            return "naw";
+          }
+        };
+      });
+
+      eleventyConfig.addTemplate("template.11ty.test", function render() {
+        return "Hello!"
+      });
+    }
+  });
+
+  let results = await elev.toJSON();
+  t.is(results.length, 1);
+  t.is(results[0].url, `/template/`);
+  t.is(results[0].content.trim(), `naw`);
+});

--- a/test/TemplateTest-CustomExtensions.js
+++ b/test/TemplateTest-CustomExtensions.js
@@ -74,7 +74,7 @@ test("Using getData: true without getInstanceFromInputPath should error", async 
   await t.throwsAsync(async () => {
     await tmpl.getData();
   }, {
-    message: "getInstanceFromInputPath callback missing from txt template engine plugin."
+    message: "`getInstanceFromInputPath` callback missing from \'txt\' template engine plugin. It is required when `getData` is in use. You can set `getData: false` to opt-out of this."
   });
 });
 
@@ -111,7 +111,7 @@ test("Using getData: [] without getInstanceFromInputPath should error", async (t
   await t.throwsAsync(async () => {
     await tmpl.getData();
   }, {
-    message: "getInstanceFromInputPath callback missing from txt template engine plugin."
+    message: "`getInstanceFromInputPath` callback missing from \'txt\' template engine plugin. It is required when `getData` is in use. You can set `getData: false` to opt-out of this."
   });
 });
 


### PR DESCRIPTION
* Adds `useJavaScriptImport` method to TemplateEngine class and enables by default for `JavaScript` (11ty.js) templates.
* `useJavaScriptImport` takes precedence over `needsToReadFileContents` (Custom template engine `read` property)
* Adds an `useJavaScriptImport` property to Custom template options (boolean)

https://www.11ty.dev/docs/languages/custom/#full-options-list