### PR TITLE
Replace UserConfig typedef with a subpath export (#3460)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
 				"minimist": "^1.2.8",
 				"moo": "^0.5.2",
 				"node-retrieve-globals": "^6.0.0",
-				"normalize-path": "^3.0.0",
 				"nunjucks": "^3.2.4",
 				"please-upgrade-node": "^3.2.0",
 				"posthtml": "^0.16.6",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,13 @@
 	"type": "module",
 	"main": "./src/Eleventy.js",
 	"exports": {
-		"import": "./src/Eleventy.js",
-		"require": "./src/EleventyCommonJs.cjs"
+		".": {
+			"import": "./src/Eleventy.js",
+			"require": "./src/EleventyCommonJs.cjs"
+		},
+		"./UserConfig": {
+			"types": "./src/UserConfig.js"
+		}
 	},
 	"bin": {
 		"eleventy": "cmd.cjs"

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -42,9 +42,6 @@ const debug = debugUtil("Eleventy");
 /**
  * Eleventy’s programmatic API
  * @module 11ty/eleventy/Eleventy
- *
- * This line is required for IDE autocomplete in config files
- * @typedef {import('./UserConfig.js').default} UserConfig
  */
 
 class Eleventy {


### PR DESCRIPTION
This is a minimum viable patch that starts work on #3460. Notably, this change removes the requirement of `maxNodeModuleJsDepth` in `tsconfig.json` for TS packages that want to import UserConfig API, as mentioned [in the mega TS issue](https://github.com/11ty/eleventy/issues/3097#issuecomment-2423050317).

Since modifying the functionality of exports, imports, and declarations will involve some cleanup, removal and renaming, further work is probably something best left to the **next major** release.

I've removed the `@typedef` comment from `Eleventy.js`, since adding a `types` subpath export makes exporting it from Eleventy's main file redundant. If backwards compatiblity is needed, then something like this will implement the fuctionality offered by the subpath export:

```diff
 /**
  * Eleventy’s programmatic API
  * @module 11ty/eleventy/Eleventy
  *
+ * This line is required for IDE autocomplete in config files
+ * @typedef {import('./UserConfig').default} UserConfig
  */
```

Also note, declaring `./src/UserConfig.js` as a `"types"` export will _still block it from being directly consumed_ (see #3460), since `"."` is the only pathname that has a `"import/require"` key. It's therefore only possible to import it as a type, either from Typescript or from JSDoc.