### PR TITLE
Add warning for missing default Eleventy config

### DIFF
--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -365,6 +365,8 @@ class TemplateConfig {
 			throw new EleventyConfigError(
 				"A configuration file was specified but not found: " + this.projectConfigPaths.join(", "),
 			);
+		} else if (!this.#configManuallyDefined && !path) {
+			this.logger?.warn("No Eleventy configuration file found. Using the default configuration.");
 		}
 
 		debug(`Merging default config with ${path}`);


### PR DESCRIPTION
Creates a warning for when a default config file (e.g. `.eleventy.js` or `eleventy.config.js`) was not found and none was explicitly specified using the `--config` option.

Fixes https://github.com/11ty/eleventy/issues/3654.

For the wording of this error, I avoided saying "No default config file found" since following that up with "using the default configuration" would be confusing. It also doesn't seem necessary to say "default config file" anyway, since this warning cannot appear when a config file was manually specified, so there is no ambiguity.