### PR TITLE
perf: dynamic import dev server

### DIFF
--- a/src/EleventyServe.js
+++ b/src/EleventyServe.js
@@ -2,7 +2,6 @@ import assert from "node:assert";
 
 import debugUtil from "debug";
 import { Merge, DeepCopy, TemplatePath } from "@11ty/eleventy-utils";
-import EleventyDevServer from "@11ty/eleventy-dev-server";
 
 import EleventyBaseError from "./Errors/EleventyBaseError.js";
 import ConsoleLogger from "./Util/ConsoleLogger.js";
@@ -84,7 +83,7 @@ class EleventyServe {
 	async getServerModule(name) {
 		try {
 			if (!name || name === DEFAULT_SERVER_OPTIONS.module) {
-				return EleventyDevServer;
+				return import("@11ty/eleventy-dev-server").then(i=>i.default)
 			}
 
 			// Look for peer dep in local project
@@ -134,7 +133,7 @@ class EleventyServe {
 					e.message,
 			);
 			debug("Eleventy server error %o", e);
-			return EleventyDevServer;
+			return import("@11ty/eleventy-dev-server").then(i=>i.default)
 		}
 	}
 


### PR DESCRIPTION
closes #3621 

cpuprof showed significant time spent loading libraries for the dev server. This ensures it is only imported when needed

```
~/Code/small/eleventyb: hyperfine "pnpm build" --warmup 1
Benchmark 1: pnpm build
  Time (mean ± σ):     636.3 ms ±  88.6 ms    [User: 572.3 ms, System: 92.2 ms]
  Range (min … max):   582.1 ms … 878.8 ms    10 runs
// after change
~/Code/small/eleventyb: hyperfine "pnpm build" --warmup 1
Benchmark 1: pnpm build
  Time (mean ± σ):     593.4 ms ±  49.5 ms    [User: 551.8 ms, System: 88.3 ms]
  Range (min … max):   533.4 ms … 701.4 ms    10 runs
```

![image](https://github.com/user-attachments/assets/7affc1c1-5958-4392-8e79-5f954caaddc6)

tested by verifying `eleventy --serve` still works

assuming 50ms of savings, with 60k downloads per week, eleventy is likely called 100k times per week, or `5200000` times per year. This means this change will save 72 hours of compute per year! buying puts on AMD!!!!!