### PR TITLE
await mdlib.render

### DIFF
--- a/src/Engines/Markdown.js
+++ b/src/Engines/Markdown.js
@@ -72,7 +72,7 @@ class Markdown extends TemplateEngine {
 				return async function (data) {
 					let fn = await fnReady;
 					let preTemplateEngineRender = await fn(data);
-					let finishedRender = mdlib.render(preTemplateEngineRender, data);
+					let finishedRender = await mdlib.render(preTemplateEngineRender, data);
 					return finishedRender;
 				};
 			}


### PR DESCRIPTION
Hi Zach, I'm over here again with my incredibly-overengineered-11ty-fuzzing-how-tf-does-this-monstrosity-work-website-called-boehs.org, and this is a tiny patch.

Markdown-it does not support async, but you can implement your own markdown renderer by `{ render: (fileContents,data) => string }`, and you may wish for this renderer to be asynchronous because you commit [coding horrors](https://github.com/boehs/site/pull/42/files)

Javascript spec says

`[rv] = await expression;`
expression: A Promise or any value to wait for.
rv: Returns the fulfilled value of the promise, *or the value itself if it's not a Promise.*

so you can kinda just chuck an await on there and pray for the best.