### PR TITLE
Allow `setLiquidOptions` to add global data

### DIFF
--- a/src/Engines/Liquid.js
+++ b/src/Engines/Liquid.js
@@ -312,6 +312,7 @@ export default class Liquid extends TemplateEngine {
 
 	async compile(str, inputPath) {
 		let engine = this.liquidLib;
+		let liquidOptions = this.liquidOptions;
 		let tmplReady = engine.parse(str, inputPath);
 
 		// Required for relative includes
@@ -325,11 +326,14 @@ export default class Liquid extends TemplateEngine {
 		return async function (data) {
 			let tmpl = await tmplReady;
 
-			options.globals = {
-				page: data?.page,
-				eleventy: data?.eleventy,
-				collections: data?.collections,
-			};
+			options.globals = Object.assign(
+				{
+					page: data?.page,
+					eleventy: data?.eleventy,
+					collections: data?.collections,
+				},
+				liquidOptions?.globals,
+			);
 
 			return engine.render(tmpl, data, options);
 		};


### PR DESCRIPTION
Fixes #4188 (with thanks to @jgarber623 for the helpful `this` pointer).

As mentioned in that issue, unsure whether a user’s configuration should be able to override `page`, `eleventy` and `collections` data, or if those should always win out.

Happy to add tests for this PR if someone can point me to an existing test I can copy and adapt to support this use case.