### PR TITLE
Begin process of decoupling all templating languages

### DIFF
--- a/src/Benchmark/BenchmarkGroup.js
+++ b/src/Benchmark/BenchmarkGroup.js
@@ -28,7 +28,7 @@ class BenchmarkGroup {
 	}
 
 	// TODO use addAsync everywhere instead
-	add(type, callback) {
+	add(type, callback, misc = {}) {
 		let benchmark = (this.benchmarks[type] = new Benchmark());
 
 		/** @this {any} */
@@ -43,6 +43,7 @@ class BenchmarkGroup {
 			value: {
 				type: isAsyncFunction(callback) ? "async" : "sync",
 				callback,
+				...misc,
 			},
 		});
 
@@ -73,7 +74,9 @@ class BenchmarkGroup {
 	setMinimumThresholdPercent(minimumThresholdPercent) {
 		let val = parseInt(minimumThresholdPercent, 10);
 		if (isNaN(val)) {
-			throw new Error("`setMinimumThresholdPercent` expects a number argument.");
+			throw new Error(
+				"`setMinimumThresholdPercent` expects a number argument.",
+			);
 		}
 		this.minimumThresholdPercent = val;
 	}

--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -26,6 +26,11 @@ export default class Liquid extends TemplateEngine {
 
 		this.argLexer = moo.compile(Liquid.argumentLexerOptions);
 		this.cacheable = true;
+
+		this.filters = eleventyConfig.getFilters({
+			lang: "liquid",
+			async: false,
+		});
 	}
 
 	setLibrary(override) {
@@ -33,7 +38,7 @@ export default class Liquid extends TemplateEngine {
 		this.liquidLib = override || new LiquidJs(this.getLiquidOptions());
 		this.setEngineLib(this.liquidLib);
 
-		this.addFilters(this.config.liquidFilters);
+		this.addFilters(this.filters);
 
 		// TODO these all go to the same place (addTag), add warnings for overwrites
 		this.addCustomTags(this.config.liquidTags);

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -384,11 +384,21 @@ class UserConfig {
 	 * Filters
 	 */
 
+	/**
+	 * @deprecated Use {@link addFilter} instead, with options.langs set to ["liquid"] if you wish it to be scoped.
+	 */
 	addLiquidFilter(name, callback) {
-		this.#add(this.liquid.filters, name, callback, {
-			description: "Liquid Filter",
-			functionName: "addLiquidFilter",
-		});
+		this.logger.warn(
+			'`addLiquidFilter` is deprecated and will be removed in a future release.\
+			 Use `addFilter` instead, with options.lang set to ["liquid"] if you wish it to be scoped.',
+		);
+		this.addFilter(
+			name,
+			callback,
+			{
+				langs: ["liquid"],
+			},
+		);
 	}
 
 	/**
@@ -459,16 +469,19 @@ class UserConfig {
 			async,
 		});
 
-		this.addLiquidFilter(name, callback);
 		this.addJavaScriptFilter(name, callback);
 	}
 
-	// Liquid, Nunjucks, and JS only
 	/**
-	 * @deprecated Pass an async function to `addFilter` instead.
+	 * Perhaps this should be deprecated.
+	 * addAsyncFilter("...", function() {return Promise}) and
+	 * addFilter("...", function() {return Promise}, {async: true})
+	 * are the same.
 	 */
 	addAsyncFilter(name, callback) {
-		this.addFilter(name, callback);
+		this.addFilter(name, callback, {
+			async: true,
+		});
 	}
 
 	/*
@@ -1267,7 +1280,6 @@ class UserConfig {
 			// Liquid
 			liquidOptions: this.liquid.options,
 			liquidTags: this.liquid.tags,
-			liquidFilters: this.liquid.filters,
 			liquidShortcodes: this.liquid.shortcodes,
 			liquidPairedShortcodes: this.liquid.pairedShortcodes,
 			liquidParameterParsing: this.liquid.parameterParsing,

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -437,16 +437,6 @@ class UserConfig {
 		);
 	}
 
-	addJavaScriptFilter(name, callback) {
-		this.#add(this.javascript.filters, name, callback, {
-			description: "JavaScript Filter",
-			functionName: "addJavaScriptFilter",
-		});
-
-		// Backwards compat for a time before `addJavaScriptFilter` existed.
-		this.addJavaScriptFunction(name, callback);
-	}
-
 	/**
 	 *
 	 * @param {*} name - The name of the filter
@@ -468,8 +458,6 @@ class UserConfig {
 			langs: options?.langs,
 			async,
 		});
-
-		this.addJavaScriptFilter(name, callback);
 	}
 
 	/**
@@ -501,7 +489,6 @@ class UserConfig {
 		});
 
 		this.addLiquidShortcode(name, callback);
-		this.addJavaScriptShortcode(name, callback);
 		this.addNunjucksShortcode(name, callback);
 	}
 
@@ -514,7 +501,6 @@ class UserConfig {
 		// Related: #498
 		this.addNunjucksAsyncShortcode(name, callback);
 		this.addLiquidShortcode(name, callback);
-		this.addJavaScriptShortcode(name, callback);
 	}
 
 	addNunjucksAsyncShortcode(name, callback) {
@@ -556,7 +542,6 @@ class UserConfig {
 
 		this.addPairedNunjucksShortcode(name, callback);
 		this.addPairedLiquidShortcode(name, callback);
-		this.addPairedJavaScriptShortcode(name, callback);
 	}
 
 	// Related: #498
@@ -568,7 +553,6 @@ class UserConfig {
 
 		this.addPairedNunjucksAsyncShortcode(name, callback);
 		this.addPairedLiquidShortcode(name, callback);
-		this.addPairedJavaScriptShortcode(name, callback);
 	}
 
 	addPairedNunjucksAsyncShortcode(name, callback) {
@@ -594,26 +578,6 @@ class UserConfig {
 			description: "Liquid Paired Shortcode",
 			functionName: "addPairedLiquidShortcode",
 		});
-	}
-
-	addJavaScriptShortcode(name, callback) {
-		this.#add(this.javascript.shortcodes, name, callback, {
-			description: "JavaScript Shortcode",
-			functionName: "addJavaScriptShortcode",
-		});
-
-		// Backwards compat for a time before `addJavaScriptShortcode` existed.
-		this.addJavaScriptFunction(name, callback);
-	}
-
-	addPairedJavaScriptShortcode(name, callback) {
-		this.#add(this.javascript.pairedShortcodes, name, callback, {
-			description: "JavaScript Paired Shortcode",
-			functionName: "addPairedJavaScriptShortcode",
-		});
-
-		// Backwards compat for a time before `addJavaScriptShortcode` existed.
-		this.addJavaScriptFunction(name, callback);
 	}
 
 	// Both Filters and shortcodes feed into this
@@ -1296,9 +1260,6 @@ class UserConfig {
 
 			// 11ty.js
 			javascriptFunctions: this.javascript.functions, // filters and shortcodes, combined
-			javascriptShortcodes: this.javascript.shortcodes,
-			javascriptPairedShortcodes: this.javascript.pairedShortcodes,
-			javascriptFilters: this.javascript.filters,
 
 			// Markdown
 			markdownHighlighter: this.markdownHighlighter,

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -46,8 +46,6 @@ import { HtmlRelativeCopyPlugin } from "./Plugins/HtmlRelativeCopyPlugin.js";
  * @property {string} [dir.includes='_includes']
  * @property {string} [dir.data='_data']
  * @property {string} [dir.output='_site']
- * @deprecated handlebarsHelpers
- * @deprecated nunjucksFilters
  */
 
 /**
@@ -171,8 +169,5 @@ export default function (config) {
 			data: "_data",
 			output: "_site",
 		},
-
-		// deprecated, use config.addNunjucksFilter
-		nunjucksFilters: {},
 	};
 }


### PR DESCRIPTION
This pull request, codeveloped with @uncenter, dramatically simplifies the API surface of eleventy by deprecating dozens of language specific functions. The full scope is unknown, over time this body will be amended.

The guiding vision of this pull request is to move towards a future where eleventy core does not make assumptions about templating languages, however the default experience is still just as powerful (so users opt out of additional features, not in). Why somebody might wish to do this:

1. Free themselves from magic defaults
2. Improve build times

The first step, which is this pull request, is to get eleventy to a place where nunjucks and other templating languages could conceivably be implemented as a plugin. Even if the broader goal is not achieved, this pull request stands great on its own by enhancing modularity and extendability.

## The PR

In cases where required, the functionality of generic APIs has been extended in backwards compatible manners, and internally, all deprecated functions have been refactored to use generic & public counterparts.

We’ve attempted to ensure that as part of the refactor of deprecated functions, the documented functionality remains the same. We expect that unholy code relying on undocumented features may break.

## Filters

Bad code on top of Nunjuck’s bad async code may break in different and unpredictable ways.

- [x] Deprecates `addNunjucksFilter` in favour of `addFilter(..,..,{langs: ["njk"]})`
- [x] Deprecates `addAsyncNunjucksFilter` in favour of `addFilter(..,..,{langs: ["njk"]})`
- [x] Deprecates `addLiquidFilter` in favour of `addFilter(..,..,{langs: ["liquid"]})`
- [x] Adds a `langs` attribute to `addFilter` so that languages can filter by lang in `getFilters`

Note that one limitation is that you can’t have two different implementation of filters with the same name targeting different languages. The same holds true for shortcodes. I can think of some crafty workarounds but I struggle to think of cases where this would be desired. 

## Shortcodes

- [ ] Deprecates `addNunjucksShortcode`
- [ ] Deprecates `addNunjucksAsyncShortcode`
- [ ] Deprecates `addPairedNunjucksAsyncShortcode`
- [ ] Deprecates `addPairedNunjucksShortcode`
- [ ] Deprecates `addLiquidShortcode`

## JavaScript

- [x] Removes `addJavaScriptShortcode`
- [x] Removes `addPairedJavaScriptShortcode`
- [x] Removes `addJavaScriptFilter`
- [ ] Deprecates `addJavaScriptFunction` in favour of `addFilter` (not done yet; tbd)

With JavaScript, we're outright removing a number of functions that do exactly the same thing and aren't publicly documented.

## Misc

- [ ] Deprecates `addLiquidTag` & `addNunjucksTag` (no global varient)
- [ ] Do something about `markdownTemplateEngine`, `addMarkdownHighlighter`
- [ ] A whole bunch of stuff we haven't found yet

Not in this PR: configuration related methods: `setLiquidParameterParsing`, `setLiquidOptions`, `setNunjucksEnvironmentOptions`. We can't do this yet.

## Finishing touches

- [ ] Test code
- [ ] Fix tests

Linked Issues #3652, #3647. I've opened this pull request early in the process to make the intent clear