### PR TITLE
HtmlBasePlugin: Fix confusing error message

### DIFF
--- a/src/Plugins/HtmlBasePlugin.js
+++ b/src/Plugins/HtmlBasePlugin.js
@@ -73,7 +73,7 @@ function eleventyHtmlBasePlugin(eleventyConfig, defaultOptions = {}) {
 	}
 
 	if (opts.baseHref === undefined) {
-		throw new Error("The `base` option is required in the HTML Base plugin.");
+		throw new Error("The `baseHref` option is required in the HTML Base plugin.");
 	}
 
 	eleventyConfig.addFilter("addPathPrefixToFullUrl", function (url) {


### PR DESCRIPTION
Fixed issue where an error message referred to the wrong option name (`base` vs. `baseHref`), leading to confusion.