### PR TITLE
Fix and test for #3807

### DIFF
--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -1178,7 +1178,15 @@ Arguments:
 		this.watcherBench.reset();
 
 		// We use a string module name and try/catch here to hide this from the zisi and esbuild serverless bundlers
-		let chokidar = await import("chokidar").then((mod) => mod.default);
+		let chokidar;
+		// eslint-disable-next-line no-useless-catch
+		try {
+			let moduleName = "chokidar";
+			let chokidarImport = await import(moduleName);
+			chokidar = chokidarImport.default;
+		} catch (e) {
+			throw e;
+		}
 
 		// Note that watching indirectly depends on this for fetching dependencies from JS files
 		// See: TemplateWriter:pathCache and EleventyWatchTargets

--- a/src/Engines/Html.js
+++ b/src/Engines/Html.js
@@ -6,9 +6,13 @@ export default class Html extends TemplateEngine {
 		this.cacheable = true;
 	}
 
+	async #getPreEngine(preTemplateEngine) {
+		return this.engineManager.getEngine(preTemplateEngine, this.extensionMap);
+	}
+
 	async compile(str, inputPath, preTemplateEngine) {
 		if (preTemplateEngine) {
-			let engine = await this.engineManager.getEngine(preTemplateEngine, this.extensionMap);
+			let engine = await this.#getPreEngine(preTemplateEngine);
 			let fnReady = engine.compile(str, inputPath);
 
 			return async function (data) {
@@ -19,7 +23,7 @@ export default class Html extends TemplateEngine {
 		}
 
 		return function () {
-			// do nothing with data if parseHtmlWith is falsy
+			// do nothing with data if preTemplateEngine is falsy
 			return str;
 		};
 	}

--- a/src/LayoutCache.js
+++ b/src/LayoutCache.js
@@ -5,7 +5,7 @@ import eventBus from "./EventBus.js";
 // Note: this is only used for TemplateLayout right now but could be used for more
 // Just be careful because right now the TemplateLayout cache keys are not directly mapped to paths
 // So you may get collisions if you use this for other things.
-class TemplateCache {
+class LayoutCache {
 	constructor() {
 		this.cache = {};
 		this.cacheByInputPath = {};
@@ -33,7 +33,7 @@ class TemplateCache {
 
 		if (typeof layoutTemplate === "string") {
 			throw new Error(
-				"Invalid argument type passed to TemplateCache->add(). Should be a TemplateLayout.",
+				"Invalid argument type passed to LayoutCache->add(). Should be a TemplateLayout.",
 			);
 		}
 
@@ -62,7 +62,7 @@ class TemplateCache {
 
 	get(key) {
 		if (!this.has(key)) {
-			throw new Error(`Could not find ${key} in TemplateCache.`);
+			throw new Error(`Could not find ${key} in LayoutCache.`);
 		}
 
 		return this.cache[key];
@@ -87,7 +87,7 @@ class TemplateCache {
 	}
 }
 
-let layoutCache = new TemplateCache();
+let layoutCache = new LayoutCache();
 
 eventBus.on("eleventy.resourceModified", () => {
 	// https://github.com/11ty/eleventy-plugin-bundle/issues/10

--- a/src/TemplateLayout.js
+++ b/src/TemplateLayout.js
@@ -4,7 +4,7 @@ import debugUtil from "debug";
 import TemplateLayoutPathResolver from "./TemplateLayoutPathResolver.js";
 import TemplateContent from "./TemplateContent.js";
 import TemplateData from "./Data/TemplateData.js";
-import templateCache from "./TemplateCache.js";
+import layoutCache from "./LayoutCache.js";
 
 // const debug = debugUtil("Eleventy:TemplateLayout");
 const debugDev = debugUtil("Dev:Eleventy:TemplateLayout");
@@ -54,16 +54,16 @@ class TemplateLayout extends TemplateContent {
 
 		let inputDir = eleventyConfig.directories.input;
 		let fullKey = TemplateLayout.resolveFullKey(key, inputDir);
-		if (!templateCache.has(fullKey)) {
+		if (!layoutCache.has(fullKey)) {
 			let layout = new TemplateLayout(key, extensionMap, eleventyConfig);
 
-			templateCache.add(layout);
-			debugDev("Added %o to TemplateCache", key);
+			layoutCache.add(layout);
+			debugDev("Added %o to LayoutCache", key);
 
 			return layout;
 		}
 
-		return templateCache.get(fullKey);
+		return layoutCache.get(fullKey);
 	}
 
 	async getTemplateLayoutMapEntry() {
@@ -199,8 +199,8 @@ class TemplateLayout extends TemplateContent {
 
 			return fns;
 		} catch (e) {
-			debugDev("Clearing TemplateCache after error.");
-			templateCache.clear();
+			debugDev("Clearing LayoutCache after error.");
+			layoutCache.clear();
 			throw e;
 		}
 	}
@@ -230,7 +230,6 @@ class TemplateLayout extends TemplateContent {
 
 	resetCaches(types) {
 		super.resetCaches(types);
-
 		delete this.dataCache;
 		delete this.layoutChain;
 		delete this.cachedLayoutMap;

--- a/src/TemplateMap.js
+++ b/src/TemplateMap.js
@@ -160,6 +160,7 @@ class TemplateMap {
 					return inputPathSet.has(inputPath);
 				})
 				.map(({ template }) => {
+					// This also happens for layouts in TemplateContent->compile
 					return template.asyncTemplateInitialization();
 				}),
 		);

--- a/src/TemplateRender.js
+++ b/src/TemplateRender.js
@@ -194,13 +194,14 @@ class TemplateRender {
 	}
 
 	// TODO templateEngineOverride
-	getPreprocessorEngine() {
+	getPreprocessorEngineName() {
 		if (this.engineName === "md" && this.parseMarkdownWith) {
 			return this.parseMarkdownWith;
 		}
 		if (this.engineName === "html" && this.parseHtmlWith) {
 			return this.parseHtmlWith;
 		}
+		// TODO do we need this?
 		return this.extensionMap.getKey(this.engineNameOrPath);
 	}
 

--- a/test/LayoutCacheTest.js
+++ b/test/LayoutCacheTest.js
@@ -1,6 +1,6 @@
 import test from "ava";
 
-import templateCache from "../src/TemplateCache.js";
+import templateCache from "../src/LayoutCache.js";
 import getNewTemplate from "./_getNewTemplateForTests.js";
 
 test("Cache can save templates", async (t) => {

--- a/test/stubs-3807/Issue3807test.js
+++ b/test/stubs-3807/Issue3807test.js
@@ -1,0 +1,67 @@
+import test from "ava";
+import fs from "node:fs";
+import Eleventy from "../../src/Eleventy.js";
+import { withResolvers } from "../../src/Util/PromiseUtil.js";
+
+// This tests Eleventy Watch and the file system!
+
+test("#3807 Nunjucks cacheable should be reused when Nunjucks is the preprocessor language", async (t) => {
+  let runs = [
+    {
+      ...withResolvers(),
+      input: `<html>first{% block main %}{{ content | safe }}{% endblock %}</html>`,
+      expected: `<html>firstHome<p>Index</p></html>`,
+    },
+    {
+      ...withResolvers(),
+      input: `<html>second{% block main %}{{ content | safe }}{% endblock %}</html>`,
+      expected: `<html>secondHome<p>Index</p></html>`,
+    },
+    {
+      ...withResolvers(),
+      input: `<html>third{% block main %}{{ content | safe }}{% endblock %}</html>`,
+      expected: `<html>thirdHome<p>Index</p></html>`,
+    }
+  ];
+
+  t.plan(runs.length + 1);
+
+  // Restore original content
+  const ORIGINAL_CONTENT = `<html>{% block main %}{{ content | safe }}{% endblock %}</html>`;
+  fs.writeFileSync("test/stubs-3807/_layouts/base.html", ORIGINAL_CONTENT, "utf8");
+
+  let index = 0;
+  let elev = new Eleventy("test/stubs-3807/", "test/stubs-3807/_site", {
+    configPath: "test/stubs-3807/eleventy.config.js",
+    config(eleventyConfig) {
+      eleventyConfig.on("eleventy.afterwatch", () => {
+        let {resolve} = runs[index];
+        index++;
+        resolve();
+      });
+    }
+  });
+
+  elev.disableLogger();
+  await elev.init();
+  await elev.watch();
+
+  // Control
+  let content = fs.readFileSync("test/stubs-3807/_site/index.html", "utf8");
+  t.is(content, `<html>Home<p>Index</p></html>`);
+
+  // Stop after all runs are complete
+  Promise.all(runs.map(entry => entry.promise)).then(async () => {
+    await elev.stopWatch();
+  });
+
+  for(let run of runs) {
+    fs.writeFileSync("test/stubs-3807/_layouts/base.html", run.input, "utf8");
+    await run.promise;
+
+    let content = fs.readFileSync("test/stubs-3807/_site/index.html", "utf8");
+    t.is(content, run.expected);
+  }
+
+  fs.writeFileSync("test/stubs-3807/_layouts/base.html", ORIGINAL_CONTENT, "utf8");
+});

--- a/test/stubs-3807/_layouts/base.html
+++ b/test/stubs-3807/_layouts/base.html
@@ -1,0 +1,1 @@
+<html>{% block main %}{{ content | safe }}{% endblock %}</html>

--- a/test/stubs-3807/_layouts/home.html
+++ b/test/stubs-3807/_layouts/home.html
@@ -1,0 +1,1 @@
+{% extends "test/stubs-3807/_layouts/base.html" %}{% block main %}Home{{ content | trim | safe }}{% endblock %}

--- a/test/stubs-3807/eleventy.config.js
+++ b/test/stubs-3807/eleventy.config.js
@@ -1,0 +1,7 @@
+export default function(eleventyConfig) {
+	eleventyConfig.setLayoutsDirectory("_layouts");
+}
+export const config = {
+	markdownTemplateEngine: "njk",
+	htmlTemplateEngine: "njk",
+}

--- a/test/stubs-3807/index.md
+++ b/test/stubs-3807/index.md
@@ -1,0 +1,4 @@
+---
+layout: home.html
+---
+Index


### PR DESCRIPTION
#3807 was caused by the HTML and Markdown engines are cacheable but Nunjucks is not, but did not use Nunjucks cacheable value when Nunjucks was the preprocessing engine.

This PR also includes some improves to make `Eleventy#watch()` more testable and renames the `TemplateCache` class to `LayoutCache` for more clarity on use.