### PR TITLE
refactor: rename addMarkdownHighlighter to setMarkdownHighlighter

### DIFF
--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -70,6 +70,20 @@ class UserConfig {
 		this.#uniqueId = Math.random();
 	}
 
+	setMarkdownHighlighter(fn) {
+		this.markdownHighlighter = fn;
+	}
+
+	/**
+	 * @deprecated Use setMarkdownHighlighter instead.
+	 */
+	aaddMarkdownHighlighter(fn) {
+		console.warn(
+			"Warning: addMarkdownHighlighter is deprecated. Use setMarkdownHighlighter instead.",
+		);
+		this.setMarkdownHighlighter(fn);
+	}
+
 	// Internally used in TemplateContent for cache keys
 	_getUniqueId() {
 		return this.#uniqueId;


### PR DESCRIPTION
## What’s changed?
- Replaced `addMarkdownHighlighter()` with `setMarkdownHighlighter()` for clarity and alignment with API behavior.
- Added deprecation warning for backward compatibility.
- Follows naming conventions consistent with non-destructive vs. destructive config APIs.

Fixes #3105
