### PR TITLE
fix: inconsistent filepath separators

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -334,9 +334,10 @@ class EleventyFiles {
 
 		// returns a promise
 		debug("Searching for: %o", globs);
-		return (await this.fileSystemSearch.search("templates", globs, {
+		const results = await this.fileSystemSearch.search("templates", globs, {
 			ignore: this.uniqueIgnores,
-		})).map(i => i.replace(/\\/g, '/'));
+		});
+		return results.map(i => i.replace(/\\/g, '/'));
 	}
 
 	getPathsWithVirtualTemplates(paths) {

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -329,14 +329,14 @@ class EleventyFiles {
 		return ret;
 	}
 
-	_globSearch() {
+	async _globSearch() {
 		let globs = this.getFileGlobs();
 
 		// returns a promise
 		debug("Searching for: %o", globs);
-		return this.fileSystemSearch.search("templates", globs, {
+		return (await this.fileSystemSearch.search("templates", globs, {
 			ignore: this.uniqueIgnores,
-		});
+		})).map(i => i.replace(/\\/g, '/'));
 	}
 
 	getPathsWithVirtualTemplates(paths) {


### PR DESCRIPTION
Hey there! Ran into the issue described in #3631 where filepaths are being formatted inconsistently on a windows dev machine, and this seems to prevent the dev server from updating to show new content.

Sample result from `_globSearch` when the server is started with `test1.md`, and then a new file `test2.md` is added:
```js
[
  './content/blog/test1.md',
  './content\\blog\\test2.md',
]
```

The inconsistent format in the newly added file seems to be carried through all the way into the templates without ever being normalized.

This is a bit of a naive fix, but not sure if there's a better place upstream to place it. I'm not familiar with the specifics but it looks like [historically](https://github.com/11ty/eleventy/commit/7e477f27b833da49ed37ec05733be457ac05c595#diff-8b8317c75f11cacab005f253a162744e6cf3530292234efec197702d27540680L204) there was transformation between `templateGlobs` and `normalizedTemplateGlobs` which may be related?

It's also possible this is a bug in `fast-glob`, which appears to be responsible for performing the actual search, but as this causes issues with the 11ty dev server I figured it'd be worth raising a PR where there's a known user-facing issue/possible fix and let the maintainers make that call.