### PR TITLE
Check `Error.cause` for `TemplateContentPrematureUseError` when rendering

### DIFF
--- a/src/Errors/EleventyErrorUtil.js
+++ b/src/Errors/EleventyErrorUtil.js
@@ -60,12 +60,11 @@ class EleventyErrorUtil {
 		// TODO the rest of the template engines
 		return (
 			e instanceof TemplateContentPrematureUseError ||
-			(e.originalError &&
-				(e.originalError.name === "RenderError" ||
-					e.originalError.name === "UndefinedVariableError") &&
-				e.originalError.originalError instanceof TemplateContentPrematureUseError) || // Liquid
-			(e.message || "").indexOf("TemplateContentPrematureUseError") > -1
-		); // Nunjucks
+			((e?.originalError?.name === "RenderError" ||
+				e?.originalError?.name === "UndefinedVariableError") &&
+				e?.originalError?.originalError instanceof TemplateContentPrematureUseError) || // Liquid
+			e?.message?.includes("TemplateContentPrematureUseError") // Nunjucks
+		);
 	}
 }
 

--- a/src/Errors/EleventyErrorUtil.js
+++ b/src/Errors/EleventyErrorUtil.js
@@ -60,9 +60,7 @@ class EleventyErrorUtil {
 		// TODO the rest of the template engines
 		return (
 			e instanceof TemplateContentPrematureUseError ||
-			((e?.originalError?.name === "RenderError" ||
-				e?.originalError?.name === "UndefinedVariableError") &&
-				e?.originalError?.originalError instanceof TemplateContentPrematureUseError) || // Liquid
+			e?.originalError?.originalError instanceof TemplateContentPrematureUseError || // Liquid
 			e?.message?.includes("TemplateContentPrematureUseError") // Nunjucks
 		);
 	}

--- a/src/Errors/EleventyErrorUtil.js
+++ b/src/Errors/EleventyErrorUtil.js
@@ -60,6 +60,7 @@ class EleventyErrorUtil {
 		// TODO the rest of the template engines
 		return (
 			e instanceof TemplateContentPrematureUseError ||
+			e?.cause instanceof TemplateContentPrematureUseError || // Custom (per Node-convention)
 			e?.originalError?.originalError instanceof TemplateContentPrematureUseError || // Liquid
 			e?.message?.includes("TemplateContentPrematureUseError") // Nunjucks
 		);

--- a/src/Errors/EleventyErrorUtil.js
+++ b/src/Errors/EleventyErrorUtil.js
@@ -61,7 +61,7 @@ class EleventyErrorUtil {
 		return (
 			e instanceof TemplateContentPrematureUseError ||
 			e?.cause instanceof TemplateContentPrematureUseError || // Custom (per Node-convention)
-			e?.originalError?.originalError instanceof TemplateContentPrematureUseError || // Liquid
+			["RenderError", "UndefinedVariableError"].includes(e?.originalError?.name) && e?.originalError?.originalError instanceof TemplateContentPrematureUseError || // Liquid
 			e?.message?.includes("TemplateContentPrematureUseError") // Nunjucks
 		);
 	}


### PR DESCRIPTION
This PR may address the issue of https://github.com/11ty/eleventy/issues/2328, and resolves a downstream issue in https://github.com/noelforte/eleventy-plugin-vento/issues/120.

I've patched the static method `EleventyErrorUtil.isPrematureTemplateContentError` to search for instances of `TemplateContentPrematureUseError`s within `Error.cause` as well, so rethrown errors (from a Custom Template Language in my case) are properly caught by Eleventy.

As work on https://github.com/11ty/eleventy/issues/3582 continues, the implementation here could probably be cleaned up even more but I figured I'd start with this single patch.

I've also added additional changes in separate commits for the following:

1. Refactored the conditional to leverage optional chaining (`?.`)
2. Removed extra checks on `originalError.name` that didn't seem to have any effect since `originalError.originalError` is what we're actually looking to identify. Unless of course `TemplateContentPrematureUseError`s can be thrown in cases that are not `RenderError`s or `UndefinedVariableError`s, in which case you can drop that commit.

Let me know if there's any changes!