### PR TITLE
Prevent rawInput circular structure

### DIFF
--- a/src/Template.js
+++ b/src/Template.js
@@ -733,7 +733,9 @@ class Template extends TemplateContent {
 		}
 
 		// https://github.com/11ty/eleventy/issues/1206
-		data.page.rawInput = rawInput;
+		data.page.rawInput = JSON.parse(
+			JSON.stringify(rawInput, (_, v) => (typeof v === "function" ? v.toString() : v)),
+		);
 
 		if (!Pagination.hasPagination(data)) {
 			await this.addComputedData(data);


### PR DESCRIPTION
JavaScript._getInstance(mod) sometime takes data object, will be circular. This change prevents passing circular object to dev server.

Probably related to https://github.com/11ty/eleventy/issues/3481 https://github.com/11ty/eleventy/issues/1206 https://github.com/11ty/eleventy/issues/3348

---

My code reading notes (Sorry if I misunderstood about implementation. I have no confidence.)

> JavaScript._getInstance(mod) sometime takes data object

https://github.com/11ty/eleventy/blob/2f559c7bd4b722b6927e31f96baad50e73ab90a9/src/Engines/JavaScript.js#L76-L84

> passing circular object to dev server

https://github.com/11ty/eleventy/blob/2f559c7bd4b722b6927e31f96baad50e73ab90a9/src/Eleventy.js#L984-L996