### PR TITLE
Fix import-related error with CommonJS modules in Node 23

### DIFF
--- a/src/Util/Require.js
+++ b/src/Util/Require.js
@@ -154,6 +154,9 @@ async function dynamicImportAbsolutePath(absolutePath, type, returnRaw = false) 
 				if (key === "default") {
 					continue;
 				}
+				if (key === "module.exports") {
+					continue;
+				}
 				if (target[key] !== target.default[key]) {
 					match = false;
 				}


### PR DESCRIPTION
Fixes https://github.com/11ty/eleventy/issues/3518. Modules in Node 23 (possible 22, didn't test that) have both a `'module.exports'` key as well as a `'default'` key, and Eleventy doesn't know about the former. As such, it incorrectly identifies the module object as the exported object, which breaks things down the road. To resolve this, accept that the top-level object has a `'module.exports'` key that the object under the `'default'` key does not have.