### PR TITLE
Throw error when virtual template format is invalid

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -367,7 +367,7 @@ class EleventyFiles {
 				.map((path) => {
 					let fullVirtualPath = this.dirs.getInputPath(path);
 					if (!this.extensionMap.getKey(fullVirtualPath)) {
-						this.eleventyConfig.logger.warn(
+						throw new Error(
 							`The virtual template at ${fullVirtualPath} is using a template format that’s not valid for your project. Your project is using: "${this.formats}". Read more about formats: https://v3.11ty.dev/docs/config/#template-formats`,
 						);
 					}


### PR DESCRIPTION
It took a while to realize my Atom feed wasn't being created because of this :sweat_smile: 