### PR TITLE
Add indicator for configuration-less runs

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -452,13 +452,17 @@ class Eleventy {
 			`in ${chalk.bold(time.toFixed(2))} ${simplePlural(time.toFixed(2), "second", "seconds")}`,
 		);
 
+		let info = "";
 		// More than 1 second total, show estimate of per-template time
 		if (time >= 1 && writeCount > 1) {
-			ret.push(`(${((time * 1000) / writeCount).toFixed(1)}ms each, v${pkg.version})`);
-		} else {
-			ret.push(`(v${pkg.version})`);
+			info += `${((time * 1000) / writeCount).toFixed(1)}ms each, `;
+		}
+		info += `v${pkg.version}`;
+		if (!this.eleventyConfig.configExists) {
+			info += " - no configuration file";
 		}
 
+		ret.push(`(${info})`);
 		return ret.join(" ");
 	}
 

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -91,6 +91,7 @@ class TemplateConfig {
 
 		this.hasConfigMerged = false;
 		this.isEsm = false;
+		this.configExists = false;
 	}
 
 	get userConfig() {
@@ -150,11 +151,10 @@ class TemplateConfig {
 	 */
 	getLocalProjectConfigFile() {
 		let configFiles = this.getLocalProjectConfigFiles();
+		let configFile = configFiles.find((path) => path && fs.existsSync(path));
+		this.configExists = Boolean(configFile);
 		// Add the configFiles[0] in case of a test, where no file exists on the file system
-		let configFile = configFiles.find((path) => path && fs.existsSync(path)) || configFiles[0];
-		if (configFile) {
-			return configFile;
-		}
+		return configFile || configFiles[0] || undefined;
 	}
 
 	getLocalProjectConfigFiles() {


### PR DESCRIPTION
Adds " - no configuration file" within the final output message to indicate that the run did not use a configuration file. This helps in cases where the user incorrectly thinks their configuration file is automatically picked up by Eleventy (such as e.g. `.eleventy.mjs`).

Fixes https://github.com/11ty/eleventy/issues/3654. For example, the error from a missing layout (as a result of a missing config file) would now be something along the lines of

```
[11ty] Problem writing Eleventy templates:
[11ty] 1. Problem creating an Eleventy Layout for the "…" template file. (via EleventyBaseError)
[11ty] 2. You’re trying to use a layout that does not exist: _includes/… (via `layout: …`)
[11ty] 
[11ty] Original error stack trace: Error: …
[11ty]     at …
[11ty]     at …
[11ty] Wrote 0 files in 0.04 seconds (v3.1.0-beta.1 - no configuration file)
[11ty] Eleventy Fatal Error (CLI):
[11ty] 1. Problem creating an Eleventy Layout for the "…" template file. (via EleventyBaseError)
[11ty] 2. You’re trying to use a layout that does not exist: _includes/… (via `layout: …`)
[11ty] 
[11ty] Original error stack trace: Error: …
[11ty]     at …
[11ty]     at …
```

This is still not _super_ clear given the ` - no configuration` file falls right in the middle of the error message, but that line specifically is highlighted in red which does increase visibility a bit.