### PR TITLE
Perf: Index collections by tag instead of re-sorting and re-deriving tags per lookup

### DIFF
--- a/src/TemplateCollection.js
+++ b/src/TemplateCollection.js
@@ -5,18 +5,61 @@ import Sortable from "./Util/Objects/Sortable.js";
 import { isGlobMatch } from "./Util/GlobMatcher.js";
 
 class TemplateCollection extends Sortable {
+	// Both caches are invalidated in `add`, the only entry point that mutates `items`
+	#allSortedCache;
+	#tagIndexCache;
+
 	constructor() {
 		super();
 
 		this._filteredByGlobsCache = new Map();
 	}
 
+	add(item) {
+		this.#allSortedCache = undefined;
+		this.#tagIndexCache = undefined;
+
+		super.add(item);
+	}
+
 	getAll() {
 		return this.items.slice();
 	}
 
+	// Sorted once per mutation instead of once per collection API call
+	#getAllSorted() {
+		if (!this.#allSortedCache) {
+			this.#allSortedCache = this.sort(Sortable.sortFunctionDateInputPath);
+		}
+
+		return this.#allSortedCache;
+	}
+
+	// Tag name to items (in sorted order), so tag lookups don’t walk the full collection
+	#getTagIndex() {
+		if (!this.#tagIndexCache) {
+			let index = new Map();
+
+			for (let item of this.#getAllSorted()) {
+				for (let tagName of TemplateData.getIncludedTagNames(item.data)) {
+					let tagItems = index.get(tagName);
+					if (!tagItems) {
+						tagItems = [];
+						index.set(tagName, tagItems);
+					}
+					tagItems.push(item);
+				}
+			}
+
+			this.#tagIndexCache = index;
+		}
+
+		return this.#tagIndexCache;
+	}
+
 	getAllSorted() {
-		return this.sort(Sortable.sortFunctionDateInputPath);
+		// Callers sort and reverse the result in place, so hand out a copy
+		return this.#getAllSorted().slice();
 	}
 
 	getSortedByDate() {
@@ -56,20 +99,29 @@ class TemplateCollection extends Sortable {
 	}
 
 	getFilteredByTag(tagName) {
-		return this.getAllSorted().filter((item) => {
-			if (!tagName || TemplateData.getIncludedTagNames(item.data).includes(tagName)) {
-				return true;
-			}
-			return false;
-		});
+		if (!tagName) {
+			return this.getAllSorted();
+		}
+
+		return this.#getTagIndex().get(tagName)?.slice() || [];
 	}
 
 	getFilteredByTags(...tags) {
-		return this.getAllSorted().filter((item) => {
-			let itemTags = new Set(TemplateData.getIncludedTagNames(item.data));
-			return tags.every((requiredTag) => {
-				return itemTags.has(requiredTag);
-			});
+		if (!tags.length) {
+			return this.getAllSorted();
+		}
+
+		let index = this.#getTagIndex();
+		let [firstTag, ...remainingTags] = tags;
+		let matches = index.get(firstTag) || [];
+		if (!remainingTags.length) {
+			return matches.slice();
+		}
+
+		// Intersect the first tag’s matches with the remaining tags
+		let remainingItems = remainingTags.map((tagName) => new Set(index.get(tagName)));
+		return matches.filter((item) => {
+			return remainingItems.every((tagItems) => tagItems.has(item));
 		});
 	}
 }

--- a/test/TemplateCollectionTest.js
+++ b/test/TemplateCollectionTest.js
@@ -139,6 +139,79 @@ test("getFilteredByTag (added out of order, sorted)", async (t) => {
   t.deepEqual(dogs[0].template, tmpl1);
 });
 
+test("getFilteredByTag (results are cached, cache is invalidated by add)", async (t) => {
+  let $config = await getTemplateConfigInstance();
+
+  let tmpl1 = await getNewTemplateByNumber(1, $config);
+  let tmpl2 = await getNewTemplateByNumber(2, $config);
+  let tmpl3 = await getNewTemplateByNumber(3, $config);
+
+  let c = new Collection();
+  await addTemplate(c, tmpl1);
+
+  let posts = c.getFilteredByTag("post");
+  t.is(posts.length, 1);
+
+  await addTemplate(c, tmpl2);
+  await addTemplate(c, tmpl3);
+
+  t.is(c.getFilteredByTag("post").length, 2);
+  t.is(c.getFilteredByTag("cat").length, 2);
+  t.is(c.getFilteredByTags("post", "cat").length, 1);
+  t.is(c.getAllSorted().length, 3);
+
+  // The result returned before the additions is unaffected
+  t.is(posts.length, 1);
+});
+
+test("getFilteredByTag (results are mutable copies)", async (t) => {
+  let $config = await getTemplateConfigInstance();
+
+  let tmpl1 = await getNewTemplateByNumber(1, $config);
+  let tmpl3 = await getNewTemplateByNumber(3, $config);
+
+  let c = new Collection();
+  await addTemplate(c, tmpl1);
+  await addTemplate(c, tmpl3);
+
+  let posts = c.getFilteredByTag("post");
+  posts.reverse();
+  posts.pop();
+
+  let posts2 = c.getFilteredByTag("post");
+  t.is(posts2.length, 2);
+  t.deepEqual(posts2[0].template, tmpl1);
+  t.deepEqual(posts2[1].template, tmpl3);
+
+  let postsPlural = c.getFilteredByTags("post");
+  postsPlural.pop();
+  t.is(c.getFilteredByTags("post").length, 2);
+});
+
+test("getFilteredByTag (no tag name returns everything, sorted)", async (t) => {
+  let $config = await getTemplateConfigInstance();
+
+  let tmpl1 = await getNewTemplateByNumber(1, $config);
+  let tmpl4 = await getNewTemplateByNumber(4, $config);
+  let tmpl5 = await getNewTemplateByNumber(5, $config);
+
+  let c = new Collection();
+  await addTemplate(c, tmpl1);
+  await addTemplate(c, tmpl4);
+  await addTemplate(c, tmpl5);
+
+  let all = c.getFilteredByTag();
+  t.is(all.length, 3);
+  t.deepEqual(all[0].template, tmpl4);
+  t.deepEqual(all[1].template, tmpl1);
+  t.deepEqual(all[2].template, tmpl5);
+
+  // `all` is not a tag name, it is filtered out of the included tag names
+  t.is(c.getFilteredByTag("all").length, 0);
+  t.is(c.getFilteredByTag("unknown-tag").length, 0);
+  t.is(c.getFilteredByTags().length, 3);
+});
+
 test("getFilteredByTags", async (t) => {
   let $config = await getTemplateConfigInstance();
 


### PR DESCRIPTION
As mentioned in prior conversation with @zachleat, a major performance improvement, and an AI-assisted result of performance optimizations on one of my Eleventy projects. I took the liberty to use AI (Claude Code) for the following summary, too.

I vouch for doing due diligence and already, successfully using the same optimizations in my own projects (via patch-package)—a massive speed-up.

## Problem

`TemplateCollection.getFilteredByTag()` is called once per collection (tag) per build, from
`TemplateMap.getTaggedCollection()`. Each call did two things that scale badly:

1. `getAllSorted()` re-sorted the entire collection (`Sortable.sort()` has no cache), so a site with `n` templates and `t` tags paid `t × O(n log n)` comparisons.
2. The filter callback called `TemplateData.getIncludedTagNames(item.data)` for every item, which rebuilds (and deduplicates) the tag array from scratch—`t × n` array allocations.

On a large site this dominates the build. On a 22,000-template site with ~1,100 tags that is roughly
24 million sort comparisons and 23 million tag-array rebuilds per build.

## Change

`TemplateCollection` now keeps two caches, both invalidated in `add()`—the only entry point that
mutates `items`, and the same signal the existing `_filteredByGlobsCache` relies on via `_dirty`:

- the sorted item list, so the collection is sorted once per mutation rather than once per lookup;
- a `Map` of tag name to items (built by walking the sorted list once), so `getFilteredByTag()` is a `Map.get()` instead of a full scan.

Because the index is built from the sorted list, each tag’s items are already in the same order the
filter produced, so results are unchanged. `getAllSorted()`, `getFilteredByTag()` and
`getFilteredByTags()` all keep returning fresh arrays, so callers can still sort or reverse the
result in place (#352).

`getFilteredByTags()` (plural) now intersects the first tag’s index entry with the remaining tags
instead of scanning the whole collection.

## Results

Synthetic benchmark, one `getFilteredByTag()` call per unique tag (as a build does), 6 tags per item:

| Templates | Tags | Before | After |
| --------- | ---- | ------ | ----- |
| 500       | 25   | 14ms   | 3ms   |
| 2,000     | 100  | 134ms  | 3ms   |
| 10,000    | 500  | 3,359ms| 20ms  |
| 22,000    | 1,100| 17,288ms| 31ms |

On a real 22,000-template site, this plus the 4.0 `inputPathMap` change for
`getMapEntryForInputPath()` took a production build from ~120–150s to ~48s, with byte-identical
output.

## Testing

- Full test suite passes (1,439 tests).
- Added regression tests in `test/TemplateCollectionTest.js`: cache invalidation when templates are added after a lookup, mutability/independence of returned arrays, and the no-tag-name / unknown-tag / `"all"` cases.
- Differential test against the previous implementation: ~50,000 randomized comparisons (string tags, comma-separated tags, duplicate tags, missing tags, `buildawesomeExcludeFromCollections` as `true`/string/array, lookups interleaved with `add()`) produced identical results.