### PR TITLE
Batched Incremental: Fixes #4274 Adds support for multiple eligible incremental files in a single build

### DIFF
--- a/cmd.cjs
+++ b/cmd.cjs
@@ -114,8 +114,11 @@ async function exec() {
 		// Only relevant for watch/serve
 		elev.setIgnoreInitial(argv["ignore-initial"]);
 
+		// v4.0.0-alpha.8 multiple now supported via:
+		// --incremental=one.md --incremental=two.md => ["one.md", "two.md"]
+		// --incremental="one.md,two.md"
 		if(argv.incremental) {
-			elev.setIncrementalFile(argv.incremental);
+			elev.setIncrementalFiles(argv.incremental);
 		} else if(argv.incremental !== undefined) {
 			elev.setIncrementalBuild(argv.incremental === "" || argv.incremental);
 		}

--- a/cmd.cjs
+++ b/cmd.cjs
@@ -116,7 +116,7 @@ async function exec() {
 
 		// v4.0.0-alpha.8 multiple now supported via:
 		// --incremental=one.md --incremental=two.md => ["one.md", "two.md"]
-		// --incremental="one.md,two.md"
+		// --incremental=one.md,two.md => ["one.md", "two.md"]
 		if(argv.incremental) {
 			elev.setIncrementalFiles(argv.incremental);
 		} else if(argv.incremental !== undefined) {

--- a/src/CoreMinimal.js
+++ b/src/CoreMinimal.js
@@ -377,11 +377,7 @@ export class MinimalCore {
 	 * @param {boolean} isIncremental - Shall Eleventy run in incremental build mode and only write the files that trigger watch updates
 	 */
 	setIncrementalBuild(isIncremental) {
-		this.isIncremental = !!isIncremental;
-
-		if (this.writer) {
-			this.writer.setIncrementalBuild(this.isIncremental);
-		}
+		this.isIncremental = Boolean(isIncremental);
 	}
 
 	/**
@@ -488,7 +484,6 @@ export class MinimalCore {
 		this.writer.logger = this.logger;
 		this.writer.extensionMap = this.extensionMap;
 		this.writer.setRunInitialBuild(this.isRunInitialBuild);
-		this.writer.setIncrementalBuild(this.isIncremental);
 
 		let debugStr = `Directories:
   Input:
@@ -662,29 +657,37 @@ Verbose Output: ${this.verboseMode}`;
 	 * This method is also wired up to the CLI --incremental=incrementalFile
 	 *
 	 * @method
-	 * @param {string} incrementalFile - File path (added or modified in a project)
+	 * @param {Array|string} incrementalFiles - File path (added or modified in a project)
 	 */
-	setIncrementalFile(incrementalFile) {
-		if (incrementalFile) {
-			// This used to also setIgnoreInitial(true) but was changed in 3.0.0-alpha.14
-			this.setIncrementalBuild(true);
-
-			this.programmaticApiIncrementalFile = TemplatePath.addLeadingDotSlash(incrementalFile);
-
-			// Used to determind template relevance for compile cache keys
-			this.eleventyConfig.setPreviousBuildModifiedFile(incrementalFile);
+	setIncrementalFiles(incrementalFiles) {
+		if (!incrementalFiles) {
+			return;
 		}
+
+		// This used to also setIgnoreInitial(true) but was changed in 3.0.0-alpha.14
+		this.setIncrementalBuild(true);
+
+		let files;
+		if (typeof incrementalFiles === "string") {
+			files = incrementalFiles.split(",");
+		} else if (Array.isArray(incrementalFiles)) {
+			files = incrementalFiles;
+		} else {
+			throw new Error("Invalid argument for setIncrementalFiles, needs string or Array");
+		}
+
+		let normalized = files.map((p) => TemplatePath.addLeadingDotSlash(p));
+
+		// Saved from --incremental
+		this.programmaticApiIncrementalFile = normalized;
+
+		// Also used to determind template relevance for compile cache keys
+		this.watchQueue?.setActiveQueue(normalized);
 	}
 
-	unsetIncrementalFile() {
-		// only applies to initial build, no re-runs (--watch/--serve)
-		if (this.programmaticApiIncrementalFile) {
-			// this.setIgnoreInitial(false);
-			this.programmaticApiIncrementalFile = undefined;
-		}
-
-		// reset back to false
-		this.setIgnoreInitial(false);
+	// Backwards compatibility (rename in v4.0.0-alpha.8)
+	setIncrementalFile(incrementalFile) {
+		this.setIncrementalFiles(incrementalFile);
 	}
 
 	/**
@@ -772,6 +775,20 @@ Verbose Output: ${this.verboseMode}`;
 		throw new Error("Feature removed in Eleventy v4: https://github.com/11ty/eleventy/issues/3382");
 	}
 
+	/*
+	 * If the active queue has a mix of template/non-template files (includes, etc), swap to run a full build
+	 */
+	isIncrementalBuildPossible(queuedFiles = []) {
+		let hasNonTemplateFiles = Boolean(
+			queuedFiles.find((path) => !this.directories.isTemplateFile(path)),
+		);
+		if (hasNonTemplateFiles) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * tbd.
 	 *
@@ -797,10 +814,10 @@ Verbose Output: ${this.verboseMode}`;
 			);
 		}
 
-		let incrementalFile =
-			this.programmaticApiIncrementalFile || this.watchQueue?.getIncrementalFile();
-		if (incrementalFile) {
-			this.writer.setIncrementalFile(incrementalFile);
+		let incrementalFiles = this.watchQueue?.getActiveQueue() || [];
+		if (this.isIncremental && this.isIncrementalBuildPossible(incrementalFiles)) {
+			// This really controls whether a build is incremental or not (internally)
+			this.writer.setIncrementalFiles(incrementalFiles);
 		}
 
 		let returnObj;
@@ -856,8 +873,10 @@ Verbose Output: ${this.verboseMode}`;
 				returnObj = [resolved.passthroughCopy, resolved.templates];
 			}
 
-			this.unsetIncrementalFile();
-			this.writer.resetIncrementalFile();
+			// always reset after first build
+			this.setIgnoreInitial(false);
+			this.writer.resetIncremental();
+			this.config.events.emit("eleventy#previousqueue", incrementalFiles);
 
 			eventsArg.uses = this.eleventyConfig.usesGraph.map;
 			await this.config.events.emit("afterBuild", eventsArg);

--- a/src/Eleventy.js
+++ b/src/Eleventy.js
@@ -34,23 +34,9 @@ export default class Eleventy extends Core {
 	// 	super(input, output, options, eleventyConfig);
 	// }
 
-	/**
-	 * Sets the incremental build mode.
-	 *
-	 * @param {boolean} isIncremental - Shall Eleventy run in incremental build mode and only write the files that trigger watch updates
-	 */
-	setIncrementalBuild(isIncremental) {
-		super.setIncrementalBuild(isIncremental);
-
-		if (this.#watchQueue) {
-			this.watchQueue.incremental = !!isIncremental;
-		}
-	}
-
 	get watchQueue() {
 		if (!this.#watchQueue) {
 			this.#watchQueue = new WatchQueue();
-			this.#watchQueue.incremental = this.isIncremental;
 		}
 		return this.#watchQueue;
 	}
@@ -100,33 +86,12 @@ export default class Eleventy extends Core {
 	 * @param {string} changedFilePath - File that triggered a re-run (added or modified)
 	 * @param {boolean} [isResetConfig] - are we doing a config reset
 	 */
-	async #addFileToWatchQueue(changedFilePath, isResetConfig) {
-		let isAdded = this.watchQueue.addToPendingQueue(changedFilePath);
-		if (!isAdded) {
-			return;
-		}
+	#resetFileInWatchQueue(changedFilePath, isResetConfig) {
+		// v3.1.0: `eleventy.templateModified` is no longer used internally
+		// v4.0.0-alpha.8 `eleventy.templateModified` event removed
 
-		// Currently this is only for 11ty.js deps but should be extended with usesGraph
-		let usedByDependants = [];
-		if (this.watchTargets) {
-			usedByDependants = this.watchTargets.getDependantsOf(
-				TemplatePath.addLeadingDotSlash(changedFilePath),
-			);
-		}
-
-		let relevantLayouts = this.eleventyConfig.usesGraph.getLayoutsUsedBy(changedFilePath);
-
-		// `eleventy.templateModified` is no longer used internally, remove in a future major version.
-		eventBus.emit("eleventy.templateModified", changedFilePath, {
-			usedByDependants,
-			relevantLayouts,
-		});
-
-		// These listeners are *global*, not cleared even on config reset
-		eventBus.emit("eleventy.resourceModified", changedFilePath, usedByDependants, {
-			viaConfigReset: isResetConfig,
-			relevantLayouts,
-		});
+		// These listeners are *global*, not cleared even on config reset (v4.0.0-alpha.8 removed some arguments here)
+		eventBus.emit("eleventy.resourceModified", changedFilePath);
 
 		this.config.events.emit("eleventy#templateModified", changedFilePath);
 	}
@@ -176,27 +141,25 @@ export default class Eleventy extends Core {
 		);
 	}
 
-	async #rewatch(opts = {}) {
-		let { skipIncremental } = opts;
-
+	async #rewatch() {
 		if (this.watchQueue.isBuildRunning()) {
 			// this.logger.forceLog("Waiting for previous build to finish…");
 			return;
-		}
-
-		if (skipIncremental) {
-			// skip incremental when pending queue size > 2 and has non-template files
-			this.unsetIncrementalFile();
-			this.writer?.resetIncrementalFile();
-			this.watchQueue.setIncrementalOverride(true);
-			this.watchQueue.clearPendingQueue();
 		}
 
 		this.watchQueue.startBuild();
 
 		let queue = this.watchQueue.getActiveQueue();
 		let isResetConfig = this.#shouldResetConfig(queue);
-		this.logger.forceLog("Build starting…" + (isResetConfig ? " (configuration reset)" : ""));
+
+		for (let p of queue) {
+			this.#resetFileInWatchQueue(p, isResetConfig);
+		}
+
+		this.logger.forceLog(
+			`Build starting${queue.length > 1 ? ` (${queue.length} queued changes)` : ""}…` +
+				(isResetConfig ? " (configuration reset)" : ""),
+		);
 
 		await this.config.events.emit("beforeWatch", queue);
 		await this.config.events.emit("eleventy.beforeWatch", queue);
@@ -241,15 +204,13 @@ export default class Eleventy extends Core {
 				);
 			});
 
-			let files = this.watchQueue.getActiveQueue();
-
 			// Maps passthrough copy files to output URLs for CSS live reload
 			let stylesheetUrls = new Set();
 			for (let entry of passthroughCopyResults) {
 				for (let filepath in entry.map) {
 					if (
 						filepath.endsWith(".css") &&
-						files.includes(TemplatePath.addLeadingDotSlash(filepath))
+						queue.includes(TemplatePath.addLeadingDotSlash(filepath))
 					) {
 						stylesheetUrls.add(
 							"/" + TemplatePath.stripLeadingSubPath(entry.map[filepath], this.outputDir),
@@ -270,7 +231,7 @@ export default class Eleventy extends Core {
 				});
 
 			await this.eleventyServe.reload({
-				files,
+				files: queue,
 				subtype: onlyCssChanges ? "css" : undefined,
 				build: {
 					stylesheets: Array.from(stylesheetUrls),
@@ -288,24 +249,7 @@ export default class Eleventy extends Core {
 		// Re-fetch
 		let pendingQueue = this.watchQueue.getPendingQueue();
 		if (pendingQueue.length > 0) {
-			let hasNonTemplateFiles = Boolean(
-				pendingQueue.find((path) => !this.directories.isTemplateFile(path)),
-			);
-			let skipIncremental = pendingQueue.length > 1 && hasNonTemplateFiles;
-
-			if (!skipIncremental && this.isIncremental) {
-				this.logger.forceLog(
-					`Build queued for: ${TemplatePath.stripLeadingDotSlash(pendingQueue.slice(0, 1).pop())}${pendingQueue.length > 1 ? ` (1/${pendingQueue.length} changes)` : ""}`,
-				);
-			} else {
-				this.logger.forceLog(
-					`Build queued… (${pendingQueue.length} change${pendingQueue.length !== 1 ? "s" : ""})`,
-				);
-			}
-
-			await this.#rewatch({
-				skipIncremental,
-			});
+			await this.#rewatch();
 		} else if (!this.#interrupted) {
 			// also logs in startWatch for initial build
 			this.logger.forceLog(`Waiting…`);
@@ -329,36 +273,33 @@ export default class Eleventy extends Core {
 		return this.bench.get("Watcher");
 	}
 
-	static async wait(timeMs) {
-		let { promise, resolve, reject } = withResolvers();
+	async waitThrottle() {
+		if (this.#watchDelay) {
+			clearTimeout(this.#watchDelay);
+		}
 
-		let id = setTimeout(resolve, timeMs);
+		if (this.config.watchThrottleWaitTime > 0) {
+			let { promise, resolve } = withResolvers();
 
-		await promise;
+			this.#watchDelay = setTimeout(resolve, this.config.watchThrottleWaitTime);
 
-		return id;
+			return promise;
+		}
 	}
 
+	// Triggers when files are modified on file system
 	async triggerWatchRunForPath(path) {
-		path = TemplatePath.normalize(path);
+		this.watchQueue.addToPendingQueue(path);
+
+		await this.waitThrottle();
 
 		try {
-			let isResetConfig = this.#shouldResetConfig([path]);
-			this.#addFileToWatchQueue(path, isResetConfig);
-
-			if (this.#watchDelay) {
-				clearTimeout(this.#watchDelay);
-			}
-
-			if (this.config.watchThrottleWaitTime) {
-				this.#watchDelay = Eleventy.wait(this.config.watchThrottleWaitTime);
-			}
-
 			await this.#rewatch();
 		} catch (e) {
+			this.watchQueue.finishBuild();
+
 			if (e instanceof EleventyBaseError) {
 				this.errorHandler.error(e, "Eleventy watch error");
-				this.watchQueue.finishBuild();
 			} else {
 				this.errorHandler.fatal(e, "Eleventy fatal watch error");
 				await this.close();
@@ -420,34 +361,38 @@ export default class Eleventy extends Core {
 			// Emulated passthrough copy logs from the server
 			if (!this.eleventyServe.isEmulatedPassthroughCopyMatch(path)) {
 				this.logger.forceLog(
-					`File changed: ${TemplatePath.stripLeadingDotSlash(TemplatePath.standardizeFilePath(path))}`,
+					`File changed: ${TemplatePath.stripLeadingDotSlash(TemplatePath.standardizeFilePath(path))}${this.watchQueue.isBuildRunning() ? " (queued for next build)" : ""}`,
 				);
 			}
 
-			await this.triggerWatchRunForPath(path);
+			// don’t await
+			this.triggerWatchRunForPath(path);
 		});
 
 		this.watcher.on("add", async (path) => {
 			// Emulated passthrough copy logs from the server
 			if (!this.eleventyServe.isEmulatedPassthroughCopyMatch(path)) {
 				this.logger.forceLog(
-					`File added: ${TemplatePath.stripLeadingDotSlash(TemplatePath.standardizeFilePath(path))}`,
+					`File added: ${TemplatePath.stripLeadingDotSlash(TemplatePath.standardizeFilePath(path))}${this.watchQueue.isBuildRunning() ? " (queued for next build)" : ""}`,
 				);
 			}
 
 			this.fileSystemSearch.add(path);
-			await this.triggerWatchRunForPath(path);
+			// don’t await
+			this.triggerWatchRunForPath(path);
 		});
 
 		this.watcher.on("unlink", async (path) => {
 			// Emulated passthrough copy logs from the server
 			if (!this.eleventyServe.isEmulatedPassthroughCopyMatch(path)) {
 				this.logger.forceLog(
-					`File deleted: ${TemplatePath.stripLeadingDotSlash(TemplatePath.standardizeFilePath(path))}`,
+					`File deleted: ${TemplatePath.stripLeadingDotSlash(TemplatePath.standardizeFilePath(path))}${this.watchQueue.isBuildRunning() ? " (queued for next build)" : ""}`,
 				);
 			}
+
 			this.fileSystemSearch.delete(path);
-			await this.triggerWatchRunForPath(path);
+			// don’t await
+			this.triggerWatchRunForPath(path);
 		});
 	}
 
@@ -588,8 +533,9 @@ Arguments:
      --incremental
        Only build the files that have changed. Best with watch/serve.
 
-     --incremental=filename.md
-       Does not require watch/serve. Run an incremental build targeting a single file.
+     --incremental=first.md,second.md
+     --incremental=first.md --incremental=second.md
+       Does not require watch/serve. Run an incremental build targeting one or more files.
 
      --ignore-initial
        Start without a build; build when files change. Works best with watch/serve/incremental.

--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -358,31 +358,27 @@ class EleventyFiles {
 		return paths;
 	}
 
-	getFileShape(paths, filePath) {
-		if (!filePath) {
+	getFileShape(paths, incrementalFilePaths) {
+		if (!incrementalFilePaths || incrementalFilePaths.length === 0) {
 			return;
 		}
-		if (this.isPassthroughCopyFile(paths, filePath)) {
+		if (this.passthroughManager.isPassthroughCopyFile(paths, incrementalFilePaths)) {
 			return "copy";
 		}
-		if (this.isFullTemplateFile(paths, filePath)) {
+		if (this.isFullTemplateFile(paths, incrementalFilePaths)) {
 			return "template";
 		}
 		// include/layout/unknown
 	}
 
-	isPassthroughCopyFile(paths, filePath) {
-		return this.passthroughManager.isPassthroughCopyFile(paths, filePath);
-	}
-
 	// Assumption here that filePath is not a passthrough copy file
-	isFullTemplateFile(paths, filePath) {
-		if (!filePath) {
+	isFullTemplateFile(paths, filePaths) {
+		if (!filePaths || !Array.isArray(filePaths)) {
 			return false;
 		}
 
 		for (let path of paths) {
-			if (path === filePath) {
+			if (filePaths.includes(path)) {
 				return true;
 			}
 		}

--- a/src/Engines/Custom.js
+++ b/src/Engines/Custom.js
@@ -9,6 +9,11 @@ export default class CustomEngine extends TemplateEngine {
 		this.needsInit = "init" in this.entry && typeof this.entry.init === "function";
 
 		this.setDefaultEngine(undefined);
+
+		this.previousQueue = [];
+		this.config.events.on("eleventy#previousqueue", (filePaths) => {
+			this.previousQueue = filePaths;
+		});
 	}
 
 	getExtensionMapEntry() {
@@ -278,16 +283,16 @@ export default class CustomEngine extends TemplateEngine {
 		return true;
 	}
 
-	isFileRelevantTo(inputPath, comparisonFile, includeLayouts) {
-		return this.config.uses.isFileRelevantTo(inputPath, comparisonFile, includeLayouts);
+	wasFileRelevantToPreviousBuild(inputPath) {
+		return this.previousQueue.find((comparisonFile) =>
+			this.config.uses.isFileRelevantTo(inputPath, comparisonFile, false),
+		);
 	}
 
 	getCompileCacheKey(str, inputPath) {
-		let lastModifiedFile = this.eleventyConfig.getPreviousBuildModifiedFile();
 		// Return this separately so we know whether or not to use the cached version
 		// but still return a key to cache this new render for next time
-		let isRelevant = this.isFileRelevantTo(inputPath, lastModifiedFile, false);
-		let useCache = !isRelevant;
+		let useCache = !this.wasFileRelevantToPreviousBuild(inputPath);
 
 		if (this.entry.compileOptions && "getCacheKey" in this.entry.compileOptions) {
 			if (typeof this.entry.compileOptions.getCacheKey !== "function") {

--- a/src/GlobalDependencyMap.js
+++ b/src/GlobalDependencyMap.js
@@ -411,10 +411,12 @@ class GlobalDependencyMap {
 		return false;
 	}
 
-	isFileUsedBy(parent, child, includeLayouts) {
-		if (this.hasDependency(parent, child, includeLayouts)) {
-			// child is used by parent
-			return true;
+	areFilesUsedBy(parents, child, includeLayouts) {
+		for (let p of parents) {
+			if (this.hasDependency(p, child, includeLayouts)) {
+				// child is used by parent
+				return true;
+			}
 		}
 		return false;
 	}

--- a/src/Template.js
+++ b/src/Template.js
@@ -479,6 +479,11 @@ class Template extends TemplateContent {
 		return super.render(str, data, bypassMarkdown);
 	}
 
+	// see also Eleventy->#resetFileInWatchQueue()
+	internalTriggerTemplateModifiedPath(changedFilePath) {
+		this.config.events.emit("eleventy#templateModified", changedFilePath);
+	}
+
 	// This is the primary render mechanism, called via TemplateMap->populateContentDataInMap
 	async renderPageEntryWithoutLayout(pageEntry) {
 		// @cachedproperty

--- a/src/TemplateConfig.js
+++ b/src/TemplateConfig.js
@@ -51,7 +51,6 @@ class TemplateConfig {
 	#userConfig = new UserConfig();
 	#existsCache = new ExistsCache();
 	#usesGraph;
-	#previousBuildModifiedFile;
 	#activeConfigPath;
 
 	constructor(customRootConfig, projectConfigPath) {
@@ -107,20 +106,9 @@ class TemplateConfig {
 		};
 
 		this.userConfig.events.on("eleventy#templateModified", (inputPath, metadata = {}) => {
-			// Might support multiple at some point
-			this.setPreviousBuildModifiedFile(inputPath, metadata);
-
 			// Issue #3569, set that this file exists in the cache
 			this.#existsCache.set(inputPath, true);
 		});
-	}
-
-	setPreviousBuildModifiedFile(inputPath, metadata = {}) {
-		this.#previousBuildModifiedFile = inputPath;
-	}
-
-	getPreviousBuildModifiedFile() {
-		return this.#previousBuildModifiedFile;
 	}
 
 	get userConfig() {

--- a/src/TemplatePassthroughManager.js
+++ b/src/TemplatePassthroughManager.js
@@ -46,7 +46,7 @@ class TemplatePassthroughManager {
 		this.count = 0;
 		this.size = 0;
 		this.conflictMap = {};
-		this.incrementalFile;
+		this.incrementalFiles = [];
 
 		this.#queue = new Map();
 	}
@@ -78,17 +78,18 @@ class TemplatePassthroughManager {
 		this.runMode = runMode;
 	}
 
-	setIncrementalFile(path) {
-		if (path) {
-			this.incrementalFile = path;
+	setIncrementalFiles(paths) {
+		if (!paths || !Array.isArray(paths)) {
+			return;
 		}
+		this.incrementalFiles = paths;
 	}
 
-	resetIncrementalFile() {
-		this.incrementalFile = undefined;
+	resetIncremental() {
+		this.incrementalFiles = undefined;
 	}
 
-	_normalizePaths(path, outputPath, copyOptions = {}) {
+	#normalizePath(path, outputPath, copyOptions = {}) {
 		return {
 			inputPath: TemplatePath.addLeadingDotSlash(path),
 			outputPath: outputPath ? TemplatePath.stripLeadingDotSlash(outputPath) : true,
@@ -101,7 +102,7 @@ class TemplatePassthroughManager {
 		let pathsRaw = this.config.passthroughCopies || {};
 		debug("`addPassthroughCopy` config API paths: %o", pathsRaw);
 		for (let [inputPath, { outputPath, copyOptions }] of Object.entries(pathsRaw)) {
-			paths.push(this._normalizePaths(inputPath, outputPath, copyOptions));
+			paths.push(this.#normalizePath(inputPath, outputPath, copyOptions));
 		}
 		debug("`addPassthroughCopy` config API normalized paths: %o", paths);
 		return paths;
@@ -226,26 +227,29 @@ class TemplatePassthroughManager {
 		);
 	}
 
-	isPassthroughCopyFile(paths, changedFile) {
-		if (!changedFile) {
+	isPassthroughCopyFile(paths, changedFiles) {
+		if (!changedFiles) {
 			return false;
+		}
+		if (!Array.isArray(changedFiles)) {
+			changedFiles = [changedFiles];
 		}
 
 		// passthrough copy by non-matching engine extension (via templateFormats)
 		for (let path of paths) {
-			if (path === changedFile && !this.extensionMap.hasEngine(path)) {
+			if (changedFiles.includes(path) && !this.extensionMap.hasEngine(path)) {
 				return true;
 			}
 		}
 
 		for (let path of this.getConfigPaths()) {
-			if (TemplatePath.startsWithSubPath(changedFile, path.inputPath)) {
+			if (changedFiles.find((p) => TemplatePath.startsWithSubPath(p, path.inputPath))) {
 				return path;
 			}
 			if (
-				changedFile &&
+				Array.isArray(changedFiles) &&
 				isDynamicPattern(path.inputPath) &&
-				isGlobMatch(changedFile, [path.inputPath])
+				changedFiles.find((p) => isGlobMatch(p, [path.inputPath]))
 			) {
 				return path;
 			}
@@ -255,15 +259,15 @@ class TemplatePassthroughManager {
 	}
 
 	getAllNormalizedPaths(paths = []) {
-		if (this.incrementalFile) {
-			let isPassthrough = this.isPassthroughCopyFile(paths, this.incrementalFile);
+		if (Array.isArray(this.incrementalFiles) && this.incrementalFiles.length > 0) {
+			let isPassthrough = this.isPassthroughCopyFile(paths, this.incrementalFiles);
 
 			if (isPassthrough) {
 				if (isPassthrough.outputPath) {
 					return [isPassthrough];
 				}
 
-				return [this._normalizePaths(this.incrementalFile)];
+				return this.incrementalFiles.map((file) => this.#normalizePath(file));
 			}
 
 			// Fixes https://github.com/11ty/eleventy/issues/2491
@@ -282,7 +286,7 @@ class TemplatePassthroughManager {
 		if (paths?.length) {
 			let passthroughPaths = this.getNonTemplatePaths(paths);
 			for (let path of passthroughPaths) {
-				let normalizedPath = this._normalizePaths(path);
+				let normalizedPath = this.#normalizePath(path);
 
 				debug(
 					`TemplatePassthrough copying from non-matching file extension: ${normalizedPath.inputPath}`,

--- a/src/TemplateWriter.js
+++ b/src/TemplateWriter.js
@@ -19,6 +19,7 @@ class TemplateWriter {
 	#passthroughManager;
 	#errorHandler;
 	#extensionMap;
+	#incrementalFiles = [];
 
 	constructor(
 		templateFormats, // TODO remove this in favor of this.#eleventyFiles
@@ -228,13 +229,15 @@ class TemplateWriter {
 			await tmpl.asyncTemplateInitialization();
 
 			// This must happen before data is generated for the incremental file only
-			if (incrementalFileShape === "template" && tmpl.inputPath === this.incrementalFile) {
+			if (incrementalFileShape === "template" && this.#incrementalFiles.includes(tmpl.inputPath)) {
 				tmpl.resetCaches();
 			} else if (
 				// Issue #3824 #3870
-				tmpl.isFileRelevantToThisTemplate(this.incrementalFile, {
-					isFullTemplate: incrementalFileShape === "template",
-				})
+				this.#incrementalFiles.find((p) =>
+					tmpl.isFileRelevantToThisTemplate(p, {
+						isFullTemplate: incrementalFileShape === "template",
+					}),
+				)
 			) {
 				tmpl.resetCaches();
 			}
@@ -248,7 +251,9 @@ class TemplateWriter {
 
 		// Delete incremental file from the dependency graph so we get fresh entries!
 		// This _must_ happen before any additions, the other ones are in Custom.js and GlobalDependencyMap.js (from the eleventy.layouts Event)
-		this.config.uses.resetNode(this.incrementalFile);
+		for (let p of this.#incrementalFiles) {
+			this.config.uses.resetNode(p);
+		}
 
 		// write new template relationships to the global dependency graph for next time
 		this.templateMap.addAllToGlobalDependencyGraph();
@@ -262,18 +267,20 @@ class TemplateWriter {
 		}
 
 		for (let tmpl of templates) {
-			if (incrementalFileShape === "template" && tmpl.inputPath === this.incrementalFile) {
+			if (incrementalFileShape === "template" && this.#incrementalFiles.includes(tmpl.inputPath)) {
 				tmpl.setRenderableOverride(undefined); // unset, probably render
 			} else if (
-				tmpl.isFileRelevantToThisTemplate(this.incrementalFile, {
-					isFullTemplate: incrementalFileShape === "template",
-				})
+				this.#incrementalFiles.find((p) =>
+					tmpl.isFileRelevantToThisTemplate(p, {
+						isFullTemplate: incrementalFileShape === "template",
+					}),
+				)
 			) {
 				// changed file is used by template
 				// template uses the changed file
 				tmpl.setRenderableOverride(undefined); // unset, probably render
 				secondOrderRelevantLookup[tmpl.inputPath] = true;
-			} else if (this.config.uses.isFileUsedBy(this.incrementalFile, tmpl.inputPath)) {
+			} else if (this.config.uses.areFilesUsedBy(this.#incrementalFiles, tmpl.inputPath)) {
 				// changed file uses this template
 				tmpl.setRenderableOverride("optional");
 			} else {
@@ -300,7 +307,7 @@ class TemplateWriter {
 
 		// Order of templates does not matter here, they’re reordered later based on dependencies in TemplateMap.js
 		for (let tmpl of templates) {
-			if (incrementalFileShape === "template" && tmpl.inputPath === this.incrementalFile) {
+			if (incrementalFileShape === "template" && this.#incrementalFiles.includes(tmpl.inputPath)) {
 				// Cache is reset above (to invalidate data cache at the right time)
 				tmpl.setDryRunViaIncremental(false);
 			} else if (!tmpl.isRenderableDisabled() && !tmpl.isRenderableOptional()) {
@@ -326,7 +333,7 @@ class TemplateWriter {
 	}
 
 	async _addToTemplateMapFullBuild(paths, to = "fs") {
-		if (this.incrementalFile) {
+		if (this.#incrementalFiles?.length > 0) {
 			return [];
 		}
 
@@ -352,18 +359,17 @@ class TemplateWriter {
 		return Promise.all(promises);
 	}
 
-	getFileShape(paths, incrementalFile) {
+	getFileShape(paths) {
 		// WARNING: This is leaky—if Core is being used instead of Eleventy we are assuming everything is a template (not passthrough copy)
 		if (!this.#eleventyFiles) {
 			return "template";
 		}
 
-		return this.#eleventyFiles.getFileShape(paths, incrementalFile);
+		return this.#eleventyFiles.getFileShape(paths, this.#incrementalFiles);
 	}
 
 	async _addToTemplateMap(paths, to = "fs") {
-		let incrementalFileShape = this.getFileShape(paths, this.incrementalFile);
-
+		let incrementalFileShape = this.getFileShape(paths);
 		// Filter out passthrough copy files
 		paths = paths.filter((path) => {
 			if (!this.extensionMap.hasEngine(path)) {
@@ -377,7 +383,7 @@ class TemplateWriter {
 			return true;
 		});
 
-		if (this.incrementalFile) {
+		if (this.#incrementalFiles?.length > 0) {
 			// Top level async to get at the promises returned.
 			return await this._addToTemplateMapIncrementalBuild(incrementalFileShape, paths, to);
 		}
@@ -541,16 +547,14 @@ class TemplateWriter {
 	setRunInitialBuild(runInitialBuild) {
 		this.isRunInitialBuild = runInitialBuild;
 	}
-	setIncrementalBuild(isIncremental) {
-		this.isIncremental = isIncremental;
+
+	setIncrementalFiles(files = []) {
+		this.#incrementalFiles = files;
+		this.#passthroughManager?.setIncrementalFiles(files);
 	}
-	setIncrementalFile(incrementalFile) {
-		this.incrementalFile = incrementalFile;
-		this.#passthroughManager?.setIncrementalFile(incrementalFile);
-	}
-	resetIncrementalFile() {
-		this.incrementalFile = null;
-		this.#passthroughManager?.resetIncrementalFile();
+	resetIncremental() {
+		this.#incrementalFiles = [];
+		this.#passthroughManager?.resetIncremental();
 	}
 
 	getMetadata() {

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -177,7 +177,7 @@ class UserConfig {
 		this.globalData = {};
 		/** @type {object} */
 		this.chokidarConfig = {};
-		this.watchThrottleWaitTime = 0; //ms
+		this.watchThrottleWaitTime = 100; //ms
 
 		// using Map to preserve insertion order
 		this.dataExtensions = new Map();

--- a/src/WatchQueue.js
+++ b/src/WatchQueue.js
@@ -2,31 +2,25 @@ import { TemplatePath } from "@11ty/eleventy-utils";
 
 import PathNormalizer from "./Util/PathNormalizer.js";
 
-/* Decides when to watch and in what mode to watch
- * Incremental builds don’t batch changes, they queue.
- * Nonincremental builds batch.
+/*
+ * Decides when to watch and in what mode to watch
  */
 
 class WatchQueue {
-	#incremental = false;
-	#incrementalOverride = false;
+	static normalizePath(path) {
+		if (!path) {
+			return;
+		}
+		return PathNormalizer.normalizeSeperator(
+			TemplatePath.addLeadingDotSlash(TemplatePath.normalize(path)),
+		);
+	}
 
 	constructor() {
 		this.activeQueue = [];
 	}
 
-	setIncrementalOverride(override) {
-		this.#incrementalOverride = Boolean(override);
-	}
-
-	set incremental(value) {
-		this.#incremental = Boolean(value);
-	}
-
-	get incremental() {
-		return this.#incrementalOverride || this.#incremental;
-	}
-
+	// on SIGINT
 	reset() {
 		this.pendingQueue = [];
 		this.activeQueue = [];
@@ -37,41 +31,41 @@ class WatchQueue {
 	}
 
 	startBuild() {
+		if (this.isBuildRunning()) {
+			throw new Error(
+				"Internal error: build already running. Use finishBuild() before calling startBuild() again.",
+			);
+		}
+
 		// pop waiting queue into the active queue
 		this.activeQueue = this.popNextActiveQueue();
 	}
 
 	finishBuild() {
-		this.#incrementalOverride = false;
 		this.activeQueue = [];
 	}
 
-	getIncrementalFile() {
-		if (this.incremental) {
-			if (this.activeQueue.length) {
-				return this.activeQueue[0];
+	setActiveQueue(queue) {
+		if (!queue || !Array.isArray(queue)) {
+			return;
+		}
+
+		for (let path of queue) {
+			let normalized = WatchQueue.normalizePath(path);
+			if (!this.activeQueue.includes(normalized)) {
+				this.activeQueue.push(normalized);
 			}
 		}
-
-		return false;
 	}
 
-	/* Returns the changed files currently being operated on in the current `watch` build
-	 * Works with or without incremental (though in incremental only one file per time will be processed)
+	/*
+	 * Returns the changed files currently being operated on in the current `watch` build
 	 */
 	getActiveQueue() {
-		if (!this.isBuildRunning()) {
-			return [];
-		} else if (this.incremental && this.activeQueue.length === 0) {
-			return [];
-		} else if (this.incremental) {
-			return [this.activeQueue[0]];
-		}
-
 		return this.activeQueue;
 	}
 
-	_queueMatches(file) {
+	#queueMatches(file) {
 		let filterCallback;
 		if (typeof file === "function") {
 			filterCallback = file;
@@ -84,13 +78,13 @@ class WatchQueue {
 
 	hasAllQueueFiles(file) {
 		return (
-			this.activeQueue.length > 0 && this.activeQueue.length === this._queueMatches(file).length
+			this.activeQueue.length > 0 && this.activeQueue.length === this.#queueMatches(file).length
 		);
 	}
 
 	hasQueuedFile(file) {
 		if (file) {
-			return this._queueMatches(file).length > 0;
+			return this.#queueMatches(file).length > 0;
 		}
 		return false;
 	}
@@ -116,16 +110,14 @@ class WatchQueue {
 	}
 
 	addToPendingQueue(path) {
-		if (path) {
-			path = PathNormalizer.normalizeSeperator(TemplatePath.addLeadingDotSlash(path));
-			if (!this.pendingQueue.includes(path)) {
-				this.pendingQueue.push(path);
-				// added
-				return true;
-			}
+		if (!path) {
+			return;
 		}
-		// skipped
-		return false;
+
+		let normalized = WatchQueue.normalizePath(path);
+		if (!this.pendingQueue.includes(normalized)) {
+			this.pendingQueue.push(normalized);
+		}
 	}
 
 	getPendingQueueSize() {
@@ -146,10 +138,6 @@ class WatchQueue {
 
 	// returns array
 	popNextActiveQueue() {
-		if (this.incremental) {
-			return this.pendingQueue.length ? [this.pendingQueue.shift()] : [];
-		}
-
 		let ret = this.pendingQueue.slice();
 		this.pendingQueue = [];
 		return ret;

--- a/test/EleventyTest.js
+++ b/test/EleventyTest.js
@@ -606,7 +606,7 @@ ${previousContents}
   fs.writeFileSync(includeFilePath, newContents, "utf8");
 
   // This also triggers that the file has changed in the event bus via setPreviousBuildModifiedFile
-  elev.setIncrementalFile(includeFilePath);
+  elev.setIncrementalFiles(includeFilePath);
 
   let results3 = await elev.toJSON();
   t.is(

--- a/test/TemplatePassthroughManagerTest.js
+++ b/test/TemplatePassthroughManagerTest.js
@@ -247,7 +247,7 @@ test("Incremental passthrough, issue #3285", async (t) => {
   await eleventyConfig.init();
 
   let mgr = new TemplatePassthroughManager(eleventyConfig);
-  mgr.setIncrementalFile("./test/stubs-3285/src/scripts/hello-world.js");
+  mgr.setIncrementalFiles(["./test/stubs-3285/src/scripts/hello-world.js"]);
   t.deepEqual(mgr.getAllNormalizedPaths([]), [
     { copyOptions: {}, inputPath: "./test/stubs-3285/src/scripts", outputPath: "scripts" },
   ]);

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -1698,7 +1698,7 @@ test("Make sure layout cache takes new changes during watch (liquid)", async (t)
   fs.writeFileSync(filePath, `alert("bye");`, "utf8");
 
   // Trigger that the file has changed
-  tmpl.eleventyConfig.setPreviousBuildModifiedFile(filePath);
+  tmpl.internalTriggerTemplateModifiedPath(filePath);
 
   t.is((await renderTemplate(tmpl, data)).trim(), '<script>alert("bye");</script>');
 });

--- a/test/WatchQueueTest.js
+++ b/test/WatchQueueTest.js
@@ -12,155 +12,38 @@ test("Standard", (t) => {
   t.is(watch.isBuildRunning(), false);
 });
 
-test("Incremental", (t) => {
+test("Queue 1", (t) => {
   let watch = new WatchQueue();
-  t.is(watch.getIncrementalFile(), false);
-
-  watch.incremental = true;
+  t.is(watch.getActiveQueueSize(), 0);
   t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), []);
 
   watch.addToPendingQueue("test.md");
   t.is(watch.getPendingQueueSize(), 1);
   t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), []);
 
-  t.is(watch.isBuildRunning(), false);
-
   watch.startBuild();
-  t.is(watch.isBuildRunning(), true);
   t.is(watch.getPendingQueueSize(), 0);
   t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), "./test.md");
   t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
 
   watch.finishBuild();
-  t.is(watch.isBuildRunning(), false);
   t.is(watch.getPendingQueueSize(), 0);
   t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), []);
-  t.deepEqual(watch.getPendingQueue(), []);
 });
 
-test("Incremental queue 2", (t) => {
+test("Queue 2", (t) => {
   let watch = new WatchQueue();
-  t.is(watch.getIncrementalFile(), false);
-
-  watch.incremental = true;
+  t.is(watch.getActiveQueueSize(), 0);
   t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), []);
 
   watch.addToPendingQueue("test.md");
   watch.addToPendingQueue("test2.md");
   t.is(watch.getPendingQueueSize(), 2);
   t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-
-  t.is(watch.isBuildRunning(), false);
-
-  watch.startBuild();
-  t.is(watch.isBuildRunning(), true);
-  t.is(watch.getPendingQueueSize(), 1);
-  t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), "./test.md");
-  t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
-  t.is(watch.isBuildRunning(), true);
-
-  watch.finishBuild();
-  t.is(watch.isBuildRunning(), false);
-  t.is(watch.getPendingQueueSize(), 1);
-  t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getPendingQueue(), ["./test2.md"]);
-  t.deepEqual(watch.getActiveQueue(), []);
-});
-
-test("Incremental add while active", (t) => {
-  let watch = new WatchQueue();
-  t.is(watch.getIncrementalFile(), false);
-
-  watch.incremental = true;
-  t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-
-  watch.addToPendingQueue("test.md");
-  t.is(watch.getPendingQueueSize(), 1);
-  t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-
-  t.is(watch.isBuildRunning(), false);
-
-  watch.startBuild();
-  t.is(watch.isBuildRunning(), true);
-  t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), "./test.md");
-  t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
-
-  watch.addToPendingQueue("test2.md");
-  t.is(watch.getPendingQueueSize(), 1);
-  t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), "./test.md");
-  t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
-
-  t.is(watch.isBuildRunning(), true);
-  watch.finishBuild();
-
-  t.is(watch.isBuildRunning(), false);
-  t.is(watch.getPendingQueueSize(), 1);
-  t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getPendingQueue(), ["./test2.md"]);
-  t.deepEqual(watch.getActiveQueue(), []);
-});
-
-test("Non-incremental", (t) => {
-  let watch = new WatchQueue();
-  t.is(watch.getIncrementalFile(), false);
-
-  t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-
-  watch.addToPendingQueue("test.md");
-  t.is(watch.getPendingQueueSize(), 1);
-  t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-
-  watch.startBuild();
-  t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
-
-  watch.finishBuild();
-  t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-});
-
-test("Non-incremental queue 2", (t) => {
-  let watch = new WatchQueue();
-  t.is(watch.getIncrementalFile(), false);
-
-  t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
-  t.deepEqual(watch.getActiveQueue(), []);
-
-  watch.addToPendingQueue("test.md");
-  watch.addToPendingQueue("test2.md");
-  t.is(watch.getPendingQueueSize(), 2);
-  t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), []);
 
   t.is(watch.isBuildRunning(), false);
@@ -169,7 +52,6 @@ test("Non-incremental queue 2", (t) => {
   t.is(watch.isBuildRunning(), true);
   t.is(watch.getPendingQueueSize(), 0);
   t.is(watch.getActiveQueueSize(), 2);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), ["./test.md", "./test2.md"]);
 
   t.is(watch.isBuildRunning(), true);
@@ -177,22 +59,19 @@ test("Non-incremental queue 2", (t) => {
   t.is(watch.isBuildRunning(), false);
   t.is(watch.getPendingQueueSize(), 0);
   t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getPendingQueue(), []);
   t.deepEqual(watch.getActiveQueue(), []);
 });
 
-test("Non-incremental add while active", (t) => {
+test("Add while active", (t) => {
   let watch = new WatchQueue();
-  t.is(watch.getIncrementalFile(), false);
-
+  t.is(watch.getActiveQueueSize(), 0);
   t.is(watch.getPendingQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
+  t.is(watch.getActiveQueueSize(), 0);
 
   watch.addToPendingQueue("test.md");
   t.is(watch.getPendingQueueSize(), 1);
   t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), []);
 
   t.is(watch.isBuildRunning(), false);
@@ -201,13 +80,11 @@ test("Non-incremental add while active", (t) => {
   t.is(watch.isBuildRunning(), true);
   t.is(watch.getPendingQueueSize(), 0);
   t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
 
   watch.addToPendingQueue("test.md");
   t.is(watch.getPendingQueueSize(), 1);
   t.is(watch.getActiveQueueSize(), 1);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getActiveQueue(), ["./test.md"]);
   t.is(watch.isBuildRunning(), true);
 
@@ -215,7 +92,6 @@ test("Non-incremental add while active", (t) => {
   t.is(watch.isBuildRunning(), false);
   t.is(watch.getPendingQueueSize(), 1);
   t.is(watch.getActiveQueueSize(), 0);
-  t.is(watch.getIncrementalFile(), false);
   t.deepEqual(watch.getPendingQueue(), ["./test.md"]);
   t.deepEqual(watch.getActiveQueue(), []);
 });


### PR DESCRIPTION
- **Changes default of https://www.11ty.dev/docs/watch-serve/#add-delay-before-re-running to `100` (ms)**
- Swaps to full build when the incremental queue would take longer.
- Fixes #4274
- Fixes #3077 for incremental builds

```
--incremental=one.md --incremental=two.md => ["one.md", "two.md"]
--incremental=one.md,two.md
```